### PR TITLE
Polish repository workflow and project metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report a reproducible pi-smart-compact problem
+title: "bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include enough context to reproduce the issue without sharing secrets or private session content.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened? What did you expect to happen?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: pi-smart-compact version
+      placeholder: "7.13.1"
+    validations:
+      required: true
+  - type: input
+    id: pi-version
+    attributes:
+      label: Pi Coding Agent version
+      placeholder: "0.75.5"
+    validations:
+      required: false
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Integration surface
+      options:
+        - /smart-compact command
+        - smart_compact tool
+        - session_before_compact auto-trigger
+        - metrics/dashboard
+        - install/build
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant configuration
+      description: Paste only non-secret `smartCompact` settings.
+      render: json
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or error output
+      description: Redact tokens, private repository content, and confidential session data.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        OS:
+        Bun:
+        Node:
+        Model/provider:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Pi Coding Agent upstream
+    url: https://github.com/earendil-works/pi
+    about: Use Pi's upstream repository for core Pi bugs that reproduce without pi-smart-compact.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest an improvement to pi-smart-compact
+title: "feat: "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What workflow would this improve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or API you would like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - extraction
+        - exploration
+        - synthesis
+        - verification
+        - auto-trigger integration
+        - dashboard/metrics
+        - configuration
+        - documentation
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Validation
+
+- [ ] `bun run typecheck`
+- [ ] `bun test`
+- [ ] `bun run build`
+
+## Checklist
+
+- [ ] User-facing behavior is documented in `README.md` or project docs
+- [ ] Release-worthy changes update `CHANGELOG.md`, `package.json`, and `src/constants.ts`
+- [ ] Tests cover changed behavior or the PR explains why tests are not needed
+- [ ] Generated output in `dist/` was not edited by hand
+
+## Notes
+
+<!-- Trade-offs, follow-up work, compatibility notes, or screenshots/logs. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - npm
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+      - name: Build
+        run: bun run build

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 *.v*-backup
 
 # Dependencies
+node_modules
 node_modules/
 
 # Environment

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Code of Conduct
+
+This project follows a simple standard: be respectful, constructive, and focused on improving the software.
+
+Expected behavior:
+
+- Use welcoming and inclusive language.
+- Assume good intent when reviewing issues and pull requests.
+- Critique ideas and code, not people.
+- Respect privacy; do not post secrets, private session logs, or confidential project data.
+
+Unacceptable behavior includes harassment, personal attacks, doxxing, deliberate disruption, or sharing private information without permission.
+
+Maintainers may edit, hide, or remove comments and may block participants who repeatedly violate these expectations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,9 @@ Depending on the change, update the relevant docs:
 - `README.md` — package overview, install, usage, config
 - `ARCHITECTURE.md` — system design and execution model
 - `CONTRIBUTING.md` — contributor workflow and expectations
+- `SECURITY.md` — vulnerability reporting and sensitive-data guidance
+- `SUPPORT.md` — support routing
+- `docs/RELEASE.md` — release checklist
 - `DEVPLAN.md` — archival implementation plan only
 - `ROADMAP.md` — current forward-looking priorities
 
@@ -71,10 +74,12 @@ Depending on the change, update the relevant docs:
 Minimum expectation:
 
 ```bash
+bun run typecheck
 bun test
 bun run build
-bun run typecheck
 ```
+
+The `verify` GitHub Actions check runs the same validation for pull requests.
 
 ## Testing guidance
 
@@ -107,6 +112,10 @@ Before a release:
 4. run tests
 5. run typecheck
 6. spot-check `README.md` for drift
+
+## Security and privacy
+
+Do not include secrets, private session logs, proprietary source, or unredacted tool output in issues, pull requests, tests, or screenshots. Use GitHub Security Advisories for vulnerabilities; see `SECURITY.md`.
 
 ## Pull request expectations
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # pi-smart-compact
 
