### PR TITLE
[codex] fix tool-result compaction boundary

### DIFF
--- a/src/app/steps/window.ts
+++ b/src/app/steps/window.ts
@@ -45,13 +45,23 @@ export function resolveCompactionWindow(rc: PreparedRc): WindowedRc | null {
     if (accTokens >= rc.profileCfg.keepRecentTokens) { keepFrom = i; break; }
   }
   keepFrom = smartKeepBoundary(msgs, keepFrom, branch);
+  // `firstKeptEntryId` is required by Pi's compaction API. When the recent
+  // token walk never reaches `keepRecentTokens`, keepFrom is the empty suffix
+  // index (`msgs.length`), so resolve that fallback before applying pair
+  // safety. Otherwise a trailing toolResult can become the first kept entry
+  // while its matching assistant toolCall is compacted away.
+  if (keepFrom >= msgs.length) keepFrom = msgs.length - 1;
   keepFrom = guardToolCallBoundary(msgs, keepFrom);
+
+  if ((msgs[keepFrom]?.message as Record<string, unknown> | undefined)?.role === "toolResult") {
+    return null;
+  }
 
   const toCompact = msgs.slice(0, keepFrom);
   if (!toCompact.length) return null;
 
   const contextPercent = rc.ctx.model && totalTokens ? (totalTokens / rc.ctx.model.contextWindow) * 100 : 0;
-  const firstKeptId = (msgs[keepFrom]?.id ?? msgs[msgs.length - 1]?.id) as string;
+  const firstKeptId = msgs[keepFrom].id as string;
   // Use the shared helper instead of a local sentinel. A literal fallback
   // (e.g. "unknown") would compare equal across unrelated sessions and
   // defeat the cross-session leak guard in `consumePending`.

