### PR TITLE
Release v7.15.1: section placement, defensive guards, dep updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ dist/
 node_modules
 node_modules/
 
+# Lockfile — this project uses bun (see bun.lock). Ignore npm's lockfile
+# so an accidental `npm install` / `npm outdated` doesn't create noise.
+package-lock.json
+
 # Environment
 .env
 .env.local

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -203,6 +203,8 @@ The code is organized into five layers, each with a single responsibility:
 | --- | --- |
 | `src/app/run-smart-compact.ts` | top-level pipeline orchestrator (was `src/core.ts`) |
 | `src/app/run-context.ts` | typed stage chain (`RcBase → Prepared → Windowed → … → Stated`) |
+| `src/app/pending-slot.ts` | encapsulated pending-compaction state cell (set/consume/clear/expire/mismatch) |
+| `src/app/explore-wrap.ts` | thin re-export shim that isolates the explore import for headless tests |
 | `src/app/steps/prepare.ts` | resolve config, auth, provider caps |
 | `src/app/steps/window.ts` | pick the prefix of messages to compact |
 | `src/app/steps/recover.ts` | recover full content for log-truncated messages |
@@ -221,7 +223,7 @@ Pure semantics; no I/O, no async, no globals.
 | File | Responsibility |
 | --- | --- |
 | `src/domain/summary-schema.ts` | canonical section list + heading regex |
-| `src/domain/summary-parse.ts` | parse/serialize summary into structured sections |
+| `src/domain/summary-parse.ts` | parse/serialize summary into structured sections; section placement (`before`/`after`) |
 
 ### Algorithm layer (`src/phases/`)
 
@@ -244,6 +246,7 @@ All external-world interaction (fs, time, network, services container).
 | `src/infra/llm-client.ts` | LLM client seam (production wraps with retry) |
 | `src/infra/llm-retry.ts` | 429/5xx exponential backoff + jitter + Retry-After |
 | `src/infra/services.ts` | per-run services container (metrics, clock, llm, tool-support cache) |
+| `src/infra/session-identity.ts` | robust session-id resolution with opaque `unresolved:` fallback |
 
 ### Utility layer (`src/utils/`)
 
@@ -257,11 +260,13 @@ All external-world interaction (fs, time, network, services container).
 | `src/utils/fingerprint.ts` | project fingerprinting (language, framework, deps) |
 | `src/utils/damage.ts` | post-compaction regression signals |
 | `src/utils/id-fingerprint.ts` | compact SHA-256 fingerprint of entry-id arrays |
+| `src/utils/file-needles.ts` | path-suffix needles for error→file attribution |
+| `src/utils/file-ref-detect.ts` | fabricated file-reference detection (SemVer-rejecting) |
 | `src/utils/session-log.ts` | streaming JSONL parser for the Pi session log |
 | `src/utils/tokens.ts` | per-(provider,model) token estimation with EMA calibration |
 | `src/utils/type-guards.ts` | runtime validators for cross-version compatibility |
 | `src/utils/logger.ts` | stderr-prefixed log shim |
-| `src/utils/fingerprint.ts` | project fingerprint cache |
+| `src/utils/lru.ts` | small bounded LRU cache primitive |
 
 ### UI layer (`src/ui/`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [7.15.1] - 2026-06-15