+[![CI](https://github.com/alpertarhan/pi-smart-compact/actions/workflows/ci.yml/badge.svg)](https://github.com/alpertarhan/pi-smart-compact/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/pi-smart-compact.svg)](https://www.npmjs.com/package/pi-smart-compact)
+[![npm downloads](https://img.shields.io/npm/dm/pi-smart-compact.svg)](https://www.npmjs.com/package/pi-smart-compact)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
-[![GitHub](https://img.shields.io/badge/GitHub-alpertarhan%2Fpi--smart--compact-blue)](https://github.com/alpertarhan/pi-smart-compact)
+[![Pi extension](https://img.shields.io/badge/Pi-extension-6f42c1)](https://github.com/earendil-works/pi)
 
 <p align="center">
   <img src="./docs/assets/pi-smart-compact.png" alt="pi-smart-compact" width="760" />
@@ -15,6 +17,14 @@
 It uses an **EESV** pipeline:
 
 **Extract → Explore → Synthesize → Verify**
+
+## Highlights
+
+- **Pi-native integration** — `/smart-compact`, `smart_compact`, and `session_before_compact` support.
+- **Verification-oriented output** — deterministic extraction and repair before trusting LLM synthesis.
+- **Adaptive cost profile** — skips unnecessary work on small sessions and uses chunking only when useful.
+- **Operational safety** — pending summaries expire, backups are available, and metrics make regressions visible.
+- **Companion-friendly** — designed to coexist with context hygiene tools such as `pi-toolkit`.
 
 Under the hood, the design is grounded in two core ideas:
 
@@ -36,6 +46,10 @@ This package is a **Pi extension** with three integration surfaces:
 The extension stages a short-lived pending summary in memory, then hands it back to Pi when compaction is applied.
 
 ---
+
+## Project status
+
+This is an actively maintained Pi extension. The public API is intentionally small, but the internals are still evolving as Pi's compaction lifecycle and extension APIs mature. Pin versions in production workflows if compaction behavior is mission-critical.
 
 ## Compatibility note
 
@@ -330,7 +344,7 @@ bun run build
 bun run typecheck
 ```
 
-Build output is published from `dist/`.
+Build output is published from `dist/`. Pull requests are expected to pass the same verification in GitHub Actions before merge.
 
 ---
 
@@ -339,6 +353,9 @@ Build output is published from `dist/`.
 - [`CHANGELOG.md`](./CHANGELOG.md) — release history
 - [`ARCHITECTURE.md`](./ARCHITECTURE.md) — system design and execution model
 - [`CONTRIBUTING.md`](./CONTRIBUTING.md) — contributor workflow and expectations
+- [`SECURITY.md`](./SECURITY.md) — vulnerability reporting and data-handling notes
+- [`SUPPORT.md`](./SUPPORT.md) — where to ask for help
+- [`docs/RELEASE.md`](./docs/RELEASE.md) — release checklist
 - [`ROADMAP.md`](./ROADMAP.md) — current priorities
 - [`DEVPLAN.md`](./DEVPLAN.md) — archived implementation plan
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes target the latest published version of `pi-smart-compact`.
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for vulnerabilities, leaked secrets, or private-session data exposure.
+
+Report privately through GitHub Security Advisories:
+
+<https://github.com/alpertarhan/pi-smart-compact/security/advisories/new>
+
+If advisories are unavailable, contact the maintainer listed in `package.json`.
+
+## Data handling notes
+
+`pi-smart-compact` processes Pi session content to produce compaction summaries. Depending on your session, this may include repository paths, command output, tool results, and user-provided context.
+
+Operational guidance:
+
+- Do not paste secrets into sessions you plan to compact.
+- Redact private logs before attaching them to issues.
+- Treat generated compaction summaries as potentially sensitive project context.
+- Review provider/model configuration before enabling auto-triggered compaction.
+
+Runtime artifacts are written under `~/.pi/agent/`; see `README.md` for the current list.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,17 @@
+# Support
+
+For usage questions or bug reports specific to `pi-smart-compact`, open an issue in this repository:
+
+<https://github.com/alpertarhan/pi-smart-compact/issues>
+
+For Pi Coding Agent core behavior that reproduces without this extension, use the upstream Pi repository:
+
+<https://github.com/earendil-works/pi>
+
+When asking for help, include:
+
+- `pi-smart-compact` version
+- Pi Coding Agent version
+- the command or integration surface used (`/smart-compact`, `smart_compact`, or auto-trigger)
+- relevant non-secret `smartCompact` configuration
+- redacted error output or logs

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,40 @@
+# Release checklist
+
+Use this checklist before publishing `pi-smart-compact`.
+
+## Prepare
+
+1. Decide the version bump using semver.
+2. Update version metadata:
+   - `package.json`
+   - `src/constants.ts`
+   - `CHANGELOG.md`
+3. Make sure user-facing behavior is reflected in `README.md` or project docs.
+
+## Validate
+
+```bash
+bun run typecheck
+bun test
+bun run build
+```
+
+The CI `verify` job runs the same validation on pull requests.
+
+## Publish
+
+```bash
+npm publish
+```
+
+`prepublishOnly` reruns typecheck, tests, and build before publishing.
+
+## After publishing
+
+1. Verify the npm package page.
+2. Create a GitHub release with highlights and compatibility notes.
+3. Confirm Pi can install the new version:
+
+```bash
+pi install npm:pi-smart-compact
+```

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/alper/.bun/install/global/node_modules

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "pi-smart-compact",
   "version": "7.13.0",
-  "description": "EESV smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification with redundancy pruning, project fingerprinting, and damage detection.",
+  "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
+  "packageManager": "bun@1.3.14",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -37,7 +38,9 @@
     "docs",
     "README.md",
     "LICENSE",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "SECURITY.md",
+    "SUPPORT.md"
   ],
   "scripts": {
     "build": "rm -rf dist && mkdir dist && bun build ./src/index.ts --outdir ./dist --target bun --external '@earendil-works/*' --external 'typebox' && bun x tsc --emitDeclarationOnly --outDir dist",


### PR DESCRIPTION
## Summary

Repository polish and workflow hardening for `pi-smart-compact`.

The earlier `session_before_compact` abort-signal runtime change has been reverted for now; this PR now keeps only repository hygiene, CI, documentation, and metadata improvements.

## Changes

- Add GitHub Actions CI (`verify`: typecheck, tests, build).
- Remove tracked local `node_modules` symlink and ignore it properly.
- Add issue templates, PR template, Dependabot config, release checklist, support, security, and code of conduct docs.
- Refresh README badges/status/highlights and package metadata.
- Configure repository About metadata/topics.
- Protect `main` with required `verify`, PR flow, linear history, conversation resolution, and no force-push/delete.

## Not included

- No runtime compaction behavior changes.
- No version bump.
- No Pi abort-signal integration changes.

## Validation

- `bun run typecheck`
- `bun test`
- `bun run build`
- GitHub Actions `verify`