--- a/test/window-boundary.test.ts
+++ b/test/window-boundary.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+import { resolveCompactionWindow } from "../src/app/steps/window.ts";
+import type { PreparedRc } from "../src/app/run-context.ts";
+import type { SessionMessageEntry } from "../src/types.ts";
+
+function messageEntry(
+  id: string,
+  parentId: string | null,
+  message: Record<string, unknown>,
+): SessionMessageEntry & { parentId: string | null; timestamp: string } {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp: "2026-06-15T00:00:00.000Z",
+    message,
+  };
+}
+
+function makePreparedRc(branch: SessionMessageEntry[], keepRecentTokens = 30_000): PreparedRc {
+  return {
+    ctx: {
+      cwd: "/tmp/pi-smart-compact-test",
+      model: { contextWindow: 150_000 },
+      getContextUsage: () => ({ tokens: 135_000, contextWindow: 150_000, percent: 90 }),
+      sessionManager: {
+        getBranch: () => branch,
+        getSessionId: () => "test-session",
+      },
+    },
+    profileCfg: {
+      keepRecentTokens,
+      summaryBudgetTokens: 6_000,
+      minChunkTokens: 500,
+      maxChunkTokens: 8_000,
+      singlePassMaxTokens: 30_000,
+      batchMaxTokens: 24_000,
+    },
+    _prepared: true,
+  } as unknown as PreparedRc;
+}
+
+describe("resolveCompactionWindow tool-result boundary", () => {
+  it("does not choose a trailing toolResult as firstKeptId when the recent tail is smaller than keepRecentTokens", () => {
+    const toolCallId = "call_test|fc_test";
+    const branch: SessionMessageEntry[] = [
+      messageEntry("m1-user", null, {
+        role: "user",
+        content: [{ type: "text", text: "please run a tool" }],
+        timestamp: 1,
+      }),
+      messageEntry("m2-assistant-toolcall", "m1-user", {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: toolCallId,
+            name: "bash",
+            arguments: { command: "echo ok" },
+          },
+        ],
+        timestamp: 2,
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        stopReason: "tool_use",
+        usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
+      }),
+      messageEntry("m3-tool-result", "m2-assistant-toolcall", {
+        role: "toolResult",
+        toolCallId,
+        toolName: "bash",
+        content: [{ type: "text", text: "ok\n" }],
+        isError: false,
+        timestamp: 3,
+      }),
+    ];
+
+    const result = resolveCompactionWindow(makePreparedRc(branch));
+
+    expect(result).not.toBeNull();
+    expect(result?.firstKeptId).toBe("m2-assistant-toolcall");
+  });
+
+  it("backs up when the token window naturally starts at a toolResult", () => {
+    const toolCallId = "call_cut|fc_cut";
+    const branch: SessionMessageEntry[] = [
+      messageEntry("m1-user", null, {
+        role: "user",
+        content: [{ type: "text", text: "please run a tool" }],
+        timestamp: 1,
+      }),
+      messageEntry("m2-assistant-toolcall", "m1-user", {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: toolCallId,
+            name: "bash",
+            arguments: { command: "echo ok" },
+          },
+        ],
+        timestamp: 2,
+      }),
+      messageEntry("m3-tool-result", "m2-assistant-toolcall", {
+        role: "toolResult",
+        toolCallId,
+        toolName: "bash",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+        timestamp: 3,
+      }),
+    ];
+
+    const result = resolveCompactionWindow(makePreparedRc(branch, 1));
+
+    expect(result).not.toBeNull();
+    expect(result?.firstKeptId).toBe("m2-assistant-toolcall");
+  });
+
+  it("does not emit a compaction if the first kept entry would still be a toolResult", () => {
+    const branch: SessionMessageEntry[] = [
+      messageEntry("m1-user", null, {
+        role: "user",
+        content: [{ type: "text", text: "please run a tool" }],
+        timestamp: 1,
+      }),
+      messageEntry("m2-assistant", "m1-user", {
+        role: "assistant",
+        content: [{ type: "text", text: "running it" }],
+        timestamp: 2,
+      }),
+      messageEntry("m3-orphan-tool-result", "m2-assistant", {
+        role: "toolResult",
+        toolCallId: "missing-call",
+        toolName: "bash",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+        timestamp: 3,
+      }),
+    ];
+
+    const result = resolveCompactionWindow(makePreparedRc(branch));
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
# [codex] fix tool-result compaction boundary

Target: `alpertarhan/pi-smart-compact:main`  
Head: `orbitingflea/pi-smart-compact:codex/fix-tool-result-boundary`

## Summary

Fix `resolveCompactionWindow()` so smart compaction does not produce a `firstKeptEntryId` that points at a `toolResult` whose matching assistant `toolCall` was compacted away.

## Observed Failure

An affected session failed with:

```text
Codex error: {"type":"error","error":{"type":"invalid_request_error","message":"No tool call found for function call output with call_id call_hVBfzQ0kBcjOlz0EPXqqqxn6.","param":"input"},"status":400}
```

The rebuilt context did not include a preceding retained tool call for that `call_id`. The compaction boundary kept the raw tool result while dropping the assistant tool call that created it.

## Root Cause

When the recent-message token walk never reached `keepRecentTokens`, `keepFrom` stayed at `msgs.length`. `guardToolCallBoundary()` treats that as an out-of-range boundary and returns early. After that, `resolveCompactionWindow()` fell back to `msgs[msgs.length - 1].id` for `firstKeptId`.

If the last message was a `toolResult`, the compacted context could keep that raw result while dropping the assistant message that created the matching tool call. OpenAI Responses rejects that transcript shape because the tool output no longer has a preceding call.

## Changes

- Normalize the empty-suffix boundary (`keepFrom >= msgs.length`) to the final real message before applying `guardToolCallBoundary()`.
- Remove the post-guard fallback that could silently select the final message as `firstKeptId`.
- Return `null` instead of emitting a compaction if the first kept message would still be a `toolResult`.
- Add regression coverage for:
  - the exact trailing-`toolResult` fallback case,
  - a token window that naturally starts at a `toolResult`,
  - a defensive orphan-`toolResult` case where no matching call can be retained.

## Validation

- `bun test test/window-boundary.test.ts`
- `bun run typecheck`
- Full suite also passed locally before pushing: `bun test` with `407 pass, 0 fail`.