+
+### Fixed
+- **Delta section placement** — `injectDeltaSection` contained a dead ternary (`hasOpenLoops ? "next-steps" : "next-steps"`) that made the `hasOpenLoops` computation unreachable, so the "Changes Since Last Compaction" section always anchored before `Next Steps` regardless of whether `Open Loops` was present. The domain layer (`summary-parse.ts`) now supports a structured `SectionPlacement` hint with both `before` and `after` semantics; the delta injector anchors *after* `Open Loops` when present, otherwise *before* `Next Steps`. The new object form is additive — the legacy positional `before` argument remains backward-compatible.
+- **Shadowed catch binding in exploration parser** — `parseExplorationReport` used `e` for both `lastIndexOf("}")` and the per-`catch` error, which compiled but was a confusing trap for future edits. Renamed the loop bounds to `startIdx`/`endIdx` and the catch bindings to `err`.
+- **Defensive guards in LLM-output parsing** — `buildExplorationReportFromParsed` now validates `typeof parsed === "object"` before touching it, so a model that returns a primitive JSON value (`42`, `"ok"`, `true`, `null`) falls back to heuristic boundaries instead of risking a `TypeError`.
+- **Non-negative index guard** — `branchIndexToMsgIndex` (used by anchor-aware keep-boundary resolution) now clamps to `Math.max(0, ...)`, so a future code path that reaches it without a prior message entry can never produce a negative index.
+
+### Changed
+- **Typed theme in TUI overlays** — `renderContextBar` and `renderTokenBar` no longer take `theme: any`; they now use the real `Theme` class exported from `@earendil-works/pi-coding-agent`, restoring compile-time type safety over `.fg()` / `.bold()` calls without inventing a parallel local interface.
+
+### Build
+- **Pi runtime peers 0.79.4** — `@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, and `@earendil-works/pi-tui` resolved from 0.79.0 → 0.79.4. Peer dependency ranges remain wide (`*`).
+- **`typebox` 1.2.11** — Patch upgrade from 1.2.3.
+- **`@types/node` 25.9.3** — Patch upgrade from 25.9.2.
+
+### Docs
+- **Architecture tables synchronized** — `ARCHITECTURE.md`'s layer tables now list every `src` module, including previously missing `pending-slot.ts`, `explore-wrap.ts`, `infra/session-identity.ts`, `utils/file-needles.ts`, `utils/file-ref-detect.ts`, and `utils/lru.ts`. README repository-layout tree and module counts updated to match (15 utility modules; 414 tests across 36 files).
+
+### Tests
+- **7 new test cases (407 → 414)** covering `upsertSection` before/after placement and legacy back-compat, plus `buildExplorationReportFromParsed` primitive/null guards.
+
+### Chore
+- **Ignore npm lockfile** — `.gitignore` now excludes `package-lock.json`; this project uses `bun` and the stray lockfile created by incidental `npm` commands should not be committed.
+
 ## [7.15.0] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ At runtime, the extension writes to paths under `~/.pi/agent/`, including:
 │   ├── app/                  # orchestration layer
 │   │   ├── run-smart-compact.ts   # pipeline orchestrator (was core.ts)
 │   │   ├── run-context.ts         # typed stage chain
+│   │   ├── pending-slot.ts        # encapsulated pending-compaction state cell
 │   │   ├── explore-wrap.ts        # explore re-export shim
 │   │   └── steps/                 # 10 stage modules
 │   │       ├── prepare.ts   →   resolves config + auth
@@ -350,12 +351,13 @@ At runtime, the extension writes to paths under `~/.pi/agent/`, including:
 │   │   ├── clock.ts             # injectable clock
 │   │   ├── llm-client.ts        # LLM client seam
 │   │   ├── llm-retry.ts         # 429/5xx backoff
-│   │   └── services.ts          # per-run services container
+│   │   ├── services.ts          # per-run services container
+│   │   └── session-identity.ts # robust session-id resolution
 │   ├── ui/                   # TUI overlays + dashboard
 │   │   ├── overlays.ts
 │   │   └── dashboard-format.ts
-│   └── utils/                # 13 focused utility modules
-├── test/                     # 280+ tests across 28 files
+│   └── utils/                # 15 focused utility modules
+├── test/                     # 414 tests across 36 files
 ├── docs/
 ├── dist/
 └── package.json

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@earendil-works/pi-ai": "*",
         "@earendil-works/pi-coding-agent": "*",
         "@earendil-works/pi-tui": "*",
-        "@types/node": "^25.9.2",
+        "@types/node": "^25.9.3",
         "typebox": "*",
         "typescript": "^6.0.0",
       },
@@ -75,13 +75,13 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.0", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-jQOtYjRGZ7+XC/olw9euLd2V03vkAPO8u0sSnQoLbyOQZz66dEBZrklTESk34Sf3AaeBSua28wjZR48ch1aXJQ=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.4", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-xkaZ3yK2XbP9HYdHrrdj/6HqZPM0o/mwbjMSU4RTJyR3HjDG0ZrPz76Hg6s0W+G4u6PpJr1mGx/srCG+3eQA8A=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-D/2aDoe9vcCbqAztALQcKkdqXGuaQcqAzLm8LfUhNaorwoIHkwnaAuDVlo+OkF5clpEwS8Z1bk2o8NiSrwEdsA=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.4", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Z1j+YP+6ZyPBKDUoc5m0GO/o1hPK17fWeErtDgegCTpm2dcKzuFvL/7GTqHeJkVkfpeXRwO37xOfgozQbK6EUw=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.79.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.79.0", "@earendil-works/pi-ai": "^0.79.0", "@earendil-works/pi-tui": "^0.79.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "typebox": "1.1.38", "undici": "8.3.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-pZoXk65vFR3dAzzmPNWEX61aHnT6+BaVhTyFDQAs1DyumaMeWpvzRV9ZrGxqlbVLwhrq+0LnXbaqDAFkhe2+MQ=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.79.4", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.79.4", "@earendil-works/pi-ai": "^0.79.4", "@earendil-works/pi-tui": "^0.79.4", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.3.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-PthzVzM5m4XH/hrU+2fVjuwuH5M4eMFWbd0NCRScH14XKpwlPc8/Fh6JDz0jQb5kTBT9oQT183YLTHVVulFL9A=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.79.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "15.0.12" } }, "sha512-qAQWMruW7YKbk2hPcTD4INtXfvIySXifbPQ+mFY5j3J8yf2tfElkh+gGPuBvgPKPT0z9WiAkd7iySCuQq0txuQ=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.79.4", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "15.0.12" } }, "sha512-/ZhfFiHSBMH7AbDrBQIN+UWlJnl9tSEpLYICRGGMzmNfyCqX+30NYacIhyOEaD8R5rS6wJZysAOPU0yNwigbXw=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
@@ -151,7 +151,7 @@
 
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
-    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
@@ -263,6 +263,8 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -275,7 +277,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typebox": ["typebox@1.2.3", "", {}, "sha512-EdFz/9FGvhQK2NmjZjSLri+nd5oMH+t/46/6lueEPbeHmS9WbWOz5IayPyLw0HHIyOWfo+wPrQGcAEQ+GsXc/w=="],
+    "typebox": ["typebox@1.2.11", "", {}, "sha512-0WPn8EoKHPZiACD/mgU+TY+SP7kn5S3pPmeoOBXhkwqkX/W4XyRLfYrDC8Nnhf23OhRf+yMe/atZtyiOLbgSVg=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "7.15.0",
+  "version": "7.15.1",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",
@@ -61,7 +61,7 @@
     "typebox": "*"
   },
   "devDependencies": {
-    "@types/node": "^25.9.2",
+    "@types/node": "^25.9.3",
     "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "7.15.0";
+export const VERSION = "7.15.1";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =

--- a/src/domain/summary-parse.ts
+++ b/src/domain/summary-parse.ts
@@ -100,19 +100,33 @@ export function renderSummary(summary: CanonicalSummary, opts: { canonicalHeadin
 }
 
 /**
+ * Placement hint for `upsertSection` when inserting a *new* section.
+ *
+ * `before`/`after` name the *kind* of an existing section that the new entry
+ * should anchor against. `before` inserts immediately ahead of the anchor;
+ * `after` inserts immediately behind it. When both are given, `before` wins
+ * (kept for back-compat with positional callers). When neither anchor is found
+ * the section falls back to append-at-end.
+ *
+ * This is how the synthesis pipeline keeps `Open Loops` ahead of `Next Steps`
+ * deterministically, and the delta injector places `Changes Since Last
+ * Compaction` directly after `Open Loops` when present.
+ */
+export interface SectionPlacement {
+  before?: SectionKind;
+  after?: SectionKind;
+}
+
+/**
  * Insert or replace a section. If a section with the same `kind` exists, its
  * heading is replaced with the canonical one and the body is overwritten. If
- * not, the section is appended.
- *
- * `before` hints at which section *kind* the new entry should precede; when
- * absent the section is appended. This is how the synthesis pipeline keeps
- * `Open Loops` ahead of `Next Steps` deterministically.
+ * not, the section is inserted according to `placement` (or appended).
  */
 export function upsertSection(
   summary: CanonicalSummary,
   kind: SectionKind,
   body: string,
-  before?: SectionKind,
+  placement?: SectionKind | SectionPlacement,
 ): CanonicalSummary {
   const heading = canonicalHeading(kind);
   const existing = summary.sections.findIndex(s => s.kind === kind);
@@ -121,12 +135,30 @@ export function upsertSection(
     sections[existing] = { kind, heading, body: body.trim() };
     return { sections };
   }
+  // Back-compat: positional callers pass a bare SectionKind as `before`.
+  const hint: SectionPlacement = placement == null
+    ? {}
+    : typeof placement === "string"
+      ? { before: placement }
+      : placement;
   const section: Section = { kind, heading, body: body.trim() };
-  if (before) {
-    const idx = summary.sections.findIndex(s => s.kind === before);
+  if (hint.before) {
+    const idx = summary.sections.findIndex(s => s.kind === hint.before);
     if (idx >= 0) {
       const sections = summary.sections.slice();
       sections.splice(idx, 0, section);
+      return { sections };
+    }
+  }
+  if (hint.after) {
+    // findLastIndex so duplicate-kind sections insert after the final one.
+    let idx = -1;
+    for (let i = summary.sections.length - 1; i >= 0; i--) {
+      if (summary.sections[i].kind === hint.after) { idx = i; break; }
+    }
+    if (idx >= 0) {
+      const sections = summary.sections.slice();
+      sections.splice(idx + 1, 0, section);
       return { sections };
     }
   }

--- a/src/phases/explore.ts
+++ b/src/phases/explore.ts
@@ -158,11 +158,15 @@ export function parseExplorationReport(text: string, llmMessages: LlmMessage[]):
   const md = text.match(/```(?:json)?\s*([\s\S]*?)```/);
   if (md) json = md[1].trim();
 
-  let s = json.indexOf("{"), e = json.lastIndexOf("}");
-  if (s === -1 || e === -1) return fallbackExplorationReport(llmMessages);
-  let rawJson = json.slice(s, e + 1);
+  // Note: `startIdx`/`endIdx` (not `s`/`e`) so the `catch (err)` blocks below
+  // cannot accidentally shadow a single-letter outer binding. Earlier code
+  // used `e` for both lastIndexOf and the catch error, which compiled but
+  // was a confusing trap for future edits.
+  const startIdx = json.indexOf("{"), endIdx = json.lastIndexOf("}");
+  if (startIdx === -1 || endIdx === -1) return fallbackExplorationReport(llmMessages);
+  const rawJson = json.slice(startIdx, endIdx + 1);
 
-  try { return buildExplorationReportFromParsed(JSON.parse(rawJson), llmMessages); } catch (e) { log.debug("JSON parse attempt 1 failed", e); }
+  try { return buildExplorationReportFromParsed(JSON.parse(rawJson), llmMessages); } catch (err) { log.debug("JSON parse attempt 1 failed", err); }
 
   // Strip trailing commas + line/block comments. We deliberately do NOT do
   // a blanket `'` -> `"` replacement: a model that returns valid JSON
