### PR TITLE
Release v7.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [7.13.2] - 2026-05-26
+
+### Changed
+- **Package gallery presentation** — Replaced README badge images with plain text links so Pi package pages do not render badges as extra image cards.
+- **Logo asset cleanup** — Replaced the oversized logo with a square transparent icon-only PNG and reduced README display size.
+- **Repository hygiene** — Removed stale audit and archived planning markdown files from the tracked repository.
+- **CI maintenance** — Updated GitHub Actions checkout from v4 to v6.
+
 ## [7.13.1] - 2026-05-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "7.13.1",
+  "version": "7.13.2",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,7 @@
 
 import type { CompressionProfile, ProfileConfig } from "./types.ts";
 
-export const VERSION = "7.13.1";
+export const VERSION = "7.13.2";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =


### PR DESCRIPTION
## Summary
- bump package/runtime version to 7.13.2
- document package gallery cleanup, stale markdown cleanup, and checkout@v6 CI maintenance

## Validation
- bun run typecheck
- bun test (289 pass)
- bun run build