@@ -174,7 +178,7 @@ export function parseExplorationReport(text: string, llmMessages: LlmMessage[]):
     .replace(/,\s*([}\]])/g, "$1")
     .replace(/\/\/.*$/gm, "")
     .replace(/\/\*[\s\S]*?\*\//g, "");
-  try { return buildExplorationReportFromParsed(JSON.parse(cleaned), llmMessages); } catch (e) { log.debug("JSON parse attempt 2 (cleaned) failed", e); }
+  try { return buildExplorationReportFromParsed(JSON.parse(cleaned), llmMessages); } catch (err) { log.debug("JSON parse attempt 2 (cleaned) failed", err); }
 
   const boundaryMatch = rawJson.match(/"boundaries"\s*:\s*\[([\s\S]*?)\]/);
   if (boundaryMatch) {
@@ -186,12 +190,21 @@ export function parseExplorationReport(text: string, llmMessages: LlmMessage[]):
         priority: ["critical", "high", "normal", "low"].includes(b.priority) ? b.priority : "normal",
         confidence: Math.min(1, Math.max(0, b.confidence ?? 0.5)),
       })) };
-    } catch (e) { log.debug("Boundary JSON parse failed", e); }
+    } catch (err) { log.debug("Boundary JSON parse failed", err); }
   }
   return fallbackExplorationReport(llmMessages);
 }
 
 export function buildExplorationReportFromParsed(parsed: any, llmMessages: LlmMessage[]): ExplorationReport {
+  // Defend against primitives: a model can return JSON that parses to a
+  // number/string/boolean (e.g. just `42` or `"ok"`). The optional-chaining
+  // below tolerates that for most fields, but `parsed.statusAssessment?.done`
+  // on a primitive yields undefined safely — so the previous code happened to
+  // work. Make the object assumption explicit so a future field access can't
+  // introduce a TypeError on `(42).something`.
+  if (typeof parsed !== "object" || parsed === null) {
+    return fallbackExplorationReport(llmMessages);
+  }
   return {
     boundaries: (parsed.boundaries ?? []).filter((b: any) => typeof b?.afterIndex === "number").map((b: any) => ({
       afterIndex: Math.min(b.afterIndex, llmMessages.length - 2),

--- a/src/ui/overlays.ts
+++ b/src/ui/overlays.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { DynamicBorder } from "@earendil-works/pi-coding-agent";
+import { DynamicBorder, Theme } from "@earendil-works/pi-coding-agent";
 import { Container, Key, matchesKey, type SelectItem, SelectList, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type {
@@ -25,7 +25,7 @@ import {
 } from "./dashboard-format.ts";
 import path from "node:path";
 
-export function renderContextBar(theme: any, pct: number, tokens: number, barLen = 24): string {
+export function renderContextBar(theme: Theme, pct: number, tokens: number, barLen = 24): string {
   const clamped = Math.min(Math.max(pct, 0), 100);
   const filled = Math.min(barLen, Math.round((clamped / 100) * barLen));
   const bar = "\u2588".repeat(filled) + "\u2591".repeat(barLen - filled);
@@ -36,7 +36,7 @@ export function renderContextBar(theme: any, pct: number, tokens: number, barLen
   return theme.fg("text", "  Context: ") + theme.fg(color, bar) + theme.fg("text", " " + clamped + "%") + theme.fg("dim", " (" + (tokens ?? 0).toLocaleString() + "t)");
 }
 
-export function renderTokenBar(theme: any, before: number, after: number, label: string, barLen = 30): string {
+export function renderTokenBar(theme: Theme, before: number, after: number, label: string, barLen = 30): string {
   const ratio = before > 0 ? after / before : 0;
   const savedPct = Math.round((1 - ratio) * 100);
   const filled = Math.min(barLen, Math.round(ratio * barLen));

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -239,7 +239,7 @@ function branchIndexToMsgIndex(branchEntries: unknown[], branchIdx: number, msgs
       msgCount++;
     }
   }
-  return Math.min(msgCount - 1, msgs.length - 1);
+  return Math.max(0, Math.min(msgCount - 1, msgs.length - 1));
 }
 
 export function smartKeepBoundary(

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -269,10 +269,16 @@ export function injectDeltaSection(summary: string, delta: CompactionDelta): str
 
   const parsed = parseSummary(summary);
   const hasOpenLoops = parsed.sections.some(s => s.kind === "open-loops");
-  // Place after Open Loops by anchoring before Next Steps when Open Loops
-  // exists; otherwise straight before Next Steps. The upsert helper falls
-  // back to append when neither anchor is found.
-  const updated = upsertSection(parsed, "changes", body, hasOpenLoops ? "next-steps" : "next-steps");
+  // Placement priority:
+  //   1. If an `Open Loops` section exists, anchor the delta directly *after*
+  //      it so the reader sees `… Open Loops → Changes → Next Steps …`.
+  //   2. Otherwise anchor directly *before* `Next Steps`.
+  // The `upsertSection` helper falls back to append-at-end when neither anchor
+  // is found, so the delta is never silently dropped.
+  const placement = hasOpenLoops
+    ? { after: "open-loops" as const }
+    : { before: "next-steps" as const };
+  const updated = upsertSection(parsed, "changes", body, placement);
   return renderSummary(updated);
 }
 

--- a/test/exploration.test.ts
+++ b/test/exploration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { parseExplorationReport, fallbackExplorationReport, shouldExplore } from "../src/phases/explore.ts";
+import { parseExplorationReport, fallbackExplorationReport, shouldExplore, buildExplorationReportFromParsed } from "../src/phases/explore.ts";
 import type { LlmMessage } from "../src/types.ts";
 
 describe("parseExplorationReport", () => {
@@ -29,6 +29,35 @@ describe("parseExplorationReport", () => {
     const report = parseExplorationReport(text, []);
     expect(report.boundaries.length).toBe(1);
     expect(report.boundaries[0].topic).toBe("X");
+  });
+});
+
+describe("buildExplorationReportFromParsed", () => {
+  it("returns a fallback for primitive JSON values (number/string/boolean)", () => {
+    // A model can return JSON that parses to a non-object (e.g. just `42`).
+    // The builder must not throw on such input — it falls back to an empty
+    // report so the pipeline can continue with heuristic boundaries.
+    expect(() => buildExplorationReportFromParsed(42, [])).not.toThrow();
+    expect(() => buildExplorationReportFromParsed("a string", [])).not.toThrow();
+    expect(() => buildExplorationReportFromParsed(true, [])).not.toThrow();
+    const report = buildExplorationReportFromParsed(42, []);
+    expect(report.boundaries.length).toBe(0);
+  });
+
+  it("returns a fallback for null", () => {
+    expect(() => buildExplorationReportFromParsed(null, [])).not.toThrow();
+    const report = buildExplorationReportFromParsed(null, []);
+    expect(report.boundaries.length).toBe(0);
+  });
+
+  it("parses a well-formed object", () => {
+    const report = buildExplorationReportFromParsed(
+      { boundaries: [{ afterIndex: 2, topic: "X", priority: "normal", confidence: 0.5 }], mainGoal: "g", sessionType: "review" },
+      [],
+    );
+    expect(report.boundaries.length).toBe(1);
+    expect(report.mainGoal).toBe("g");
+    expect(report.sessionType).toBe("review");
   });
 });
 

--- a/test/summary-parse.test.ts
+++ b/test/summary-parse.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect } from "bun:test";
 import { parseSummary, findSection, hasSection, upsertSection, appendToSection, renderSummary } from "../src/domain/summary-parse.ts";
+import type { SectionPlacement } from "../src/domain/summary-parse.ts";
 
 describe("parseSummary", () => {
   it("classifies common section variants", () => {
@@ -78,6 +79,32 @@ describe("upsertSection", () => {
     const parsed = parseSummary("## Goal\ng\n");
     const next = upsertSection(parsed, "open-loops", "- loop", "next-steps");
     expect(next.sections.map(s => s.kind)).toEqual(["goal", "open-loops"]);
+  });
+
+  it("inserts after an anchor when placement.after is given", () => {
+    const parsed = parseSummary("## Goal\ng\n## Open Loops\n- loop\n## Next Steps\n1. n\n");
+    const next = upsertSection(parsed, "changes", "- delta", { after: "open-loops" });
+    // Order must be: Goal, Open Loops, Changes, Next Steps — changes sits
+    // directly behind Open Loops, not appended after Next Steps.
+    expect(next.sections.map(s => s.kind)).toEqual(["goal", "open-loops", "changes", "next-steps"]);
+  });
+
+  it("inserts before an anchor when placement.before is given", () => {
+    const parsed = parseSummary("## Goal\ng\n## Next Steps\n1. n\n");
+    const next = upsertSection(parsed, "changes", "- delta", { before: "next-steps" });
+    expect(next.sections.map(s => s.kind)).toEqual(["goal", "changes", "next-steps"]);
+  });
+
+  it("falls back to append when neither placement anchor exists", () => {
+    const parsed = parseSummary("## Goal\ng\n");
+    const next = upsertSection(parsed, "changes", "- delta", { after: "open-loops" });
+    expect(next.sections.map(s => s.kind)).toEqual(["goal", "changes"]);
+  });
+
+  it("treats a bare SectionKind as the legacy positional `before` arg", () => {
+    const parsed = parseSummary("## Goal\ng\n## Next Steps\n1. n\n");
+    const next = upsertSection(parsed, "open-loops", "- loop", "next-steps");
+    expect(next.sections.map(s => s.kind)).toEqual(["goal", "open-loops", "next-steps"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Patch release (`7.15.0` → `7.15.1`): code-health fixes, defensive guards, doc sync, and dependency updates. **No breaking changes, no new user-facing features.**

This is an audit-driven cleanup pass. See `CHANGELOG.md` for the full entry.

## Fixed
- **Delta section placement** — `injectDeltaSection` contained a dead ternary (`hasOpenLoops ? "next-steps" : "next-steps"`) that made the `hasOpenLoops` computation unreachable. Domain layer now supports structured `SectionPlacement` (`before` + `after`); delta anchors *after* `Open Loops` when present, else *before* `Next Steps`. Legacy positional `before` arg stays backward-compatible.
- **Shadowed catch binding** in `parseExplorationReport` (`e` vs `lastIndexOf`) → renamed to `startIdx`/`endIdx` + `err`.
- **Defensive guards** — `buildExplorationReportFromParsed` validates object shape before access; `branchIndexToMsgIndex` clamps to non-negative.

## Changed
- **Typed theme in TUI overlays** — `renderContextBar`/`renderTokenBar` use the real `Theme` class instead of `any`.

## Build
- Pi runtime peers `0.79.0` → `0.79.4` (ranges remain wide `*`).
- `typebox` `1.2.3` → `1.2.11`; `@types/node` `25.9.2` → `25.9.3`.

## Docs
- Synchronized `ARCHITECTURE.md` layer tables (all 47 `src` modules now listed) + README layout/counts.

## Tests
- 7 new test cases (407 → 414): `upsertSection` placement + `buildExplorationReportFromParsed` primitive/null guards.

## Validation
- [x] `bun x tsc --noEmit` — 0 errors
- [x] `bun run build` — 46 modules, clean
- [x] `bun test` — 414 pass / 0 fail (2908 assertions)

## After merge
- Tag `v7.15.1`, create GitHub release
- `npm publish` (manual — npm auth required)