### PR TITLE
Release v7.16.0

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,33 +1,34 @@
 # Architecture
 
-This document describes how `pi-smart-compact` works at a system level.
+System-level design of `pi-smart-compact`. This is the maintainer-facing
+companion to the user-facing [`README.md`](./README.md).
 
-## Overview
+> **Job:** not to produce a generic recap, but to preserve the agent's working
+> state so the next turn can continue with minimal loss.
 
-`pi-smart-compact` is a Pi extension for **verification-oriented smart compaction**.
-
-Its job is not to produce a generic recap. Its job is to preserve the agent's working state so the next turn can continue with minimal loss.
+## Design ideas
 
 The design combines three ideas:
 
-- **agentic compaction** — let the system inspect the session, not just summarize it
-- **Kamradt-style chunking** — segment large conversations into more coherent units before synthesis
-- **EESV** — **Extract → Explore → Synthesize → Verify**
+- **Agentic compaction** — let the system inspect the session, not just summarize it.
+- **Kamradt-style chunking** — segment large conversations into coherent units before synthesis.
+- **EESV** — **Extract → Explore → Synthesize → Verify**: facts first, synthesis second, verification last.
 
 ## Integration surfaces
 
-The extension registers three surfaces from `src/index.ts`:
+Registered in [`src/index.ts`](./src/index.ts). See the README for usage; this
+section is about lifecycle.
 
-1. `/smart-compact`
-   - interactive or direct manual compaction
-2. `session_before_compact`
-   - auto-triggered smart compaction before Pi's default compaction
-3. `smart_compact` tool
-   - agent-callable compaction for long sessions
+| Surface | Lifecycle |
+| --- | --- |
+| `/smart-compact` | Manual command. Interactive picker or direct args. Bypasses the adaptive gate. |
+| `session_before_compact` | Auto hook. Consumes any pending summary, else runs when context pressure is high. |
+| `smart_compact` tool | Agent-callable. Prepares a pending summary; never compacts mid-turn. |
 
-A short-lived pending compaction is kept in memory and consumed by Pi when compaction is applied.
+A short-lived pending compaction is staged in the [`PendingSlot`](#pending-compaction-slot)
+and handed to Pi when compaction is applied.
 
-## High-level flow
+## Pipeline at a glance
 
 ```mermaid
 flowchart LR
@@ -43,151 +44,209 @@ flowchart LR
     I --> J[Pending compaction returned to Pi]
 ```
 
+The orchestrator ([`src/app/run-smart-compact.ts`](./src/app/run-smart-compact.ts))
+threads a typed context through ten stages:
+
+| # | Stage | Module | Transition |
+| ---: | --- | --- | --- |
+| 1 | prepare | `app/steps/prepare.ts` | config + auth + provider caps |
+| 2 | window | `app/steps/window.ts` | pick the prefix to compact |
+| 3 | recover | `app/steps/recover.ts` | restore log-truncated messages |
+| 4 | tier | `app/steps/tier.ts` | choose none / light / full |
+| 5 | extract | `app/steps/extract.ts` | prune + deterministic extraction + cache |
+| 6 | synthesize | `app/steps/synthesize.ts` | single-pass or EESV |
+| 7 | verify | `app/steps/verify.ts` | structural verify + repair |
+| 8 | state | `app/steps/state.ts` | state machine + open loops + delta |
+| 9 | persist | `app/steps/persist.ts` | stage pending, apply compaction |
+| 10 | metrics | `app/steps/metrics.ts` | success / failure record |
+
+## The typed stage machine
+
+[`src/app/run-context.ts`](./src/app/run-context.ts) models the pipeline context
+as a **state machine of branded intersection types**. Each step accepts the
+previous stage type and returns the next, so reordering or skipping a step is a
+**compile-time error**, not a runtime crash:
+
+```
+RcBase
+  → PreparedRc      (after prepare)
+  → WindowedRc      (after window)
+  → RecoveredRc     (after recover)
+  → TieredRc        (after tier)
+  → ExtractedRc     (after extract)
+  → SynthesizedRc   (after synthesize)
+  → VerifiedRc      (after verify)
+  → StatedRc        (after state)
+```
+
+Each stage adds a `_prepared` / `_windowed` / … discriminator field that is
+**never read at runtime** — it exists only to carry the type-level proof.
+Mutation is preserved: a step mutates its input object and casts it to the
+next stage (no per-step copy of ~30 fields). The final alias
+`RunContext = StatedRc` keeps post-`buildState` consumers readable.
+
+This is what lets `applyCompaction` read `rc.details` with zero `!` non-null
+assertions: the type system proves `buildState` has run.
+
 ## Core execution model
 
-### 1. Entry and context gate
+### Entry and context gate
 
-`src/index.ts` resolves models, parses command arguments, and routes work into `runSmartCompact()` in `src/app/run-smart-compact.ts`. The orchestrator is a thin pipeline of typed stages (see `src/app/run-context.ts`); each stage is a separate module under `src/app/steps/`.
+`src/index.ts` resolves models, parses command arguments, and routes work into
+`runSmartCompact()`. Before any expensive work, the system checks context size
+against the threshold in `src/constants.ts`. Auto / tool runs are skipped while
+context is small; manual `/smart-compact` bypasses the gate.
 
-Before doing expensive work, the system checks context size. If usage is below the threshold in `src/constants.ts`, compaction is skipped.
+### Keep window and preprocessing
 
-## 2. Keep window and preprocessing
+`app/steps/window.ts` keeps a recent tail of messages untouched so very recent
+context stays live, anchored by:
 
-`src/app/steps/window.ts` keeps a recent tail of messages untouched so very recent context stays live.
+- **pi-toolkit anchor protection** — never compact past the latest on-branch anchor
+- **`toolCall` / `toolResult` boundary guard** — never orphan a result from its call
 
-Before summarization, the pipeline also:
+Before summarization the pipeline also prunes redundant messages, serializes the
+compacted portion, creates a backup, loads previous compaction context, checks
+the incremental extraction cache, and loads the project fingerprint.
 
-- prunes redundant messages
-- serializes the compacted portion of the conversation
-- creates a backup when enabled
-- loads previous compaction context
-- checks incremental extraction cache
-- loads project fingerprint data if available
+### Extract
 
-## 3. Extract
+Primary: [`src/utils/extraction.ts`](./src/utils/extraction.ts). **Zero LLM calls.**
 
-Primary implementation: `src/utils/extraction.ts`
+Deterministically pulls: modified / read / deleted files, tool and bash-like
+errors, retry / resolution signals, explicit & implicit decisions, constraints
+and preferences, heuristic topic segments, timeline events, the main goal, and
+open loops. **This is the ground truth** that synthesis and verification trust.
 
-This phase is deterministic and uses **zero LLM calls**.
+### Explore
 
-It extracts:
+Primary: [`src/phases/explore.ts`](./src/phases/explore.ts). Optional — runs only
+when the session looks complex (gated by `shouldExplore`). The model inspects
+the conversation through a small toolset: message ranges, conversation search,
+recent user messages, local context around an index, file-change lookups, and
+error chains. Tool support is runtime-probed once and cached per run; if a
+provider has no function calling, the system falls back to a direct structured
+analysis path.
 
-- modified files
-- read files
-- deleted files
-- tool and bash-like errors
-- retry / resolution signals
-- explicit and implicit decisions
-- constraints and preferences
-- heuristic topic segments
-- timeline events
-- main goal
-- open loops
+### Synthesize
 
-This phase provides the ground truth used later by synthesis and verification.
+Primary: [`src/phases/synthesize.ts`](./src/phases/synthesize.ts). Two modes:
 
-## 4. Explore
+- **Single-pass** — when the compacted conversation fits under the configured threshold.
+- **Hierarchical** — for larger sessions: merge heuristic + exploratory boundaries → chunk → batch by token budget → summarize batches → assemble.
 
-Primary implementation: `src/phases/explore.ts`
+Behaviors: session-aware prompting, decision propagation across later batches,
+provider-aware output limits and concurrency (wave scheduling), and a
+deterministic fallback assembly when LLM assembly fails.
 
-Exploration is optional. It runs only when the session appears complex enough.
+### Verify
 
-If it runs, the model can inspect the conversation through a small toolset such as:
+Primary: [`src/phases/verify.ts`](./src/phases/verify.ts). Scores the summary
+against the deterministic extraction. It checks for missing modified files,
+missing unresolved errors, missing high-confidence constraints, weak goal
+coverage, missing structure sections, suspicious fabricated file references,
+done/unresolved inconsistencies, missing explicit decisions, and missing
+open-loop coverage.
 
-- message ranges
-- conversation search
-- recent user messages
-- local context around a message
-- file-change lookups
-- error chains
+**Repair order is intentional:** (1) accept if good enough → (2) deterministic
+patch first (free, idempotent) → (3) LLM patch only if still insufficient.
 
-If tool support is unavailable, the system falls back to a direct structured analysis path.
+## State, caching & persistence
 
-## 5. Synthesize
+Post-verification, `app/steps/state.ts` + `src/utils/state.ts` enrich the
+summary, and `app/steps/persist.ts` applies the compaction and persists
+reusable state.
 
-Primary implementation: `src/phases/synthesize.ts`
+| Concern | Where | Notes |
+| --- | --- | --- |
+| Open-loop injection | `utils/state.ts` | inserted before Next Steps via the canonical parser |
+| `CompactionState` | `utils/state.ts` | machine-readable, reused across compactions |
+| Cross-compaction delta | `utils/state.ts` | "Changes Since Last Compaction" section |
+| Incremental extraction cache | `utils/cache.ts` + `utils/id-fingerprint.ts` | SHA-256 prefix fingerprint + tail; safe only when the pruned prefix still matches |
+| Session-log recovery | `utils/session-log.ts` | streaming JSONL parse; bypasses pi-toolkit truncation by entry-id mapping |
+| Project fingerprint | `utils/fingerprint.ts` | language / framework / key dirs across sessions |
+| Damage detection | `utils/damage.ts` | best-effort post-compaction regression signals |
 
-Two synthesis modes exist:
+**Important TTLs:** pending in-memory compaction 5 min · exploration
+tool-support cache 30 min · extraction cache 1 h · compaction state 7 d.
 
-### Single-pass
-Used when the compacted conversation still fits under the configured single-pass threshold.
+## Concurrency & safety model
 
-### Hierarchical
-Used for larger sessions:
+The extension is built to run safely alongside other Pi sessions and other
+extensions.
 
-1. merge heuristic and exploratory boundaries
-2. create chunks
-3. batch chunks according to token budget
-4. summarize batches
-5. assemble a final summary
+### Pending-compaction slot
 
-Important behaviors:
+[`src/app/pending-slot.ts`](./src/app/pending-slot.ts) is an encapsulated,
+host-agnostic state cell (one producer, one consumer, single-threaded event
+loop). `consume()` returns a discriminated result:
 
-- session-aware prompting
-- decision propagation across later batches
-- provider-aware output limits and concurrency
-- deterministic fallback assembly when LLM assembly fails
+| `ConsumeResult.kind` | Meaning |
+| --- | --- |
+| `ok` | fresh payload for this session |
+| `empty` | nothing staged |
+| `expired` | older than the 5-minute TTL |
+| `mismatch` | staged by a **different** session (cross-session leak guard) |
 
-## 6. Verify
+Session identity comes from [`infra/session-identity.ts`](./src/infra/session-identity.ts):
+a real id when the host exposes one, otherwise a per-call unforgeable
+`unresolved:<uuid>` — two unresolved sessions can never collide.
 
-Primary implementation: `src/phases/verify.ts`
+### Cancellation & hard timeout
 
-Verification scores the summary against deterministic extraction data.
+Some providers ignore `AbortSignal`. The auto-trigger therefore uses a shared
+[`ExternalCancellation`](./src/app/run-smart-compact.ts) handle as a second line
+of defense: an outer `setTimeout` fires `abort()` and sets `timedOut`, and every
+side-effect gate in the orchestrator checks that flag before writing state or
+applying compaction. No `Promise.race` is needed — the shared flag drives the
+bailout, eliminating the race where the outer timer fired while the pipeline was
+mid-`applyCompaction`.
 
-It checks for things like:
+### Filesystem & concurrency
 
-- missing modified files
-- missing unresolved errors
-- missing high-confidence constraints
-- weak goal coverage
-- missing structure sections
-- suspicious fabricated file references
-- done/unresolved inconsistencies
-- missing explicit decisions
-- missing open-loop coverage
+All disk writes go through [`src/infra/fs.ts`](./src/infra/fs.ts): atomic
+temp-file + rename so a crash never leaves a half-truncated JSON, and a
+`mkdir`-based advisory lock around the append-only metrics log so concurrent
+sessions cannot interleave bytes. Per-run state lives on the
+[`services` container](#dependency-injection), not module singletons.
 
-Repair order is intentional:
+## Provider awareness
 
-1. accept if good enough
-2. deterministic patch first
-3. LLM patch only if still insufficient
+[`src/utils/tokens.ts`](./src/utils/tokens.ts) keeps a per-provider capability
+table (Anthropic, OpenAI, Google, DeepSeek, MiniMax, Xiaomi, Mistral, xAI, …)
+with unknowns falling back to a safe default + fuzzy alias matching. Each entry
+drives pipeline behavior:
 
-## 7. Post-processing and persistence
+| Capability | Drives |
+| --- | --- |
+| `maxOutputTokens` | caps synthesis / patch budgets |
+| `supportsTools` (`true \| false \| "probe"`) | exploration tool-call probing |
+| `concurrencyLimit` | batch synthesis wave scheduling |
+| `cacheStrategy` | prompt-cache retention per call |
+| `timeoutMultiplier` | auto-trigger hard-timeout headroom |
+| `singlePassTokenMultiplier` | single-pass vs chunked threshold |
+| `tokenRatioEstimate` | token estimation; refined by per-(provider,model) **EMA calibration** |
 
-After verification, `src/app/steps/state.ts` and `src/utils/state.ts` enrich the summary, and `src/app/steps/persist.ts` plus `runDamageDetection` apply the compaction and persist reusable state.
+## Dependency injection
 
-Post-processing includes:
+[`src/infra/services.ts`](./src/infra/services.ts) is a per-`runSmartCompact`
+service bag. The previous module-level singletons (metrics array, tool-support
+cache, token calibration, compact-session id) leaked state across sessions and
+across tests. Each run gets its own container:
 
-- open-loop extraction and injection
-- `CompactionState` construction
-- delta computation against previous compaction
-- changes-since-last-compaction injection
-- project fingerprint persistence
-- compaction state persistence
-- metrics logging
-- best-effort damage detection
+| Service | Role |
+| --- | --- |
+| `clock` | injectable wall clock (deterministic tests) |
+| `llm` | LLM client seam (production wraps with retry) |
+| `toolSupport` | provider tool-support cache (1 h TTL) |
+| `metrics` | bounded metrics sink |
+| `extractionCacheStats` | hit / miss counters |
+| `tokenCalibration` | per-(provider,model) EMA factors |
+| `compactSessionId` | per-run prompt-cache namespace |
 
-## Runtime state and artifacts
+## Layer responsibilities
 
-The extension writes data under `~/.pi/agent/`, including:
-
-- conversation backups
-- extraction cache
-- metrics logs
-- project fingerprints
-- compaction states
-- damage reports
-
-Important TTLs in the current design:
-
-- pending in-memory compaction: 5 minutes
-- exploration tool-support cache: 30 minutes
-- extraction cache: 1 hour
-- compaction state: 7 days
-
-## Key files
-
-The code is organized into five layers, each with a single responsibility:
+The code is organized into six layers, each with a single responsibility.
 
 ### Entry layer
 
@@ -201,103 +260,97 @@ The code is organized into five layers, each with a single responsibility:
 
 | File | Responsibility |
 | --- | --- |
-| `src/app/run-smart-compact.ts` | top-level pipeline orchestrator (was `src/core.ts`) |
-| `src/app/run-context.ts` | typed stage chain (`RcBase → Prepared → Windowed → … → Stated`) |
-| `src/app/pending-slot.ts` | encapsulated pending-compaction state cell (set/consume/clear/expire/mismatch) |
-| `src/app/explore-wrap.ts` | thin re-export shim that isolates the explore import for headless tests |
-| `src/app/steps/prepare.ts` | resolve config, auth, provider caps |
-| `src/app/steps/window.ts` | pick the prefix of messages to compact |
-| `src/app/steps/recover.ts` | recover full content for log-truncated messages |
-| `src/app/steps/tier.ts` | choose compaction tier (none/light/balanced/aggressive) |
-| `src/app/steps/extract.ts` | pruning + deterministic extraction with incremental cache |
-| `src/app/steps/synthesize.ts` | single-pass / EESV synthesis |
-| `src/app/steps/verify.ts` | structural verification + repair |
-| `src/app/steps/state.ts` | enrich summary with state machine + open loops |
-| `src/app/steps/persist.ts` | apply compaction, save fingerprint, persist state |
-| `src/app/steps/metrics.ts` | record success / failure metrics |
+| `app/run-smart-compact.ts` | top-level pipeline orchestrator |
+| `app/run-context.ts` | typed stage chain (`RcBase → … → StatedRc`) |
+| `app/pending-slot.ts` | encapsulated pending-compaction state cell |
+| `app/explore-wrap.ts` | thin re-export shim isolating the explore import for headless tests |
+| `app/steps/prepare.ts` | resolve config, auth, provider caps |
+| `app/steps/window.ts` | pick the prefix of messages to compact |
+| `app/steps/recover.ts` | recover full content for log-truncated messages |
+| `app/steps/tier.ts` | choose compaction tier (none / light / full) |
+| `app/steps/extract.ts` | pruning + deterministic extraction with incremental cache |
+| `app/steps/synthesize.ts` | single-pass / EESV synthesis |
+| `app/steps/verify.ts` | structural verification + repair |
+| `app/steps/state.ts` | enrich summary with state machine + open loops |
+| `app/steps/persist.ts` | apply compaction, save fingerprint, persist state |
+| `app/steps/metrics.ts` | record success / failure metrics |
 
 ### Domain layer (`src/domain/`)
 
-Pure semantics; no I/O, no async, no globals.
+Pure semantics — no I/O, no async, no globals.
 
 | File | Responsibility |
 | --- | --- |
-| `src/domain/summary-schema.ts` | canonical section list + heading regex |
-| `src/domain/summary-parse.ts` | parse/serialize summary into structured sections; section placement (`before`/`after`) |
+| `domain/summary-schema.ts` | canonical section kinds + heading classification |
+| `domain/summary-parse.ts` | parse/render summary into structured sections; placement (`before`/`after`) |
 
 ### Algorithm layer (`src/phases/`)
 
 | File | Responsibility |
 | --- | --- |
-| `src/phases/explore.ts` | targeted exploration with tool-call probing |
-| `src/phases/synthesize.ts` | chunking, single-pass compact, batch summarization, assembly |
-| `src/phases/verify.ts` | scoring, gap detection, summary patching |
+| `phases/explore.ts` | targeted exploration with tool-call probing |
+| `phases/synthesize.ts` | chunking, single-pass compact, batch summarization, assembly |
+| `phases/verify.ts` | scoring, gap detection, summary patching |
 
 ### Infrastructure layer (`src/infra/`)
 
-All external-world interaction (fs, time, network, services container).
+All external-world interaction.
 
 | File | Responsibility |
 | --- | --- |
-| `src/infra/fs.ts` | atomic writes, advisory locks |
-| `src/infra/paths.ts` | canonical cache/session/backup paths |
-| `src/infra/git.ts` | cached git-root discovery |
-| `src/infra/clock.ts` | injectable wall clock |
-| `src/infra/llm-client.ts` | LLM client seam (production wraps with retry) |
-| `src/infra/llm-retry.ts` | 429/5xx exponential backoff + jitter + Retry-After |
-| `src/infra/services.ts` | per-run services container (metrics, clock, llm, tool-support cache) |
-| `src/infra/session-identity.ts` | robust session-id resolution with opaque `unresolved:` fallback |
+| `infra/fs.ts` | atomic writes, advisory locks |
+| `infra/paths.ts` | canonical cache/session/backup paths |
+| `infra/git.ts` | cached git-root discovery |
+| `infra/clock.ts` | injectable wall clock |
+| `infra/llm-client.ts` | LLM client seam (production wraps with retry) |
+| `infra/llm-retry.ts` | 429/5xx exponential backoff + jitter + Retry-After |
+| `infra/services.ts` | per-run services container |
+| `infra/session-identity.ts` | robust session-id resolution with opaque `unresolved:` fallback |
 
 ### Utility layer (`src/utils/`)
 
 | File | Responsibility |
 | --- | --- |
-| `src/utils/extraction.ts` | deterministic fact extraction (files, errors, decisions) |
-| `src/utils/pruning.ts` | redundancy removal on the message list |
-| `src/utils/state.ts` | structured state, open loops, delta |
-| `src/utils/helpers.ts` | config, backups, batching, shared helpers |
-| `src/utils/cache.ts` | metrics log + extraction prefix cache |
-| `src/utils/fingerprint.ts` | project fingerprinting (language, framework, deps) |
-| `src/utils/damage.ts` | post-compaction regression signals |
-| `src/utils/id-fingerprint.ts` | compact SHA-256 fingerprint of entry-id arrays |
-| `src/utils/file-needles.ts` | path-suffix needles for error→file attribution |
-| `src/utils/file-ref-detect.ts` | fabricated file-reference detection (SemVer-rejecting) |
-| `src/utils/session-log.ts` | streaming JSONL parser for the Pi session log |
-| `src/utils/tokens.ts` | per-(provider,model) token estimation with EMA calibration |
-| `src/utils/type-guards.ts` | runtime validators for cross-version compatibility |
-| `src/utils/logger.ts` | stderr-prefixed log shim |
-| `src/utils/lru.ts` | small bounded LRU cache primitive |
+| `utils/extraction.ts` | deterministic fact extraction (files, errors, decisions) |
+| `utils/pruning.ts` | redundancy removal on the message list |
+| `utils/state.ts` | structured state, open loops, delta |
+| `utils/helpers.ts` | config, backups, batching, shared helpers |
+| `utils/cache.ts` | metrics log + extraction prefix cache + dashboards |
+| `utils/fingerprint.ts` | project fingerprinting (language, framework, deps) |
+| `utils/damage.ts` | post-compaction regression signals |
+| `utils/id-fingerprint.ts` | compact SHA-256 fingerprint of entry-id arrays |
+| `utils/file-needles.ts` | path-suffix needles for error→file attribution |
+| `utils/file-ref-detect.ts` | fabricated file-reference detection (SemVer-rejecting) |
+| `utils/session-log.ts` | streaming JSONL parser for the Pi session log |
+| `utils/tokens.ts` | per-(provider,model) token estimation with EMA calibration |
+| `utils/type-guards.ts` | runtime validators for cross-version compatibility |
+| `utils/logger.ts` | stderr-prefixed log shim |
+| `utils/lru.ts` | small bounded LRU cache primitive |
 
 ### UI layer (`src/ui/`)
 
 | File | Responsibility |
 | --- | --- |
-| `src/ui/overlays.ts` | model/profile pickers, progress, result, dashboard screens |
-| `src/ui/dashboard-format.ts` | pure formatters for the metrics dashboard |
+| `ui/overlays.ts` | model/profile pickers, progress, result, dashboard screens |
+| `ui/dashboard-format.ts` | pure formatters for the metrics dashboard |
 
-## Safety properties
+## Design principles
 
 The architecture intentionally biases toward safety:
 
-- deterministic extraction before summarization
+- deterministic extraction before any synthesis
 - adaptive exploration instead of always-on tool use
 - verified file lists and error context
 - deterministic repair before additional LLM calls
 - hallucinated file-reference detection
 - stateful tracking of open loops and cross-compaction deltas
-
-## Design constraints
-
-A few constraints shape the implementation:
-
-- tool-driven compaction must not compact the conversation mid-turn
-- summaries must preserve exact file paths and identifiers where possible
-- recent conversation tail should remain live outside the compacted region
-- docs should separate user-facing overview from maintainer-facing internals
+- tool-driven compaction never compacts mid-turn
+- summaries preserve exact file paths and identifiers where possible
+- the recent tail stays live outside the compacted region
 
 ## Extending the system
 
-When adding features, prefer this order of operations:
+When adding features, prefer this order:
 
 1. extract more deterministic signal if possible
 2. enrich exploration only when needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [7.16.0] - 2026-06-18
+
+### Added
+- **Pinned never-compact context** (`smartCompact.pinPaths`) — file paths that must always survive compaction regardless of what the LLM summary includes. Surfaced in the summary's Files Read via a deterministic, LLM-free `ensurePinnedPaths` step in `buildState`.
+- **Damage auto-remediation** — `detectDamage` now collects the files the agent re-reads after a compaction (`reReadFiles`), persists them as remediation hints, and the *next* compaction re-preserves them (merged with `pinPaths`) so lost context stops being lost twice. Closes the detect → remediate loop.
+- **`/smart-compact restore`** — list, view, and restore backups. `listBackups`/`readBackupContent` make the previously write-only backups browsable; `showRestorePicker` + `showRestoreAction` + `showBackupViewer` provide a TUI; and a true restore forks from the current leaf and re-injects the pre-compaction content as context via `sendMessage` (graceful fallback to view on any failure).
+- `asBranchMessage` / `asSerializableMessages` boundary adapters in `src/infra/ai-messages.ts`, documenting why each cross-package upcast is sound.
+
+### Fixed
+- **session-log timestamp** — `normalizeLogMessage` stamped `Date.now()` (the recovery wall-clock) gated on a nonsensical content-shape condition, and dropped `toolName`. Now parses the log entry's real timestamp and preserves `toolName`.
+- **`synthesize` empty-batch guard** — `batches[0]` could be dereferenced when the chunk list was empty; now guarded with a deterministic fallback.
+- **`backupDir` config validation** — the one config key without type validation now rejects non-string values.
+- **result-screen timer** — the `setTimeout` used in the result-screen `Promise.race` is now cleared in a `finally` instead of lingering up to 5s.
+- **negative exploration boundary clamp** — `normalizeBoundaries` now lower-clamps `afterIndex` to 0 (LLMs occasionally emit negative values) and guards `confidence` against non-numeric values.
+- **`computeToolCharPercentage` dead branch** — removed the unreachable `block.content` path (text blocks carry `.text`).
+- **`ctx.ui.notify` invalid type** — restore used `"success"`, which `ctx.ui.notify` does not accept; corrected to `"info"`.
+- **state.ts basename recompute** — the per-error file-attribution basename is now precomputed once instead of recomputed for every (error × file) pair.
+
+### Changed
+- **Message cast normalization** — the explore feedback loop now builds native `Message[]` (assistant turns are the real `AssistantMessage` from `trackedComplete`, no longer downcast to `LlmMessage`); `recover`/`persist`/`extract` route through the documented `asBranchMessage`/`asSerializableMessages` adapters. Removes the lossy `as unknown as Message[]` casts and the silent dropping of `usage`/`api`/`provider`/`model`/`stopReason`.
+- **Tools cast normalization** — `EXPLORATION_TOOLS` is now declared as native `Tool[]` using typebox schemas, removing both `as unknown as Parameters<...>["tools"]` casts. Behavior-preserving: every pi-ai provider only serializes the schema, so real typebox schemas are wire-identical to the previous plain JSON-schema objects.
+- `failedChunkSummary` co-located with `assembleFallback` in `phases/synthesize.ts` and exported (was an untested module-private in the step module).
+- `buildExplorationReportFromParsed` parameter narrowed `any` → `unknown` with proper field validation.
+
+### Build
+- **pi runtime peers resolved 0.79.4 → 0.79.6** and **typebox 1.2.11 → 1.2.16** in the lockfile. `peerDependencies`/`devDependencies` keep their `*` wildcard ranges per the forward-compatibility policy from 7.15.0.
+
+### Tests
+- **+79 tests (414 → 493):** type-guards validators (`isValidSmartCompactDetails`/`sanitizeSmartCompactDetails`), synthesize fallback contracts (`assembleFallback`/`failedChunkSummary`), `ai-messages` adapters, pinned-paths injection, remediation-hints round-trip, backup restore (list/read/build-restore-message), and exploration boundary normalization (negative clamp, confidence guard, non-string mainGoal).
+
+### Docs
+- README, ARCHITECTURE, CONTRIBUTING, SECURITY, SUPPORT, RELEASE, and CODE_OF_CONDUCT redesigned; new `docs/assets/banner.svg` hero. CONTRIBUTING drift fixed (`core.ts`/`DEVPLAN.md`/`ROADMAP.md` references removed; repo map updated to the layered architecture).
+
 ## [7.15.1] - 2026-06-15
 
 ### Fixed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,14 +1,21 @@
 # Code of Conduct
 
-This project follows a simple standard: be respectful, constructive, and focused on improving the software.
+This project follows a simple standard: be respectful, constructive, and
+focused on improving the software.
 
-Expected behavior:
+## Expected behavior
 
 - Use welcoming and inclusive language.
 - Assume good intent when reviewing issues and pull requests.
 - Critique ideas and code, not people.
 - Respect privacy; do not post secrets, private session logs, or confidential project data.
 
-Unacceptable behavior includes harassment, personal attacks, doxxing, deliberate disruption, or sharing private information without permission.
+## Unacceptable behavior
 
-Maintainers may edit, hide, or remove comments and may block participants who repeatedly violate these expectations.
+Harassment, personal attacks, doxxing, deliberate disruption, or sharing private
+information without permission.
+
+## Enforcement
+
+Maintainers may edit, hide, or remove comments and may block participants who
+repeatedly violate these expectations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,60 +2,70 @@
 
 Thanks for contributing to `pi-smart-compact`.
 
-This project sits on the boundary between product UX, LLM orchestration, and deterministic safety checks. Good contributions keep all three in balance.
+This project sits on the boundary between product UX, LLM orchestration, and
+deterministic safety checks. Good contributions keep all three in balance.
 
 ## Project principles
 
 When making changes, prefer these priorities:
 
 1. **Deterministic facts before LLM inference**
-   - If something can be extracted, validated, or repaired without an LLM call, prefer that path.
+   If something can be extracted, validated, or repaired without an LLM call, prefer that path.
 2. **Preserve agent working state**
-   - The package exists to preserve goals, files, decisions, errors, constraints, and follow-up loops.
+   The package exists to preserve goals, files, decisions, errors, constraints, and follow-up loops.
 3. **Keep README user-facing**
-   - Put deep implementation detail in `ARCHITECTURE.md` or code comments, not `README.md`.
+   Put deep implementation detail in `ARCHITECTURE.md` or code comments, not `README.md`.
 4. **Minimize documentation drift**
-   - If behavior or metadata changes, update docs in the same change.
-5. **Do not edit generated output manually**
-   - `dist/` is build output.
+   If behavior or metadata changes, update docs in the same change.
+5. **Never hand-edit generated output**
+   `dist/` is build output; rebuild from `src/`.
 
 ## Local setup
 
 ```bash
 bun install
-```
-
-## Common commands
-
-```bash
 bun test
-bun run build
 bun run typecheck
+bun run build
 ```
+
+The CI `verify` job runs `typecheck → test → build` on every pull request.
 
 ## Repository map
 
+The codebase is a layered architecture (see [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+for the full responsibility breakdown):
+
 ```text
 src/
-  index.ts            extension entrypoint
-  core.ts             end-to-end pipeline orchestration
-  phases/             explore / synthesize / verify
-  utils/              extraction, state, tokens, cache, helpers, etc.
-  ui/                 compact UI overlays and result screens
+  index.ts            extension entrypoint (command + hook + tool registration)
+  constants.ts        version, thresholds, prompts, config keys
+  types.ts            shared types and discriminated unions
+  app/                orchestration layer
+    run-smart-compact.ts   pipeline orchestrator
+    run-context.ts         typed stage chain (state machine)
+    pending-slot.ts        pending-compaction state cell
+    steps/                 10 stage modules (prepare … metrics)
+  domain/             pure semantics, no I/O (summary schema + parse)
+  phases/             algorithms (explore / synthesize / verify)
+  infra/              external-world interaction (fs, git, services, llm, …)
+  ui/                 TUI overlays + dashboard
+  utils/              focused helpers (extraction, state, tokens, cache, …)
 
 test/                 unit and regression tests
+docs/                 release checklist + assets
 ```
 
 ## Development workflow
 
 ### 1. Make changes in `src/`
-Never patch `dist/` by hand. Build output is generated from source.
+Never patch `dist/` by hand — it is generated from source.
 
 ### 2. Keep version metadata synchronized
-If a release-worthy change affects published behavior, sync:
+A release-worthy change should keep these in step:
 
 - `package.json`
-- `src/constants.ts`
+- `src/constants.ts` (`VERSION`, rewritten by `scripts/sync-version.ts` at build time)
 - `CHANGELOG.md`
 
 ### 3. Keep docs aligned
@@ -67,11 +77,8 @@ Depending on the change, update the relevant docs:
 - `SECURITY.md` — vulnerability reporting and sensitive-data guidance
 - `SUPPORT.md` — support routing
 - `docs/RELEASE.md` — release checklist
-- `DEVPLAN.md` — archival implementation plan only
-- `ROADMAP.md` — current forward-looking priorities
 
 ### 4. Run validation before shipping
-Minimum expectation:
 
 ```bash
 bun run typecheck
@@ -79,11 +86,9 @@ bun test
 bun run build
 ```
 
-The `verify` GitHub Actions check runs the same validation for pull requests.
-
 ## Testing guidance
 
-When touching specific areas, make sure nearby tests still tell a coherent story:
+When touching specific areas, keep nearby tests telling a coherent story:
 
 - extraction logic → `test/extraction.test.ts`
 - exploration heuristics / parsing → `test/exploration.test.ts`
@@ -92,13 +97,16 @@ When touching specific areas, make sure nearby tests still tell a coherent story
 - state / delta / open loops → `test/state.test.ts`
 - token logic / provider caps → `test/tokens.test.ts`
 - incremental cache merge behavior → `test/cache.test.ts`
+- the typed stage chain / lifecycle → `test/stage-machine.test.ts`
+- pending-slot lifecycle / cross-session guard → `test/pending-slot.test.ts`
 
-If you change summary structure, verification rules, or state persistence, add or update tests.
+If you change summary structure, verification rules, or state persistence, add
+or update tests.
 
 ## Documentation standards
 
 - Prefer durable wording over volatile repo snapshots.
-- Avoid hardcoding temporary counts like line counts, module counts, or passing-test totals in `README.md`.
+- Avoid hardcoding temporary counts (line counts, module counts, passing-test totals) in `README.md`.
 - If you reference a release number, make sure it matches current metadata.
 - Keep examples realistic and consistent with current config keys (`smartCompact`, not only legacy aliases).
 
@@ -106,16 +114,19 @@ If you change summary structure, verification rules, or state persistence, add o
 
 Before a release:
 
-1. sync `package.json` and `src/constants.ts`
+1. sync `package.json` and `src/constants.ts` (`bun run sync-version`)
 2. update `CHANGELOG.md`
 3. rebuild `dist/`
-4. run tests
-5. run typecheck
-6. spot-check `README.md` for drift
+4. run tests + typecheck
+5. spot-check `README.md` for drift
+
+See [`docs/RELEASE.md`](./docs/RELEASE.md) for the full checklist.
 
 ## Security and privacy
 
-Do not include secrets, private session logs, proprietary source, or unredacted tool output in issues, pull requests, tests, or screenshots. Use GitHub Security Advisories for vulnerabilities; see `SECURITY.md`.
+Do not include secrets, private session logs, proprietary source, or unredacted
+tool output in issues, pull requests, tests, or screenshots. Use GitHub Security
+Advisories for vulnerabilities; see [`SECURITY.md`](./SECURITY.md).
 
 ## Pull request expectations
 

--- a/README.md
+++ b/README.md
@@ -1,395 +1,271 @@
-# pi-smart-compact
+<div align="center">
 
-[CI](https://github.com/alpertarhan/pi-smart-compact/actions/workflows/ci.yml) · [npm](https://www.npmjs.com/package/pi-smart-compact) · [MIT License](./LICENSE) · [Pi extension](https://github.com/earendil-works/pi)
+<img src="./docs/assets/banner.svg" alt="pi-smart-compact" width="860" />
 
-<p align="center">
-  <img src="./docs/assets/pi-smart-compact.png" alt="pi-smart-compact" width="420" />
-</p>
+[![CI](https://github.com/alpertarhan/pi-smart-compact/actions/workflows/ci.yml/badge.svg)](https://github.com/alpertarhan/pi-smart-compact/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/pi-smart-compact?color=60a5fa)](https://www.npmjs.com/package/pi-smart-compact)
+[![license](https://img.shields.io/npm/l/pi-smart-compact?color=22c55e)](./LICENSE)
+[![Pi extension](https://img.shields.io/badge/Pi-extension-fbbf24)](https://github.com/earendil-works/pi)
 
-> Verification-oriented smart compaction for the [Pi Coding Agent](https://github.com/earendil-works/pi-coding-agent).
+**Verification-oriented smart compaction for the [Pi Coding Agent](https://github.com/earendil-works/pi-coding-agent).**
 
-`pi-smart-compact` replaces blind conversation trimming with a structured compaction pipeline that tries to preserve what an agent actually needs to continue working: the goal, modified files, unresolved errors, decisions, constraints, and open follow-up loops.
+</div>
 
-It uses an **EESV** pipeline:
+Default compaction trims your conversation blind. `pi-smart-compact` keeps what
+the agent actually needs to continue — the **goal, changed files, unresolved
+errors, decisions, constraints, and open loops** — through a verified
+**Extract → Explore → Synthesize → Verify** pipeline.
 
-**Extract → Explore → Synthesize → Verify**
-
-## Highlights
-
-- **Pi-native integration** — `/smart-compact`, `smart_compact`, and `session_before_compact` support.
-- **Verification-oriented output** — deterministic extraction and repair before trusting LLM synthesis.
-- **Adaptive cost profile** — skips unnecessary work on small sessions and uses chunking only when useful.
-- **Operational safety** — pending summaries expire, backups are available, and metrics make regressions visible.
-- **Companion-friendly** — designed to coexist with context hygiene tools such as `pi-toolkit`.
-
-Under the hood, the design is grounded in two core ideas:
-
-- **agentic compaction**: let the system inspect and reason about the session instead of collapsing everything into generic prose
-- **Kamradt-style chunking**: break large conversations into more coherent segments before synthesis
+> Facts first, synthesis second, verification last.
 
 ---
 
-## What this project is
+## Why
 
-This package is a **Pi extension** with three integration surfaces:
+Default compaction produces a vague recap and quietly drops the operational
+context that matters most during coding. The result is the classic
+*"didn't we already fix this?"* loop.
 
-| Surface | Purpose |
+| Default compaction | `pi-smart-compact` |
 | --- | --- |
-| `/smart-compact` | manual compaction from the chat UI |
-| `session_before_compact` | auto-run before Pi's default compaction |
-| `smart_compact` tool | agent-callable compaction for long sessions |
+| Trims by token count | Extracts facts deterministically (zero LLM) |
+| Generic prose recap | Structured working-state summary |
+| Loses files / errors / decisions | Preserves them, then **verifies** they survived |
+| No regression signal | Damage detection + metrics dashboard |
 
-The extension stages a short-lived pending summary in memory, then hands it back to Pi when compaction is applied.
-
----
-
-## Project status
-
-This is an actively maintained Pi extension. The public API is intentionally small, but the internals are still evolving as Pi's compaction lifecycle and extension APIs mature. Pin versions in production workflows if compaction behavior is mission-critical.
-
-## Compatibility note
-
-`pi-smart-compact` sits close to Pi's compaction path: it registers `session_before_compact`, reads the active branch and session log, stages a pending summary, and may call Pi's native compaction flow from `/smart-compact`.
-
-Because of that, use extra care with extensions that also manipulate:
-
-- **compaction hooks** — especially extensions that return a custom result from `session_before_compact`
-- **session / branch history** — rewriting, pruning, reordering, or replacing entries before compaction
-- **message identity** — removing entry IDs, tool-call IDs, or tool-result metadata used to align log entries
-- **tool output content** — truncating or rewriting `toolResult` messages before extraction
-- **compaction boundaries** — moving the keep/discard split or splitting `toolCall` / `toolResult` pairs
-- **session log storage** — replacing or deleting Pi's `.jsonl` logs under `~/.pi/agent/sessions`
-
-It is intentionally compatible with, and recommended alongside, [`pi-toolkit`](https://github.com/ersintarhan/pi-toolkit): pi-toolkit handles everyday context hygiene such as anchors, pivots, status lines, and old tool-output trimming; `pi-smart-compact` handles high-pressure verified compaction. The integration protects recent pi-toolkit anchors and can recover original tool outputs from the session log when older tool results were trimmed.
-
-If you use another automatic compaction or context-rewriting extension, prefer enabling only one `session_before_compact` owner unless the hook order and returned values are explicitly coordinated.
-
----
-
-## Why it exists
-
-Default compaction often loses the parts that matter most during coding work:
-
-- which files were actually changed
-- which errors are still unresolved
-- what the user explicitly asked for
-- what decisions already won
-- what should happen next
-
-`pi-smart-compact` is built to preserve that operational context instead of producing a vague recap.
-
----
-
-## How it works
-
-```mermaid
-flowchart LR
-    A[Extract<br/>deterministic facts] --> B[Explore<br/>optional targeted analysis]
-    B --> C[Synthesize<br/>single-pass or chunked summary]
-    C --> D[Verify<br/>score gaps and repair]
-    D --> E[Return smart compaction to Pi]
-```
-
-### Pipeline summary
-
-1. **Extract**
-   - deterministically pulls files, errors, decisions, constraints, topics, and open loops from the session
-2. **Explore**
-   - optionally inspects the conversation more deeply when the session is complex
-3. **Synthesize**
-   - creates either a single-pass summary or a chunked hierarchical summary
-4. **Verify**
-   - checks the result against extracted facts and patches missing critical details
-
-In short: **facts first, synthesis second, verification last**.
-
----
-
-## What it tries to preserve
-
-- user goal
-- constraints and preferences
-- modified / read / deleted files
-- unresolved and resolved errors
-- key decisions
-- open follow-up work
-- critical context needed for the next turn
-- delta from the previous compaction
-
----
-
-## Installation
-
-### npm / Pi package
+## Install
 
 ```bash
 pi install npm:pi-smart-compact
 ```
 
-### GitHub
+From GitHub:
 
 ```bash
 pi install git:github.com/alpertarhan/pi-smart-compact
 ```
 
-### Local development
-
-```bash
-cd ~/.pi/agent/extensions
-git clone https://github.com/alpertarhan/pi-smart-compact.git
-cd pi-smart-compact
-bun install
-bun run build
-```
-
----
-
 ## Quick start
 
-### Interactive
-
 ```bash
-/smart-compact
-```
-
-With no arguments, the extension opens a small picker for:
-
-1. model
-2. profile
-
-### Direct command examples
-
-```bash
+/smart-compact                              # interactive — pick model + profile
 /smart-compact anthropic/claude-sonnet-4 balanced
-/smart-compact dry-run
-/smart-compact debug
-/smart-compact metrics
-/smart-compact dashboard
-/smart-compact "focus on auth changes and unresolved follow-up work"
+/smart-compact "focus on auth + unresolved follow-ups"
+/smart-compact metrics                      # profile / provider comparison
+/smart-compact dashboard                    # interactive TUI dashboard
 ```
 
-### Tool usage
+Or let the agent call it as a tool on long sessions:
 
-```json
+```jsonc
 {
   "name": "smart_compact",
-  "parameters": {
-    "profile": "balanced",
-    "verbose": false,
-    "dry_run": false,
-    "report": false,
-    "dashboard": false
-  }
+  "parameters": { "profile": "balanced", "dashboard": false }
 }
 ```
 
-The tool prepares a pending smart summary and lets Pi consume it on the next natural compaction.
+Auto-compaction also runs before Pi's native compact once context pressure
+crosses your threshold (default 60% **actual** context usage).
 
----
+## How it works
 
-## Usage notes
+```mermaid
+flowchart LR
+    A["Extract<br/>deterministic facts<br/><i>0 LLM calls</i>"] --> B["Explore<br/>optional deep<br/>analysis"]
+    B --> C["Synthesize<br/>single-pass or<br/>chunked summary"]
+    C --> D["Verify<br/>score gaps,<br/>repair"]
+    D --> E["Return verified<br/>summary to Pi"]
+```
 
-- auto/tool compaction is skipped when the context is still small enough (default: below 60% actual context usage)
-- explicit manual `/smart-compact` commands bypass the 60% adaptive gate because the user intentionally requested compaction
-- pi-toolkit `tool=XX%` status means tool-output ratio, **not** context fullness; smart-compact uses actual `context=XX%`
-- the tool path does **not** compact the conversation mid-turn
-- pending summaries are kept in memory for **5 minutes**
-- exploration is adaptive and may be skipped for simple sessions
-- use `/smart-compact metrics` for profile/provider comparisons
-- use `/smart-compact dashboard` to open the interactive TUI dashboard (overview, latest run, current session, recent runs, or write HTML)
+| Stage | What it does |
+| --- | --- |
+| **Extract** | Deterministically pulls files, errors, decisions, constraints, topics, and open loops — no LLM, the ground truth. |
+| **Explore** | Optionally inspects the conversation more deeply when the session is complex. |
+| **Synthesize** | Single-pass for short sessions, Kamradt-style chunked + assembled for long ones. |
+| **Verify** | Scores the result against extracted facts and patches missing critical details. |
 
-This keeps the extension helpful without forcing extra work when it is not needed.
+**What it preserves:** user goal · constraints & preferences · modified / read /
+deleted files · unresolved & resolved errors · key decisions · open follow-up
+work · critical next-turn context · the delta since the previous compaction.
 
----
+## Integration surfaces
+
+| Surface | When | Detail |
+| --- | --- | --- |
+| `/smart-compact` | Manual | Interactive picker or direct args; bypasses the adaptive gate. |
+| `session_before_compact` | Auto | Runs before Pi's native compaction when context pressure is high. |
+| `smart_compact` tool | Agent | Prepares a pending summary; Pi applies it on the next natural compact. |
+
+A short-lived pending summary is staged in memory (5-minute TTL) and handed to
+Pi when compaction is applied.
+
+## Example output
+
+A generated summary follows a stable, structured contract:
+
+```markdown
+## Goal
+Add retry/backoff to the LLM client so transient 429/5xx don't abort compaction.
+
+## Constraints & Preferences
+- [requirement] never compact mid-turn from the tool path
+
+## Progress
+### Done
+- [x] Added `withRetry` wrapper in src/infra/llm-retry.ts
+### In Progress
+- [ ] Wire retry client into the services container
+### Blocked
+- None
+
+## Key Decisions
+- **Honor Retry-After verbatim**: providers that set it know their limits best.
+
+## Files Modified
+- src/infra/llm-retry.ts
+- src/infra/llm-client.ts
+
+## Files Read
+- src/app/run-smart-compact.ts
+
+## Open Loops
+- [high] Retried but unresolved: AbortSignal ignored by some providers
+
+## Changes Since Last Compaction
+- New files touched: src/infra/llm-retry.ts
+- New loops: AbortSignal ignored by some providers
+
+## Next Steps
+1. Add an outer hard-timeout as a second line of defense
+
+## Critical Context
+- 408/425/429/5xx are retriable; 4xx (other) fails fast
+
+## Topics Covered
+- LLM retry wrapper (high)
+```
+
+A machine-readable `CompactionState` is built alongside it for reuse across
+later compactions (delta tracking, damage detection).
 
 ## Configuration
 
-Add this to `~/.pi/agent/settings.json`:
+Add to `~/.pi/agent/settings.json`:
 
 ```json
 {
   "smartCompact": {
     "profile": "balanced",
     "summaryModel": "anthropic/claude-sonnet-4",
-    "segmentationModel": "anthropic/claude-haiku-3",
     "autoTrigger": true,
-    "autoTriggerTimeoutMs": 120000,
     "minContextPercent": 60,
-    "backupEnabled": true,
-    "profiles": {
-      "balanced": {
-        "summaryBudgetTokens": 6000,
-        "keepRecentTokens": 20000
-      }
-    }
+    "backupEnabled": true
   }
 }
 ```
 
-### Supported keys
-
 | Key | Type | Default |
 | --- | --- | --- |
 | `profile` | `light \| balanced \| aggressive` | `balanced` |
-| `summaryModel` | `string \| null` | `null` |
+| `summaryModel` | `string \| null` | `null` (uses session model) |
 | `segmentationModel` | `string \| null` | `null` |
 | `autoTrigger` | `boolean` | `true` |
 | `autoTriggerTimeoutMs` | `number` | `120000` |
 | `minContextPercent` | `number` | `60` |
 | `backupEnabled` | `boolean` | `true` |
 | `backupDir` | `string` | `~/.pi/agent/compact-backups` |
-| `profiles` | partial per-profile overrides | built-ins |
+| `profiles` | per-profile overrides | built-ins |
 
 ### Profiles
 
-| Profile | Summary budget | Keep recent | Typical use |
+| Profile | Summary budget | Keep recent | Use when |
 | --- | ---: | ---: | --- |
 | `light` | 10000 | 30000 | preserve more detail |
-| `balanced` | 6000 | 20000 | default general use |
+| `balanced` | 6000 | 20000 | default, general use |
 | `aggressive` | 3000 | 10000 | tighter summaries |
 
-### Backward compatibility
-
-The extension still accepts the old config key `semanticCompact`, but `smartCompact` is the current key.
-
----
-
-## Output contract
-
-Generated summaries are expected to use this structure:
-
-```markdown
-## Goal
-## Constraints & Preferences
-## Progress
-### Done
-### In Progress
-### Blocked
-## Key Decisions
-## Files Modified
-## Files Read
-## Open Loops
-## Changes Since Last Compaction
-## Next Steps
-## Critical Context
-## Topics Covered
-```
-
-The extension also builds a structured `CompactionState` for reuse across later compactions.
-
----
+The legacy config key `semanticCompact` is still accepted.
 
 ## Safeguards
 
-The current design includes:
+**Correctness**
 
-- deterministic extraction before summarization
-- adaptive exploration
-- chunked synthesis for larger sessions
-- deterministic verification scoring
-- deterministic patching before LLM patching
-- hallucinated file-reference detection
-- open-loop injection
-- project fingerprinting and delta tracking
-- provider-specific timeout and single-pass strategies
-- multimodal attachment metadata preservation
-- backup creation before compaction
-- metrics logging, profile/provider comparison, and damage detection
+- Deterministic extraction before any synthesis
+- Verification scoring with deterministic patching **before** LLM patching
+- Hallucinated file-reference detection (SemVer-aware)
+- Open-loop injection + cross-compaction delta tracking
 
----
+**Safety**
+
+- Conversation backups before compaction (retention-pruned)
+- `toolCall` / `toolResult` pair integrity at the compaction boundary
+- Cross-session leak guard on the pending summary
+- Session-log recovery that bypasses truncation of older tool results
+
+**Observability**
+
+- Metrics logging with profile / provider comparison
+- Post-compaction damage (regression) detection
+- Interactive TUI + HTML dashboards
+
+## Usage notes
+
+- Auto / tool compaction is skipped while context is small (below 60% actual usage).
+- Manual `/smart-compact` bypasses that gate — you asked for it.
+- `pi-toolkit`'s `tool=XX%` means tool-output ratio, **not** context fullness;
+  smart-compact uses actual `context=XX%`.
+- The tool path does **not** compact mid-turn (it stages a pending summary).
+- Exploration is adaptive and may be skipped for simple sessions.
+
+## Companions & compatibility
+
+`pi-smart-compact` is designed to coexist with — and recommended alongside —
+[`pi-toolkit`](https://github.com/ersintarhan/pi-toolkit). pi-toolkit handles
+everyday context hygiene (anchors, pivots, status lines, old tool-output
+trimming); smart-compact handles high-pressure verified compaction. The
+integration protects recent pi-toolkit anchors and recovers original tool
+outputs from the session log.
+
+Because smart-compact sits close to Pi's compaction path, take extra care with
+extensions that also rewrite compaction hooks, branch history, entry IDs, tool
+output, or the compaction boundary. If you run another automatic compaction /
+context-rewriting extension, prefer a single `session_before_compact` owner
+unless hook order is explicitly coordinated.
 
 ## Runtime artifacts
 
-At runtime, the extension writes to paths under `~/.pi/agent/`, including:
+The extension writes under `~/.pi/agent/`:
 
-- `settings.json`
-- `compact-backups/`
-- `.cache/compact-extraction-<session>.json`
-- `.cache/compact-metrics.jsonl`
-- `.cache/smart-compact-report.html`
-- `.cache/smart-compact/projects/<projectId>.json`
-- `.cache/smart-compact/states/<projectId>.json`
-- `.cache/smart-compact/damage-reports.jsonl`
-
----
-
-## Repository layout
-
-```text
-.
-├── src/
-│   ├── index.ts              # extension registration + command routing
-│   ├── constants.ts          # version, thresholds, prompts
-│   ├── types.ts              # shared types
-│   ├── app/                  # orchestration layer
-│   │   ├── run-smart-compact.ts   # pipeline orchestrator (was core.ts)
-│   │   ├── run-context.ts         # typed stage chain
-│   │   ├── pending-slot.ts        # encapsulated pending-compaction state cell
-│   │   ├── explore-wrap.ts        # explore re-export shim
-│   │   └── steps/                 # 10 stage modules
-│   │       ├── prepare.ts   →   resolves config + auth
-│   │       ├── window.ts    →   picks compaction window
-│   │       ├── recover.ts   →   recovers truncated messages
-│   │       ├── tier.ts      →   chooses compaction tier
-│   │       ├── extract.ts   →   pruning + extraction + cache
-│   │       ├── synthesize.ts→   single-pass / EESV summarization
-│   │       ├── verify.ts    →   structural verify + repair
-│   │       ├── state.ts     →   state machine + open loops
-│   │       ├── persist.ts   →   apply compaction
-│   │       └── metrics.ts   →   success / failure metrics
-│   ├── domain/               # pure semantics (no I/O)
-│   │   ├── summary-schema.ts
-│   │   └── summary-parse.ts
-│   ├── phases/               # algorithms
-│   │   ├── explore.ts
-│   │   ├── synthesize.ts
-│   │   └── verify.ts
-│   ├── infra/                # external-world interaction
-│   │   ├── fs.ts                # atomic writes, advisory locks
-│   │   ├── paths.ts             # canonical paths
-│   │   ├── git.ts               # git-root discovery (cached)
-│   │   ├── clock.ts             # injectable clock
-│   │   ├── llm-client.ts        # LLM client seam
-│   │   ├── llm-retry.ts         # 429/5xx backoff
-│   │   ├── services.ts          # per-run services container
-│   │   └── session-identity.ts # robust session-id resolution
-│   ├── ui/                   # TUI overlays + dashboard
-│   │   ├── overlays.ts
-│   │   └── dashboard-format.ts
-│   └── utils/                # 15 focused utility modules
-├── test/                     # 414 tests across 36 files
-├── docs/
-├── dist/
-└── package.json
-```
-
-See `ARCHITECTURE.md` for the full responsibility breakdown of each layer.
-
----
+| Path | Purpose |
+| --- | --- |
+| `settings.json` | configuration (read) |
+| `compact-backups/` | conversation backups (retention-pruned) |
+| `.cache/compact-extraction-<session>.json` | incremental extraction cache |
+| `.cache/compact-metrics.jsonl` | metrics log |
+| `.cache/smart-compact-report.html` | HTML dashboard |
+| `.cache/smart-compact/projects/<projectId>.json` | project fingerprint |
+| `.cache/smart-compact/states/<projectId>.json` | reusable compaction state |
+| `.cache/smart-compact/damage-reports.jsonl` | regression signals |
 
 ## Development
 
 ```bash
 bun install
-bun test
-bun run build
-bun run typecheck
+bun run typecheck   # tsc --noEmit
+bun test            # full test suite
+bun run build       # dist/ output for publishing
 ```
 
-Build output is published from `dist/`. Pull requests are expected to pass the same verification in GitHub Actions before merge.
+Pull requests run the same verification in GitHub Actions before merge.
 
----
+## Documentation
 
-## Project docs
-
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — system design, execution model, layer responsibilities
 - [`CHANGELOG.md`](./CHANGELOG.md) — release history
-- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — system design and execution model
 - [`CONTRIBUTING.md`](./CONTRIBUTING.md) — contributor workflow and expectations
 - [`SECURITY.md`](./SECURITY.md) — vulnerability reporting and data-handling notes
 - [`SUPPORT.md`](./SUPPORT.md) — where to ask for help
 - [`docs/RELEASE.md`](./docs/RELEASE.md) — release checklist
-
----
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,15 @@
 
 Security fixes target the latest published version of `pi-smart-compact`.
 
+| Version | Supported |
+| --- | --- |
+| Latest `7.x` | ✅ |
+| Older | ❌ |
+
 ## Reporting a vulnerability
 
-Please do **not** open a public issue for vulnerabilities, leaked secrets, or private-session data exposure.
+Please do **not** open a public issue for vulnerabilities, leaked secrets, or
+private-session data exposure.
 
 Report privately through GitHub Security Advisories:
 
@@ -14,15 +20,18 @@ Report privately through GitHub Security Advisories:
 
 If advisories are unavailable, contact the maintainer listed in `package.json`.
 
-## Data handling notes
+## Data handling
 
-`pi-smart-compact` processes Pi session content to produce compaction summaries. Depending on your session, this may include repository paths, command output, tool results, and user-provided context.
+`pi-smart-compact` processes Pi session content to produce compaction summaries.
+Depending on the session, this may include repository paths, command output,
+tool results, and user-provided context.
 
 Operational guidance:
 
 - Do not paste secrets into sessions you plan to compact.
 - Redact private logs before attaching them to issues.
 - Treat generated compaction summaries as potentially sensitive project context.
-- Review provider/model configuration before enabling auto-triggered compaction.
+- Review provider / model configuration before enabling auto-triggered compaction.
 
-Runtime artifacts are written under `~/.pi/agent/`; see `README.md` for the current list.
+Runtime artifacts are written under `~/.pi/agent/`; see the
+[runtime artifacts table](./README.md#runtime-artifacts) in the README.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,17 +1,30 @@
 # Support
 
-For usage questions or bug reports specific to `pi-smart-compact`, open an issue in this repository:
+For usage questions or bug reports specific to `pi-smart-compact`, open an
+issue in this repository:
 
 <https://github.com/alpertarhan/pi-smart-compact/issues>
 
-For Pi Coding Agent core behavior that reproduces without this extension, use the upstream Pi repository:
+For Pi Coding Agent core behavior that reproduces **without** this extension,
+use the upstream Pi repository:
 
 <https://github.com/earendil-works/pi>
 
-When asking for help, include:
+## Before you file
 
-- `pi-smart-compact` version
+Helpful things to include:
+
+- `pi-smart-compact` version (from `package.json` or `/smart-compact` output)
 - Pi Coding Agent version
-- the command or integration surface used (`/smart-compact`, `smart_compact`, or auto-trigger)
+- the integration surface used (`/smart-compact`, `smart_compact`, or auto-trigger)
 - relevant non-secret `smartCompact` configuration
 - redacted error output or logs
+
+## Self-service diagnostics
+
+- `/smart-compact metrics` — profile / provider comparison from the metrics log
+- `/smart-compact dashboard` — interactive TUI dashboard (overview, latest run, current session, recent runs)
+- `/smart-compact dashboard` → *Write HTML dashboard* — a local `~/.pi/agent/.cache/smart-compact-report.html`
+
+For security issues, see [`SECURITY.md`](./SECURITY.md) — please do **not**
+open a public issue for vulnerabilities.

--- a/bun.lock
+++ b/bun.lock
@@ -5,18 +5,18 @@
     "": {
       "name": "pi-smart-compact",
       "devDependencies": {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*",
-        "@earendil-works/pi-tui": "*",
+        "@earendil-works/pi-ai": "^0.79.6",
+        "@earendil-works/pi-coding-agent": "^0.79.6",
+        "@earendil-works/pi-tui": "^0.79.6",
         "@types/node": "^25.9.3",
-        "typebox": "*",
+        "typebox": "^1.2.16",
         "typescript": "^6.0.0",
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*",
-        "@earendil-works/pi-tui": "*",
-        "typebox": "*",
+        "@earendil-works/pi-ai": "^0.79.6",
+        "@earendil-works/pi-coding-agent": "^0.79.6",
+        "@earendil-works/pi-tui": "^0.79.6",
+        "typebox": "^1.2.16",
       },
     },
   },
@@ -75,13 +75,13 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.4", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-xkaZ3yK2XbP9HYdHrrdj/6HqZPM0o/mwbjMSU4RTJyR3HjDG0ZrPz76Hg6s0W+G4u6PpJr1mGx/srCG+3eQA8A=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.6", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.6", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-SXZc4rQI+3zgUmAJDbU0GzFEHCPHbhItjN7QLsahj3TKfQAon4guwCqsrwZBLH5lPcub2+evTojPNrPItL62tA=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.4", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Z1j+YP+6ZyPBKDUoc5m0GO/o1hPK17fWeErtDgegCTpm2dcKzuFvL/7GTqHeJkVkfpeXRwO37xOfgozQbK6EUw=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.6", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-KGepEdgEeWDs7Imwlp96tBsO8TjSIpcDBvazsCDtHRa81+uwJI/YGetTegI52pMlKhVpJFLIGajRi4PCGC5MUg=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.79.4", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.79.4", "@earendil-works/pi-ai": "^0.79.4", "@earendil-works/pi-tui": "^0.79.4", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.3.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-PthzVzM5m4XH/hrU+2fVjuwuH5M4eMFWbd0NCRScH14XKpwlPc8/Fh6JDz0jQb5kTBT9oQT183YLTHVVulFL9A=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.79.6", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.79.6", "@earendil-works/pi-ai": "^0.79.6", "@earendil-works/pi-tui": "^0.79.6", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.3.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-xPQDoA3+4Q8UsInST8OGFHPHyi7JQIbx51ku5kf2VuhXrrTv/npjVTXYD3A3D5xs6QRebV0B2mQqHfXaxQAplw=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.79.4", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "15.0.12" } }, "sha512-/ZhfFiHSBMH7AbDrBQIN+UWlJnl9tSEpLYICRGGMzmNfyCqX+30NYacIhyOEaD8R5rS6wJZysAOPU0yNwigbXw=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.79.6", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-6JCq780X0UuqvJsUDSJmi4V54ObB8qSwFQiBOI1jhPpC+Ydusd8SEXn2HtyIqve/utMgwcZT9aOyZM72m26A0w=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
@@ -231,7 +231,7 @@
 
     "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
-    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+    "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -277,7 +277,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typebox": ["typebox@1.2.11", "", {}, "sha512-0WPn8EoKHPZiACD/mgU+TY+SP7kn5S3pPmeoOBXhkwqkX/W4XyRLfYrDC8Nnhf23OhRf+yMe/atZtyiOLbgSVg=="],
+    "typebox": ["typebox@1.2.16", "", {}, "sha512-p85YWtR1RznP2kt/sftmj1leGiObfHVJwkK2hkDdEKhbtQONeUeBtbYdK0x9tLPh+5AaEPD62APv189Cy+/C2g=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,7 +7,7 @@ Use this checklist before publishing `pi-smart-compact`.
 1. Decide the version bump using semver.
 2. Update version metadata:
    - `package.json`
-   - `src/constants.ts`
+   - `src/constants.ts` via `bun run sync-version`
    - `CHANGELOG.md`
 3. Make sure user-facing behavior is reflected in `README.md` or project docs.
 

--- a/docs/assets/banner.svg
+++ b/docs/assets/banner.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="320" viewBox="0 0 1280 320" role="img" aria-label="pi-smart-compact — verification-oriented smart compaction for the Pi Coding Agent. Extract, Explore, Synthesize, Verify.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#08111f"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.12" cy="0.05" r="0.6">
+      <stop offset="0" stop-color="#60a5fa" stop-opacity="0.22"/>
+      <stop offset="1" stop-color="#60a5fa" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#60a5fa"/>
+      <stop offset="0.5" stop-color="#22c55e"/>
+      <stop offset="1" stop-color="#fbbf24"/>
+    </linearGradient>
+  </defs>
+
+  <!-- card -->
+  <rect x="0" y="0" width="1280" height="320" rx="28" fill="url(#bg)"/>
+  <rect x="0" y="0" width="1280" height="320" rx="28" fill="url(#glow)"/>
+  <rect x="0" y="0" width="1280" height="5" fill="url(#accent)"/>
+
+  <!-- eyebrow -->
+  <text x="80" y="78" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="17" font-weight="700" letter-spacing="3" fill="#60a5fa">PI EXTENSION</text>
+
+  <!-- title -->
+  <text x="80" y="138" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="56" font-weight="800" fill="#e5edf8">pi-smart-compact</text>
+
+  <!-- tagline -->
+  <text x="80" y="180" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="22" font-weight="400" fill="#8fa3bf">Verification-oriented smart compaction for the Pi Coding Agent</text>
+
+  <!-- EESV pipeline pills -->
+  <g font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="20" font-weight="700">
+    <!-- Extract -->
+    <rect x="80" y="226" width="138" height="46" rx="23" fill="#1e3a5f" stroke="#60a5fa" stroke-width="1.5"/>
+    <text x="149" y="255" text-anchor="middle" fill="#bfdbfe">① Extract</text>
+
+    <!-- arrow -->
+    <path d="M226 249 L246 249" stroke="#3b4a63" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M242 243 L250 249 L242 255" fill="none" stroke="#3b4a63" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <!-- Explore -->
+    <rect x="256" y="226" width="146" height="46" rx="23" fill="#3b2f5a" stroke="#a78bfa" stroke-width="1.5"/>
+    <text x="329" y="255" text-anchor="middle" fill="#ddd6fe">② Explore</text>
+
+    <!-- arrow -->
+    <path d="M410 249 L430 249" stroke="#3b4a63" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M426 243 L434 249 L426 255" fill="none" stroke="#3b4a63" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <!-- Synthesize -->
+    <rect x="440" y="226" width="180" height="46" rx="23" fill="#1f3d2e" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="530" y="255" text-anchor="middle" fill="#bbf7d0">③ Synthesize</text>
+
+    <!-- arrow -->
+    <path d="M628 249 L648 249" stroke="#3b4a63" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M644 243 L652 249 L644 255" fill="none" stroke="#3b4a63" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <!-- Verify -->
+    <rect x="658" y="226" width="132" height="46" rx="23" fill="#4a3a17" stroke="#fbbf24" stroke-width="1.5"/>
+    <text x="724" y="255" text-anchor="middle" fill="#fde68a">④ Verify</text>
+  </g>
+
+  <!-- right-side signature mark -->
+  <g transform="translate(1052, 80)">
+    <circle cx="84" cy="84" r="78" fill="none" stroke="#24324a" stroke-width="2"/>
+    <circle cx="84" cy="84" r="62" fill="none" stroke="#2a3b57" stroke-width="2"/>
+    <!-- compact "check" mark in a shield-ish node -->
+    <path d="M84 44 L116 58 V92 C116 112 100 124 84 128 C68 124 52 112 52 92 V58 Z" fill="#0f1c33" stroke="#22c55e" stroke-width="2.5" stroke-linejoin="round"/>
+    <path d="M70 86 L80 96 L100 74" fill="none" stroke="#22c55e" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/src/app/run-smart-compact.ts
+++ b/src/app/run-smart-compact.ts
@@ -251,8 +251,15 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
 
     if (!stated.flags.autoTriggered) {
       try {
-        const timeoutPromise = new Promise<void>(resolve => setTimeout(resolve, 5000));
-        await Promise.race([showResultScreen(stated.ctx, stated.details, stated.extraction, stated.services), timeoutPromise]);
+        let resultTimer: ReturnType<typeof setTimeout> | undefined;
+        const timeoutPromise = new Promise<void>(resolve => { resultTimer = setTimeout(resolve, 5000); });
+        try {
+          await Promise.race([showResultScreen(stated.ctx, stated.details, stated.extraction, stated.services), timeoutPromise]);
+        } finally {
+          // Clear the fallback timer whether the screen or the timeout won
+          // the race — otherwise it lingers up to 5s after we've moved on.
+          if (resultTimer) clearTimeout(resultTimer);
+        }
       } catch (err) {
         log.warn("Result screen error", err);
         stated.notify("Result screen skipped", "info");

--- a/src/app/steps/extract.ts
+++ b/src/app/steps/extract.ts
@@ -32,6 +32,7 @@ import { getPreviousCompactionContext } from "../../utils/helpers.ts";
 import { isPrefixOf, legacyPrefixMatch } from "../../utils/id-fingerprint.ts";
 import { estimateTokens } from "../../utils/tokens.ts";
 import { serializeConversation } from "@earendil-works/pi-coding-agent";
+import { asSerializableMessages } from "../../infra/ai-messages.ts";
 import { backupConversation } from "../../utils/helpers.ts";
 
 export function extractWithCache(rc: TieredRc): ExtractedRc {
@@ -60,7 +61,7 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
   markMeasuredPhase(rc, "prune", extractStepStart, pruneEnd);
 
   const extractionStart = pruneEnd;
-  const convText = serializeConversation(rc.llmMessages as unknown as import("@earendil-works/pi-ai").Message[]);
+  const convText = serializeConversation(asSerializableMessages(rc.llmMessages));
   const convTokens = estimateTokens(convText);
 
   const backupPath = backupConversation(convText, rc.sessionId);

--- a/src/app/steps/persist.ts
+++ b/src/app/steps/persist.ts
@@ -22,9 +22,10 @@ import type { RunContext } from "../run-context.ts";
 import type { PendingCompaction, LlmMessage } from "../../types.ts";
 import { saveProjectFingerprint } from "../../utils/fingerprint.ts";
 import { saveCompactionState } from "../../utils/state.ts";
-import { detectDamage, logDamageReport } from "../../utils/damage.ts";
+import { detectDamage, logDamageReport, writeRemediationHints } from "../../utils/damage.ts";
 import { sanitizeSmartCompactDetails } from "../../utils/type-guards.ts";
 import { convertToLlm } from "@earendil-works/pi-coding-agent";
+import { asBranchMessage } from "../../infra/ai-messages.ts";
 import { markPhase } from "../run-context.ts";
 import * as log from "../../utils/logger.ts";
 
@@ -46,7 +47,7 @@ export function persistDurableState(rc: RunContext): void {
 export function runDamageDetection(rc: RunContext): void {
   try {
     const postCompactMsgs = rc.msgs.slice(rc.keepFrom)
-      .map(e => convertToLlm([e.message as import("@earendil-works/pi-ai").Message]))
+      .map(e => convertToLlm([asBranchMessage(e.message)]))
       .flat() as LlmMessage[];
     if (postCompactMsgs.length <= 2) return;
 
@@ -71,6 +72,11 @@ export function runDamageDetection(rc: RunContext): void {
       rc.notify("Previous compaction damage: " + damage.summary, "warning");
     }
     logDamageReport(rc.sessionId, damage, safeDetails);
+    // Feed re-read files forward as remediation hints so the next compaction
+    // preserves them instead of losing them again.
+    if (damage.reReadFiles.length > 0) {
+      writeRemediationHints(rc.projectId, damage.reReadFiles);
+    }
   } catch (err) { log.warn("Damage detection error", err); }
 }
 

--- a/src/app/steps/recover.ts
+++ b/src/app/steps/recover.ts
@@ -12,12 +12,13 @@
 import type { WindowedRc, RecoveredRc } from "../run-context.ts";
 import { advance } from "../run-context.ts";
 import { convertToLlm } from "@earendil-works/pi-coding-agent";
+import { asBranchMessage } from "../../infra/ai-messages.ts";
 import type { LlmMessage } from "../../types.ts";
 import { hasTruncatedMessages, resolveCompactionMessages } from "../../utils/session-log.ts";
 
 export function recoverSessionLog(rc: WindowedRc): RecoveredRc {
   let llmMessages = convertToLlm(
-    rc.toCompact.map(e => e.message as import("@earendil-works/pi-ai").Message),
+    rc.toCompact.map(e => asBranchMessage(e.message)),
   ) as LlmMessage[];
 
   if (hasTruncatedMessages(llmMessages)) {

--- a/src/app/steps/state.ts
+++ b/src/app/steps/state.ts
@@ -14,8 +14,10 @@ import { advance } from "../run-context.ts";
 import {
   buildCompactionState, injectOpenLoopsSection, extractNextActions,
   extractCriticalContext, loadCompactionState, computeDelta, injectDeltaSection,
+  ensurePinnedPaths,
 } from "../../utils/state.ts";
 import { extractOpenLoops } from "../../utils/extraction.ts";
+import { readRemediationHints } from "../../utils/damage.ts";
 import { estimateTokens } from "../../utils/tokens.ts";
 import type { SmartCompactDetails, OpenLoop, CompactionState } from "../../types.ts";
 
@@ -31,6 +33,22 @@ export function buildState(rc: VerifiedRc): StatedRc {
       "info",
     );
     summary = injectOpenLoopsSection(summary, openLoops);
+  }
+
+  // Pinned paths ("never compact") + remediation hints (files the agent
+  // re-read after a prior compaction) — a deterministic guarantee that survives
+  // whatever the LLM chose to include. Ensured before state/delta so the
+  // canonical headings exist for downstream injectors.
+  const pinPaths = rc.config.pinPaths ?? [];
+  const remediated = readRemediationHints(rc.projectId);
+  const preserve = remediated.length
+    ? Array.from(new Set([...pinPaths, ...remediated]))
+    : pinPaths;
+  if (remediated.length) {
+    rc.notify("Remediation: re-preserving " + remediated.length + " file(s) lost in a prior compaction", "info");
+  }
+  if (preserve.length > 0) {
+    summary = ensurePinnedPaths(summary, preserve);
   }
 
   const nextActions = extractNextActions(summary);

--- a/src/app/steps/synthesize.ts
+++ b/src/app/steps/synthesize.ts
@@ -21,7 +21,7 @@
 import type { ChunkSummary, TopicBoundary } from "../../types.ts";
 import { showProgressOverlay } from "../../ui/overlays.ts";
 import { exploreConversation, shouldExplore } from "../explore-wrap.ts";
-import { chunkLlmMessages, singlePassCompact, summarizeBatch, assembleLLM, assembleFallback } from "../../phases/synthesize.ts";
+import { chunkLlmMessages, singlePassCompact, summarizeBatch, assembleLLM, assembleFallback, failedChunkSummary } from "../../phases/synthesize.ts";
 import { MAX_EXPLORATION_ROUNDS } from "../../constants.ts";
 import { createBatches } from "../../utils/helpers.ts";
 import { extractText } from "../../utils/extraction.ts";
@@ -157,10 +157,17 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
     const concurrency = rc.providerCaps.concurrencyLimit;
 
     if (totalBatches <= 1) {
-      try {
-        summaries.push(...await summarizeBatch(batches[0], extraction, rc.summaryModel, rc.summaryAuth, rc.cancellation.signal, rc.services));
-      } catch (err) {
-        summaries.push(...batches[0].map(ch => failedChunkSummary(ch)));
+      const single = batches[0];
+      if (single) {
+        try {
+          summaries.push(...await summarizeBatch(single, extraction, rc.summaryModel, rc.summaryAuth, rc.cancellation.signal, rc.services));
+        } catch (err) {
+          summaries.push(...single.map(ch => failedChunkSummary(ch)));
+        }
+      } else {
+        // Defensive: empty chunk list (no messages to summarize). Skip batch
+        // summarization; the deterministic assembleFallback below covers it.
+        rc.vlog("Synthesize: 0 batches — skipping summarization, using fallback assembly");
       }
     } else {
       const results: ChunkSummary[][] = new Array(totalBatches);
@@ -236,10 +243,3 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
   return advance<ExtractedRc, SynthesizedRc>(out, "_synthesized");
 }
 
-function failedChunkSummary(ch: import("../../types.ts").LlmChunk): ChunkSummary {
-  return {
-    topic: ch.topic, startIndex: ch.startIndex, endIndex: ch.endIndex,
-    summary: "[Failed] " + ch.messages.map(m => extractText(m.content)).join("\n").slice(0, 300),
-    keyDecisions: [], filesModified: [], filesRead: [], priority: ch.priority,
-  };
-}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "7.15.1";
+export const VERSION = "7.16.0";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =
@@ -57,6 +57,7 @@ export const DEFAULT_CONFIG = {
   backupEnabled: true,
   backupDir: "",
   minContextPercent: 60, // Don't compact below this context threshold (tool=97% ≠ context full)
+  pinPaths: [] as string[],
 };
 
 export const NO_OP_RE = /applied:\s*0|no changes applied|nothing to (?:do|change)|0 edits? applied/i;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,11 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type { CompressionProfile, PendingCompaction, Cell } from "./types.ts";
 import { VERSION, MIN_TOKEN_THRESHOLD, CONFIG_KEY, CONFIG_KEY_ALT } from "./constants.ts";
-import { loadConfig, extractUserNote } from "./utils/helpers.ts";
+import { loadConfig, extractUserNote, listBackups, readBackupContent, buildRestoreMessage } from "./utils/helpers.ts";
 import { getProviderCaps } from "./utils/tokens.ts";
 import { buildMetricsReport, readMetricsLog, writeMetricsDashboard } from "./utils/cache.ts";
 import { runSmartCompact } from "./app/run-smart-compact.ts";
-import { showCompactUI, showMetricsDashboardUI } from "./ui/overlays.ts";
+import { showCompactUI, showMetricsDashboardUI, showRestorePicker, showBackupViewer, showRestoreAction } from "./ui/overlays.ts";
 import { resolveSessionId, isUnresolvedSessionId } from "./infra/session-identity.ts";
 import { createPendingSlot, type PendingSlot, type ConsumeResult } from "./app/pending-slot.ts";
 import * as log from "./utils/logger.ts";
@@ -128,6 +128,43 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
             }
           } else {
             ctx.ui.notify(buildMetricsReport(), "info");
+          }
+          return;
+        }
+        if (flags.includes("restore")) {
+          const backups = listBackups();
+          if (!backups.length) { ctx.ui.notify("No smart-compact backups found", "info"); return; }
+          const selected = await showRestorePicker(ctx, backups);
+          if (!selected) { ctx.ui.notify("Cancelled", "info"); return; }
+          const content = readBackupContent(selected);
+          if (!content) { ctx.ui.notify("Could not read backup: " + selected, "error"); return; }
+          const action = await showRestoreAction(ctx, selected);
+          if (action === "restore") {
+            // The command context exposes a read-only session manager, so we
+            // can't inject into the *current* session. True restore forks from
+            // the current leaf (preserving recent work) and injects the backup
+            // as context via the replacement session's sendMessage.
+            const branch = ctx.sessionManager.getBranch() as Array<{ id?: string }>;
+            const leafId = branch.length ? branch[branch.length - 1].id : undefined;
+            if (!leafId) {
+              ctx.ui.notify("Cannot restore: no session leaf to fork from — showing content instead", "warning");
+              await showBackupViewer(ctx, content, selected);
+              return;
+            }
+            try {
+              const result = await ctx.fork(leafId, {
+                withSession: async (rctx) => {
+                  await rctx.sendMessage(buildRestoreMessage(content, selected), { deliverAs: "nextTurn" });
+                },
+              });
+              ctx.ui.notify(result.cancelled ? "Restore cancelled" : "Restored backup into a new session", "info");
+            } catch (e) {
+              log.warn("Restore fork failed", e);
+              ctx.ui.notify("Restore failed (" + (e instanceof Error ? e.message : String(e)) + ") — showing content instead", "warning");
+              await showBackupViewer(ctx, content, selected);
+            }
+          } else if (action === "view") {
+            await showBackupViewer(ctx, content, selected);
           }
           return;
         }

--- a/src/infra/ai-messages.ts
+++ b/src/infra/ai-messages.ts
@@ -1,0 +1,46 @@
+/**
+ * Boundary adapters between the project's loose `LlmMessage` type and
+ * pi-ai's strict `Message` type.
+ *
+ * Why these exist: pi-ai's `Context.messages` is typed `Message[]` with no
+ * permissive input variant, and `AssistantMessage` requires response
+ * metadata (`api` / `provider` / `model` / `usage` / `stopReason`). Several
+ * call sites hold data that is *genuinely* a `Message` at runtime but is
+ * typed looser (`unknown` for raw branch entries, `LlmMessage[]` for the
+ * pruned pipeline). Rather than scatter blind `as` casts, each boundary
+ * upcast lives here with a comment documenting the data's provenance so a
+ * reader can verify soundness without re-deriving it.
+ *
+ * Note: the explore-tool feedback loop does NOT use these — it builds its
+ * conversation buffer in native `Message[]` directly (see `phases/explore.ts`),
+ * which is the preferred pattern for any new code that talks to a provider.
+ */
+
+import type { Message } from "@earendil-works/pi-ai";
+import type { LlmMessage } from "../types.ts";
+
+/**
+ * Upcast a raw branch entry's `message` to a `Message` for `convertToLlm`.
+ *
+ * Provenance: pi-coding-agent's `SessionMessageEntry.message` is typed
+ * `AgentMessage`, and pi-ai's `Message` (`UserMessage | AssistantMessage |
+ * ToolResultMessage`) is a subset of `AgentMessage` — so casting through
+ * `Message` is sound and assignable to `convertToLlm`'s `AgentMessage[]`
+ * parameter. A branch only ever stores real messages produced by Pi.
+ */
+export function asBranchMessage(message: unknown): Message {
+  return message as Message;
+}
+
+/**
+ * Re-widen pruned `LlmMessage[]` to `Message[]` for `serializeConversation`.
+ *
+ * Provenance: the messages were produced by `convertToLlm` (real `Message`s)
+ * and pruning only rewrites tool-result `content` via an object spread that
+ * preserves `role`, `toolCallId`, `toolName`, `isError`, and `timestamp` —
+ * every field `Message` requires. `serializeConversation` reads only
+ * `role` + `content` to render text, so the upcast is sound.
+ */
+export function asSerializableMessages(msgs: LlmMessage[]): Message[] {
+  return msgs as unknown as Message[];
+}

--- a/src/infra/paths.ts
+++ b/src/infra/paths.ts
@@ -87,6 +87,11 @@ export function compactionStateFile(projectId: string): string {
   return path.join(compactionStateDir(), projectId + ".json");
 }
 
+/** Remediation hints file — files to re-preserve after a damage event. */
+export function remediationHintsFile(projectId: string): string {
+  return path.join(smartCompactCacheDir(), "remediation-" + projectId + ".json");
+}
+
 /** HTML metrics dashboard file. */
 export function metricsDashboardFile(): string {
   return path.join(cacheDir(), "smart-compact-report.html");

--- a/src/phases/explore.ts
+++ b/src/phases/explore.ts
@@ -2,8 +2,9 @@
  * Phase 2: Targeted LLM Exploration.
  */
 
-import type { Model, Api, ToolCall, TextContent, Message } from "@earendil-works/pi-ai";
-import type { LlmMessage, StructuredExtraction, ExplorationReport } from "../types.ts";
+import type { Model, Api, ToolCall, TextContent, Message, Tool } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import type { LlmMessage, StructuredExtraction, ExplorationReport, TopicBoundary } from "../types.ts";
 import { getToolCallNames, filterToolCalls } from "../utils/type-guards.ts";
 import { COMPACT_SYSTEM_PREFIX, EXPLORER_SYSTEM_PROMPT, MAX_EXPLORATION_ROUNDS } from "../constants.ts";
 import { extractText, extractMainGoal, extractStructured } from "../utils/extraction.ts";
@@ -39,30 +40,37 @@ export function shouldExplore(extraction: StructuredExtraction): boolean {
   return true;
 }
 
-const EXPLORATION_TOOLS = [
+// Exploration tools declared in pi-ai's native `Tool[]` shape using typebox
+// schemas. pi-ai types `Tool.parameters` as a typebox `TSchema`; the providers
+// only ever *serialize* the schema (anthropic reads `properties`/`required`;
+// google/mistral strip symbol keys via Object.entries; openai forwards and
+// relies on JSON dropping symbols), so a real typebox schema is wire-identical
+// to the plain JSON-schema objects used here previously — but now type-checks
+// without a cast and survives any future typebox-aware validation.
+const EXPLORATION_TOOLS: Tool[] = [
   {
     name: "get_message_range", description: "Get compact summaries of messages from start to end index (0-based).",
-    parameters: { type: "object", properties: { start: { type: "number" }, end: { type: "number" } }, required: ["start", "end"] },
+    parameters: Type.Object({ start: Type.Number(), end: Type.Number() }),
   },
   {
     name: "search_conversation", description: "Search for text in conversation messages.",
-    parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+    parameters: Type.Object({ query: Type.String() }),
   },
   {
     name: "get_recent_user_messages", description: "Get the last N user messages.",
-    parameters: { type: "object", properties: { count: { type: "number" } } },
+    parameters: Type.Object({ count: Type.Optional(Type.Number()) }),
   },
   {
     name: "get_context_around", description: "Get context around a specific message index.",
-    parameters: { type: "object", properties: { index: { type: "number" }, radius: { type: "number" } }, required: ["index"] },
+    parameters: Type.Object({ index: Type.Number(), radius: Type.Optional(Type.Number()) }),
   },
   {
     name: "get_file_changes", description: "Get tool calls that modified a specific file.",
-    parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+    parameters: Type.Object({ path: Type.String() }),
   },
   {
     name: "get_error_chain", description: "Get all messages related to a specific error.",
-    parameters: { type: "object", properties: { index: { type: "number" }, context_radius: { type: "number" } }, required: ["index"] },
+    parameters: Type.Object({ index: Type.Number(), context_radius: Type.Optional(Type.Number()) }),
   },
 ];
 
@@ -184,45 +192,78 @@ export function parseExplorationReport(text: string, llmMessages: LlmMessage[]):
   if (boundaryMatch) {
     try {
       const boundaries = JSON.parse("[" + boundaryMatch[1] + "]");
-      return { ...fallbackExplorationReport(llmMessages), boundaries: boundaries.filter((b: any) => typeof b?.afterIndex === "number").map((b: any) => ({
-        afterIndex: Math.min(b.afterIndex, llmMessages.length - 2),
-        topic: String(b.topic ?? "").slice(0, 100),
-        priority: ["critical", "high", "normal", "low"].includes(b.priority) ? b.priority : "normal",
-        confidence: Math.min(1, Math.max(0, b.confidence ?? 0.5)),
-      })) };
+      return { ...fallbackExplorationReport(llmMessages), boundaries: normalizeBoundaries(boundaries, llmMessages.length) };
     } catch (err) { log.debug("Boundary JSON parse failed", err); }
   }
   return fallbackExplorationReport(llmMessages);
 }
 
-export function buildExplorationReportFromParsed(parsed: any, llmMessages: LlmMessage[]): ExplorationReport {
+const BOUNDARY_PRIORITIES = ["critical", "high", "normal", "low"] as const;
+type BoundaryPriority = (typeof BOUNDARY_PRIORITIES)[number];
+const SESSION_TYPES = ["implementation", "review", "debugging", "discussion"] as const;
+type SessionTypeLiteral = (typeof SESSION_TYPES)[number];
+
+/** Coerce an unknown value into a clean `string[]` (non-strings pass through `String()`). */
+function stringArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.map(String) : [];
+}
+
+/**
+ * Normalize a raw `boundaries` JSON value (from an LLM) into validated
+ * {@link TopicBoundary}s. Centralized so the boundary-recovery path and the
+ * full-report path share identical validation, including:
+ *  - a lower clamp of 0 (LLMs occasionally emit negative `afterIndex`), and
+ *  - a numeric guard on `confidence` (a string would otherwise become `NaN`
+ *    via Math.min before reaching the 0.5 fallback).
+ */
+function normalizeBoundaries(raw: unknown, llmLength: number): TopicBoundary[] {
+  if (!Array.isArray(raw)) return [];
+  const maxIndex = Math.max(0, llmLength - 2);
+  return raw
+    .filter((b): b is Record<string, unknown> =>
+      !!b && typeof b === "object" && typeof (b as Record<string, unknown>).afterIndex === "number")
+    .map((b) => {
+      const priority = b.priority;
+      const confidence = b.confidence;
+      return {
+        afterIndex: Math.max(0, Math.min(b.afterIndex as number, maxIndex)),
+        topic: String(b.topic ?? "").slice(0, 100),
+        priority: typeof priority === "string" && (BOUNDARY_PRIORITIES as readonly string[]).includes(priority)
+          ? (priority as BoundaryPriority)
+          : "normal",
+        confidence: typeof confidence === "number" && Number.isFinite(confidence)
+          ? Math.min(1, Math.max(0, confidence))
+          : 0.5,
+      };
+    });
+}
+
+export function buildExplorationReportFromParsed(parsed: unknown, llmMessages: LlmMessage[]): ExplorationReport {
   // Defend against primitives: a model can return JSON that parses to a
-  // number/string/boolean (e.g. just `42` or `"ok"`). The optional-chaining
-  // below tolerates that for most fields, but `parsed.statusAssessment?.done`
-  // on a primitive yields undefined safely — so the previous code happened to
-  // work. Make the object assumption explicit so a future field access can't
-  // introduce a TypeError on `(42).something`.
+  // number/string/boolean (e.g. just `42` or `"ok"`). Make the object
+  // assumption explicit so a future field access can't introduce a TypeError
+  // on `(42).something`.
   if (typeof parsed !== "object" || parsed === null) {
     return fallbackExplorationReport(llmMessages);
   }
+  const p = parsed as Record<string, unknown>;
+  const statusAssessment = (p.statusAssessment ?? null) as Record<string, unknown> | null;
+  const sessionTypeRaw = p.sessionType;
   return {
-    boundaries: (parsed.boundaries ?? []).filter((b: any) => typeof b?.afterIndex === "number").map((b: any) => ({
-      afterIndex: Math.min(b.afterIndex, llmMessages.length - 2),
-      topic: String(b.topic ?? "").slice(0, 100),
-      priority: ["critical", "high", "normal", "low"].includes(b.priority) ? b.priority : "normal",
-      confidence: Math.min(1, Math.max(0, b.confidence ?? 0.5)),
-    })),
-    mainGoal: parsed.mainGoal ?? "",
-    sessionType: ["implementation", "review", "debugging", "discussion"].includes(parsed.sessionType) ? parsed.sessionType : "implementation",
-    enrichedConstraints: Array.isArray(parsed.enrichedConstraints) ? parsed.enrichedConstraints.map(String) : [],
-    crossReferences: Array.isArray(parsed.crossReferences) ? parsed.crossReferences.map(String) : [],
+    boundaries: normalizeBoundaries(p.boundaries, llmMessages.length),
+    mainGoal: typeof p.mainGoal === "string" ? p.mainGoal : "",
+    sessionType: typeof sessionTypeRaw === "string" && (SESSION_TYPES as readonly string[]).includes(sessionTypeRaw)
+      ? (sessionTypeRaw as SessionTypeLiteral)
+      : "implementation",
+    enrichedConstraints: stringArray(p.enrichedConstraints),
+    crossReferences: stringArray(p.crossReferences),
     statusAssessment: {
-      done: Array.isArray(parsed.statusAssessment?.done) ? parsed.statusAssessment.done.map(String) : [],
-      inProgress: Array.isArray(parsed.statusAssessment?.inProgress) ? parsed.statusAssessment.inProgress.map(String) : [],
-      blocked: Array.isArray(parsed.statusAssessment?.blocked) ? parsed.statusAssessment.blocked.map(String) : [],
+      done: stringArray(statusAssessment?.done),
+      inProgress: stringArray(statusAssessment?.inProgress),
+      blocked: stringArray(statusAssessment?.blocked),
     },
-    criticalContext: Array.isArray(parsed.criticalContext) ? parsed.criticalContext.map(String) : [],
-    keyDecisions: Array.isArray(parsed.keyDecisions) ? parsed.keyDecisions.map(String) : [],
+    criticalContext: stringArray(p.criticalContext),
+    keyDecisions: stringArray(p.keyDecisions),
   };
 }
 
@@ -297,7 +338,7 @@ export async function exploreConversation(
     const probeResp = await trackedComplete("explore", model, {
       systemPrompt: COMPACT_SYSTEM_PREFIX,
       messages: [{ role: "user", content: [{ type: "text", text: userContent }], timestamp: Date.now() }],
-      tools: EXPLORATION_TOOLS as unknown as Parameters<typeof trackedComplete>[2]["tools"],
+      tools: EXPLORATION_TOOLS,
     }, { apiKey: auth.apiKey, headers: auth.headers, signal }, svc);
 
     const toolCalls = probeResp.content.filter((c): c is ToolCall => c.type === "toolCall");
@@ -305,13 +346,16 @@ export async function exploreConversation(
     if (toolCalls.length > 0) {
       supportsTools = true;
       toolSupport.set(cacheKey, true, svc.clock.now());
-      // Typed message buffer for the explore-tool feedback loop. Using
-      // `any[]` here previously masked a real shape divergence between
-      // pi-ai's `Message` and our internal `LlmMessage`; cast at the call
-      // site where the shapes are known to be compatible.
-      const messages: LlmMessage[] = [
+      // Conversation buffer for the explore-tool feedback loop, kept in
+      // pi-ai's native `Message[]` shape so it can be fed straight to
+      // `complete()` with no cast. The assistant turn is the *whole*
+      // `AssistantMessage` returned by `trackedComplete` — previously the
+      // code downcast it to `LlmMessage` and discarded
+      // `usage`/`api`/`provider`/`model`/`stopReason`, then cast back to
+      // `Message[]` at the call site. Keeping the real object avoids both.
+      const messages: Message[] = [
         { role: "user", content: [{ type: "text", text: userContent }], timestamp: Date.now() },
-        { role: "assistant", content: probeResp.content as LlmMessage["content"], timestamp: Date.now() },
+        probeResp,
       ];
       for (const tc of toolCalls) {
         const result = executeExplorationTool({ name: tc.name, arguments: tc.arguments }, llmMessages);
@@ -325,8 +369,8 @@ export async function exploreConversation(
         try {
           response = await trackedComplete("explore-loop", model, {
             systemPrompt: COMPACT_SYSTEM_PREFIX + "\n\n" + EXPLORER_SYSTEM_PROMPT,
-            messages: messages as unknown as Message[],
-            tools: EXPLORATION_TOOLS as unknown as Parameters<typeof trackedComplete>[2]["tools"],
+            messages,
+            tools: EXPLORATION_TOOLS,
           }, { apiKey: auth.apiKey, headers: auth.headers, signal }, svc);
         } catch (err) {
           log.warn("Explore loop error", err);
@@ -344,7 +388,7 @@ export async function exploreConversation(
           return { report, rounds, toolSupported: true };
         }
 
-        messages.push({ role: "assistant", content: response.content as LlmMessage["content"], timestamp: Date.now() });
+        messages.push(response);
         for (const tc of nextToolCalls) {
           const result = executeExplorationTool({ name: tc.name, arguments: tc.arguments }, llmMessages);
           messages.push({ role: "toolResult", toolCallId: tc.id, toolName: tc.name, content: [{ type: "text", text: result }], isError: false, timestamp: Date.now() });

--- a/src/phases/synthesize.ts
+++ b/src/phases/synthesize.ts
@@ -216,3 +216,17 @@ export function assembleFallback(summaries: ChunkSummary[], extraction: Structur
     "## Topics Covered", ...summaries.map(s => "- **" + s.topic + "** [" + s.priority + "]: " + s.summary.slice(0, 200)),
   ].join("\n");
 }
+
+/**
+ * Build a placeholder {@link ChunkSummary} when a batch's LLM call failed, so the
+ * assembly step still has something deterministic to merge rather than
+ * dropping the segment silently. Co-located with `assembleFallback` so both
+ * fallback contracts live in the algorithm layer (no I/O, trivially testable).
+ */
+export function failedChunkSummary(ch: LlmChunk): ChunkSummary {
+  return {
+    topic: ch.topic, startIndex: ch.startIndex, endIndex: ch.endIndex,
+    summary: "[Failed] " + ch.messages.map(m => extractText(m.content)).join("\n").slice(0, 300),
+    keyDecisions: [], filesModified: [], filesRead: [], priority: ch.priority,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,9 @@ export interface CompactConfig {
   backupEnabled: boolean;
   backupDir: string;
   minContextPercent: number; // Don't compact below this threshold
+  /** File paths that must always survive compaction, regardless of what the
+   *  LLM summary chooses to include. Surfaced in the summary's Files Read. */
+  pinPaths: string[];
 }
 
 export interface ProviderCapabilities {

--- a/src/ui/overlays.ts
+++ b/src/ui/overlays.ts
@@ -10,6 +10,7 @@ import type {
   CompactMetricsEntry, CompressionProfile, ModelOption, ProgressState,
   SmartCompactDetails, StructuredExtraction,
 } from "../types.ts";
+import type { BackupEntry } from "../utils/helpers.ts";
 import type { SmartCompactServices } from "../infra/services.ts";
 import { effectivePromptInputTokens, getExtractionCacheStats, getMetricsSummary } from "../utils/cache.ts";
 import { getProviderCaps } from "../utils/tokens.ts";
@@ -443,4 +444,119 @@ export async function showCompactUI(
   const selectedProfile = await selectProfile(ctx, selectedModel, { contextTokens: opts.contextTokens, contextPercent: opts.contextPercent });
   if (!selectedProfile) return null;
   return { model: selectedModel, profile: selectedProfile };
+}
+
+/** Picker for `/smart-compact restore` — list backups, return the chosen path. */
+export async function showRestorePicker(
+  ctx: ExtensionCommandContext,
+  backups: BackupEntry[],
+): Promise<string | null> {
+  const items: SelectItem[] = backups.map(b => ({
+    value: b.path,
+    label: new Date(b.date).toLocaleString() + "  \u00b7  " + Math.max(1, Math.round(b.sizeBytes / 1024)) + "KB",
+    description: b.sessionId.slice(0, 20),
+  }));
+  return await ctx.ui.custom<string | null>((tui, theme, _kb, done) => {
+    const c = new Container();
+    c.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
+    c.addChild(new Text(theme.fg("accent", theme.bold("  \u21a9 Smart Compact \u2014 Restore")), 1, 0));
+    c.addChild(new Text(theme.fg("dim", "  Pick a backup to view its pre-compaction content"), 0, 0));
+    c.addChild(new Text("", 0, 0));
+    const sel = new SelectList(items, Math.min(items.length, 12), {
+      selectedPrefix: t => theme.fg("accent", t),
+      selectedText: t => theme.fg("accent", t),
+      description: t => theme.fg("muted", t),
+      scrollInfo: t => theme.fg("dim", t),
+      noMatch: t => theme.fg("warning", t),
+    });
+    sel.onSelect = item => done(item.value);
+    sel.onCancel = () => done(null);
+    c.addChild(sel);
+    c.addChild(new Text("", 0, 0));
+    c.addChild(new Text(theme.fg("dim", "  \u2191\u2193 navigate \u00b7 enter view \u00b7 esc cancel"), 0, 0));
+    c.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
+    return {
+      render: (w: number) => c.render(w),
+      invalidate: () => c.invalidate(),
+      handleInput: (d: string) => { sel.handleInput(d); tui.requestRender(); },
+    };
+  });
+}
+
+/** Scrollable viewer for a restored backup's content. */
+export async function showBackupViewer(
+  ctx: ExtensionCommandContext,
+  content: string,
+  fp: string,
+): Promise<void> {
+  await ctx.ui.custom<void>((tui, theme, keybindings, done) => {
+    const lines = content.split("\n");
+    const pageSize = 40;
+    let scroll = 0;
+    const maxScroll = Math.max(0, lines.length - pageSize);
+    return {
+      render: (w: number) => {
+        const out: string[] = [
+          truncateToWidth(theme.fg("accent", theme.bold("  \u21a9 Restored backup")) + theme.fg("dim", "  \u00b7  " + lines.length + " lines \u00b7 " + Math.max(1, Math.round(content.length / 1024)) + "KB"), w),
+          truncateToWidth(theme.fg("dim", "  " + fp), w),
+          truncateToWidth(theme.fg("borderMuted", "\u2500".repeat(Math.max(0, w))), w),
+        ];
+        for (const line of lines.slice(scroll, scroll + pageSize)) {
+          out.push(truncateToWidth(theme.fg("text", line), w));
+        }
+        if (lines.length > pageSize) {
+          out.push(truncateToWidth(theme.fg("dim", "  showing " + (scroll + 1) + "\u2013" + Math.min(lines.length, scroll + pageSize) + " of " + lines.length), w));
+        }
+        out.push("", truncateToWidth(theme.fg("dim", "  \u2191\u2193 scroll \u00b7 pgup/pgdn \u00b7 home/end \u00b7 esc/q close"), w));
+        return out;
+      },
+      invalidate: () => {},
+      handleInput: (data: string) => {
+        if (keybindings.matches(data, "tui.select.cancel") || data === "q") { done(undefined); return; }
+        if (matchesKey(data, Key.home)) scroll = 0;
+        else if (matchesKey(data, Key.end)) scroll = maxScroll;
+        else if (keybindings.matches(data, "tui.select.pageUp")) scroll = Math.max(0, scroll - pageSize);
+        else if (keybindings.matches(data, "tui.select.pageDown")) scroll = Math.min(maxScroll, scroll + pageSize);
+        else if (keybindings.matches(data, "tui.select.up")) scroll = Math.max(0, scroll - 1);
+        else if (keybindings.matches(data, "tui.select.down")) scroll = Math.min(maxScroll, scroll + 1);
+        tui.requestRender();
+      },
+    };
+  }, { overlay: true, overlayOptions: { width: "85%", anchor: "center", maxHeight: "85%" } });
+}
+
+/** Action menu after a backup is picked: view its content or restore it. */
+export async function showRestoreAction(
+  ctx: ExtensionCommandContext,
+  backupPath: string,
+): Promise<"view" | "restore" | null> {
+  const items: SelectItem[] = [
+    { value: "view", label: "View content", description: "Read the pre-compaction conversation" },
+    { value: "restore", label: "Restore into a new session", description: "Fork from here + inject this backup as context" },
+  ];
+  return await ctx.ui.custom<"view" | "restore" | null>((tui, theme, _kb, done) => {
+    const c = new Container();
+    c.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
+    c.addChild(new Text(theme.fg("accent", theme.bold("  \u21a9 Restore action")), 1, 0));
+    c.addChild(new Text(theme.fg("dim", "  " + backupPath), 0, 0));
+    c.addChild(new Text("", 0, 0));
+    const sel = new SelectList(items, 2, {
+      selectedPrefix: t => theme.fg("accent", t),
+      selectedText: t => theme.fg("accent", t),
+      description: t => theme.fg("muted", t),
+      scrollInfo: t => theme.fg("dim", t),
+      noMatch: t => theme.fg("warning", t),
+    });
+    sel.onSelect = item => done(item.value as "view" | "restore");
+    sel.onCancel = () => done(null);
+    c.addChild(sel);
+    c.addChild(new Text("", 0, 0));
+    c.addChild(new Text(theme.fg("dim", "  \u2191\u2193 navigate \u00b7 enter select \u00b7 esc cancel"), 0, 0));
+    c.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
+    return {
+      render: (w: number) => c.render(w),
+      invalidate: () => c.invalidate(),
+      handleInput: (d: string) => { sel.handleInput(d); tui.requestRender(); },
+    };
+  });
 }

--- a/src/utils/damage.ts
+++ b/src/utils/damage.ts
@@ -7,8 +7,8 @@ import type { LlmMessage, SmartCompactDetails } from "../types.ts";
 import { isToolCallBlock } from "../utils/type-guards.ts";
 import { extractText } from "./extraction.ts";
 import * as log from "./logger.ts";
-import { damageReportsFile } from "../infra/paths.ts";
-import { appendLineLocked } from "../infra/fs.ts";
+import { damageReportsFile, remediationHintsFile } from "../infra/paths.ts";
+import { appendLineLocked, writeJsonSync, readJsonSync } from "../infra/fs.ts";
 
 export interface RegressionSignal {
   type: "re-read" | "re-question" | "contradiction" | "user-complaint";
@@ -20,6 +20,9 @@ export interface DamageReport {
   signals: RegressionSignal[];
   damageScore: number; // 0 = no damage, 100 = severe damage
   summary: string;
+  /** Distinct file paths the agent re-read after compaction — fed forward as
+   *  remediation hints so the next compaction preserves them. */
+  reReadFiles: string[];
 }
 
 // User complaint patterns indicating compaction may have lost important info
@@ -41,6 +44,7 @@ export function detectDamage(
   details: SmartCompactDetails,
 ): DamageReport {
   const signals: RegressionSignal[] = [];
+  const reReadFiles: string[] = [];
   const compactedFiles = new Set(details.modifiedFiles.map(f => f.toLowerCase()));
   const compactedReadFiles = new Set(details.readFiles.map(f => f.toLowerCase()));
 
@@ -62,6 +66,7 @@ export function detectDamage(
                 severity: "medium",
                 detail: "Agent re-read compacted file: " + fp,
               });
+              if (!reReadFiles.includes(fp)) reReadFiles.push(fp);
             }
           }
         }
@@ -119,6 +124,7 @@ export function detectDamage(
     summary: parts.length
       ? "Damage score: " + damageScore + "/100 — " + parts.join(", ")
       : "No regression signals detected (score: 0)",
+    reReadFiles,
   };
 }
 
@@ -144,4 +150,31 @@ export function logDamageReport(
     // Lock the JSONL append so concurrent pi sessions cannot interleave bytes.
     appendLineLocked(damageReportsFile(), JSON.stringify(entry));
   } catch (e) { log.warn("logDamageReport failed", e); }
+}
+
+const REMEDIATION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Persist the files the agent re-read after a compaction so the NEXT
+ * compaction treats them as must-preserve (remediation). Overwrites with the
+ * latest set; a TTL bounds how long stale hints linger.
+ */
+export function writeRemediationHints(projectId: string, files: string[]): void {
+  if (!files.length) return;
+  const cleaned = [...new Set(files.map(f => (f ?? "").trim()).filter(f => f.length > 0))];
+  if (!cleaned.length) return;
+  try {
+    writeJsonSync(remediationHintsFile(projectId), { files: cleaned, updatedAt: Date.now() });
+  } catch (e) { log.warn("writeRemediationHints failed", e); }
+}
+
+/**
+ * Read remediation hints for a project. Returns [] when absent, malformed,
+ * or older than the TTL.
+ */
+export function readRemediationHints(projectId: string): string[] {
+  const data = readJsonSync<{ files?: unknown; updatedAt?: number }>(remediationHintsFile(projectId));
+  if (!data || !Array.isArray(data.files)) return [];
+  if (typeof data.updatedAt === "number" && Date.now() - data.updatedAt > REMEDIATION_TTL_MS) return [];
+  return data.files.filter((f): f is string => typeof f === "string");
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -88,6 +88,16 @@ export function validateSmartCompactConfig(sc: Record<string, unknown>): void {
       delete sc.minContextPercent;
     }
   }
+  if ("backupDir" in sc && sc.backupDir !== undefined && typeof sc.backupDir !== "string") {
+    log.warn("smart-compact config: backupDir must be a string, got " + typeof sc.backupDir + ". Using default.");
+    delete sc.backupDir;
+  }
+  if ("pinPaths" in sc && sc.pinPaths !== undefined) {
+    if (!Array.isArray(sc.pinPaths) || !sc.pinPaths.every(x => typeof x === "string")) {
+      log.warn("smart-compact config: pinPaths must be a string[], ignoring.");
+      delete sc.pinPaths;
+    }
+  }
 }
 
 // Module-level config cache keyed by file mtime. Kept private so tests cannot
@@ -195,6 +205,81 @@ export function backupConversation(convText: string, sessionId: string): string 
     schedulePruneBackups(dir);
     return fp;
   } catch (e) { log.warn("backupConversation failed", e); return null; }
+}
+
+export interface BackupEntry {
+  path: string;
+  sessionId: string;
+  date: string;
+  sizeBytes: number;
+}
+
+/**
+ * List recent smart-compact backups (newest first), parsing session + date
+ * from each backup's header. Returns [] when the backup dir is absent or
+ * unreadable. Backups were previously write-only; this makes them browsable
+ * for `/smart-compact restore`.
+ */
+export function listBackups(limit = 20): BackupEntry[] {
+  try {
+    const dir = loadConfig().backupDir;
+    if (!fs.existsSync(dir)) return [];
+    const out: BackupEntry[] = [];
+    for (const name of fs.readdirSync(dir)) {
+      if (!name.endsWith(".md")) continue;
+      const full = path.join(dir, name);
+      try {
+        const stat = fs.statSync(full);
+        if (!stat.isFile()) continue;
+        const head = fs.readFileSync(full, "utf-8").split("\n").slice(0, 5).join("\n");
+        const date = head.match(/^# Date:\s*(.+)$/m)?.[1]?.trim();
+        const session = head.match(/^# Session:\s*(.+)$/m)?.[1]?.trim();
+        out.push({
+          path: full,
+          sessionId: session ?? name,
+          date: date ?? stat.mtime.toISOString(),
+          sizeBytes: stat.size,
+        });
+      } catch { /* skip unreadable backup */ }
+    }
+    out.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+    return out.slice(0, limit);
+  } catch (e) { log.warn("listBackups failed", e); return []; }
+}
+
+/**
+ * Read a backup's pre-compaction conversation text, stripping the
+ * `# Smart Compact Backup` header. Returns null if the file can't be read or
+ * the body is empty.
+ */
+export function readBackupContent(fp: string): string | null {
+  try {
+    const raw = fs.readFileSync(fp, "utf-8");
+    const lines = raw.split("\n");
+    let i = 0;
+    while (i < lines.length && lines[i].startsWith("#")) i++;
+    if (i < lines.length && lines[i].trim() === "") i++;
+    return lines.slice(i).join("\n").trim() || null;
+  } catch (e) { log.warn("readBackupContent failed", e); return null; }
+}
+
+/**
+ * Build the custom-message payload used to re-inject a backup's pre-compaction
+ * content when restoring into a new (forked) session. Pure + testable; the
+ * fork/sendMessage wiring lives in the `/smart-compact restore` command.
+ */
+export function buildRestoreMessage(content: string, source: string): {
+  customType: string;
+  content: string;
+  display: boolean;
+  details: { source: string; restoredAt: number };
+} {
+  return {
+    customType: "smart-compact-restore",
+    content: "# Restored pre-compaction context (smart-compact backup)\nSource: " + source + "\n\n" + content,
+    display: true,
+    details: { source, restoredAt: Date.now() },
+  };
 }
 
 export function getPreviousCompactionContext(branch: unknown[]): string {
@@ -503,7 +588,6 @@ export function computeToolCharPercentage(branchEntries: readonly unknown[]): nu
         if (!part || typeof part !== "object") continue;
         const block = part as Record<string, unknown>;
         if (block.type === "text" && typeof block.text === "string") mc += block.text.length;
-        else if (block.type === "text" && typeof block.content === "string") mc += block.content.length;
       }
     }
     totalChars += mc;

--- a/src/utils/session-log.ts
+++ b/src/utils/session-log.ts
@@ -204,20 +204,27 @@ function findSessionLogFile(sessionId: string): string | null {
 
 /**
  * Normalize a log message entry to the LlmMessage shape used by extraction.
+ *
+ * `entryTimestamp` is the ISO timestamp recorded on the surrounding log
+ * entry; we parse it to epoch ms when valid. The previous implementation
+ * stamped `Date.now()` (the recovery wall-clock) gated on whether `content`
+ * was an object — a nonsensical condition that also produced chronologically
+ * wrong values. The field is currently write-only internally, but using the
+ * real timestamp keeps recovered messages consistent with their neighbors.
  */
-function normalizeLogMessage(msg: LogMessage | undefined): LlmMessage | null {
+function normalizeLogMessage(msg: LogMessage | undefined, entryTimestamp?: string): LlmMessage | null {
   if (!msg || !msg.role) return null;
 
   const role = msg.role;
   if (role === "user" || role === "assistant" || role === "toolResult") {
+    const ts = entryTimestamp ? Date.parse(entryTimestamp) : NaN;
     return {
       role: role as LlmMessage["role"],
       content: msg.content,
       isError: msg.isError,
       toolCallId: msg.toolCallId,
-      timestamp: msg.content && typeof msg.content === "object"
-        ? Date.now() // best-effort
-        : undefined,
+      toolName: msg.toolName,
+      timestamp: Number.isFinite(ts) ? ts : undefined,
     };
   }
   // Skip custom/pi-status and other non-LLM roles
@@ -264,7 +271,7 @@ function readOriginalMessageMap(sessionId: string): Map<string, LlmMessage> | nu
         continue;
       }
       if (entry.type === "message" && entry.id && entry.message) {
-        const normalized = normalizeLogMessage(entry.message);
+        const normalized = normalizeLogMessage(entry.message, entry.timestamp);
         if (normalized) map.set(entry.id, normalized);
       }
     }

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -11,7 +11,7 @@ import { inferSessionType } from "./helpers.ts";
 import * as log from "./logger.ts";
 import { compactionStateFile } from "../infra/paths.ts";
 import { writeJsonSync, readJsonSync } from "../infra/fs.ts";
-import { parseSummary, upsertSection, renderSummary } from "../domain/summary-parse.ts";
+import { parseSummary, upsertSection, renderSummary, appendToSection } from "../domain/summary-parse.ts";
 
 function getStatePath(projectId: string): string {
   return compactionStateFile(projectId);
@@ -59,6 +59,12 @@ export function buildCompactionState(
   let constraintId = 0;
   let errorId = 0;
 
+  // Precompute basenames once; previously recomputed for every (error × file) pair.
+  const modifiedBasenames = extraction.modifiedFiles.map(f => ({
+    path: f.path,
+    bn: f.path.split("/").pop()?.toLowerCase() ?? "",
+  }));
+
   return {
     goal: extraction.mainGoal,
     decisions: extraction.decisions.map(d => ({
@@ -77,7 +83,8 @@ export function buildCompactionState(
     readFiles: extraction.readFiles,
     deletedFiles: extraction.deletedFiles,
     unresolvedErrors: extraction.errors.filter(e => !e.resolved).map(e => {
-      const bn = extraction.modifiedFiles.find(f => e.message.toLowerCase().includes(f.path.split("/").pop()?.toLowerCase() ?? "__none__"));
+      const msgLower = e.message.toLowerCase();
+      const bn = modifiedBasenames.find(f => f.bn.length > 0 && msgLower.includes(f.bn));
       return {
         id: "error-" + (++errorId),
         message: e.message.slice(0, 300),
@@ -279,6 +286,27 @@ export function injectDeltaSection(summary: string, delta: CompactionDelta): str
     ? { after: "open-loops" as const }
     : { before: "next-steps" as const };
   const updated = upsertSection(parsed, "changes", body, placement);
+  return renderSummary(updated);
+}
+
+/**
+ * Ensure user-pinned paths ("never compact") appear in the summary. Any pinned
+ * path not already mentioned is appended to the Files Read section so it
+ * survives compaction regardless of what the LLM chose to include. This is a
+ * deterministic, LLM-free guarantee — the pin wins over synthesis output.
+ */
+export function ensurePinnedPaths(summary: string, pinned: readonly string[]): string {
+  if (!pinned.length) return summary;
+  const lower = summary.toLowerCase();
+  const missing = pinned.filter(p => p && p.trim().length > 0 && !lower.includes(p.toLowerCase()));
+  if (!missing.length) return summary;
+  const parsed = parseSummary(summary);
+  const updated = appendToSection(
+    parsed,
+    "files-read",
+    missing.map(p => "- " + p).join("\n"),
+    "- Pinned by config (always preserved):",
+  );
   return renderSummary(updated);
 }
 

--- a/test/ai-messages.test.ts
+++ b/test/ai-messages.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "bun:test";
+import { asBranchMessage, asSerializableMessages } from "../src/infra/ai-messages.ts";
+import type { LlmMessage } from "../src/types.ts";
+
+describe("asBranchMessage", () => {
+  it("returns the same object reference (no defensive copy)", () => {
+    const msg = { role: "user", content: "hi", timestamp: 1 };
+    expect(asBranchMessage(msg)).toBe(msg);
+  });
+
+  it("accepts arbitrary unknown input without throwing", () => {
+    expect(() => asBranchMessage(null)).not.toThrow();
+    expect(() => asBranchMessage({ role: "assistant", content: [] })).not.toThrow();
+  });
+});
+
+describe("asSerializableMessages", () => {
+  it("preserves array length, order, and element identity", () => {
+    const msgs: LlmMessage[] = [
+      { role: "user", content: "a" },
+      { role: "assistant", content: [] },
+      { role: "toolResult", toolCallId: "1", toolName: "read", content: [], isError: false },
+    ];
+    const out = asSerializableMessages(msgs);
+    expect(out.length).toBe(3);
+    expect(out[0]).toBe(msgs[0]);
+    expect(out[2]).toBe(msgs[2]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(asSerializableMessages([])).toEqual([]);
+  });
+});

--- a/test/backup-restore.test.ts
+++ b/test/backup-restore.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { listBackups, readBackupContent, resetConfigCache, buildRestoreMessage } from "../src/utils/helpers.ts";
+
+let prevHome: string | undefined;
+let tmp: string;
+
+beforeEach(() => {
+  prevHome = process.env.HOME;
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "sc-restore-"));
+  process.env.HOME = tmp;
+  resetConfigCache();
+});
+afterEach(() => {
+  process.env.HOME = prevHome;
+  resetConfigCache();
+});
+
+function writeBackup(name: string, date: string, session: string, body: string): string {
+  const dir = path.join(tmp, ".pi", "agent", "compact-backups");
+  fs.mkdirSync(dir, { recursive: true });
+  const fp = path.join(dir, name);
+  fs.writeFileSync(fp, "# Smart Compact Backup\n# Date: " + date + "\n# Session: " + session + "\n\n" + body);
+  return fp;
+}
+
+describe("listBackups", () => {
+  it("returns [] when the backup dir does not exist", () => {
+    expect(listBackups()).toEqual([]);
+  });
+
+  it("lists backups newest-first with parsed metadata", () => {
+    writeBackup("s1-old.md", "2026-06-01T00:00:00.000Z", "s1", "old content");
+    writeBackup("s1-new.md", "2026-06-02T00:00:00.000Z", "s1", "new content");
+    const list = listBackups();
+    expect(list.length).toBe(2);
+    expect(list[0].date).toBe("2026-06-02T00:00:00.000Z");
+    expect(list[1].date).toBe("2026-06-01T00:00:00.000Z");
+    expect(list[0].sessionId).toBe("s1");
+    expect(list[0].sizeBytes).toBeGreaterThan(0);
+    expect(list[0].path).toContain("s1-new.md");
+  });
+
+  it("ignores non-markdown files", () => {
+    writeBackup("s1-x.md", "2026-06-01T00:00:00.000Z", "s1", "x");
+    fs.writeFileSync(path.join(tmp, ".pi", "agent", "compact-backups", "notes.txt"), "junk");
+    expect(listBackups().length).toBe(1);
+  });
+
+  it("falls back to filename when the header lacks a session", () => {
+    const dir = path.join(tmp, ".pi", "agent", "compact-backups");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "orphan.md"), "# Smart Compact Backup\nno proper header here\n\nbody");
+    const list = listBackups();
+    expect(list.length).toBe(1);
+    expect(list[0].sessionId).toBe("orphan.md");
+  });
+});
+
+describe("readBackupContent", () => {
+  it("strips the backup header and returns the conversation body", () => {
+    const fp = writeBackup("s1.md", "2026-06-01T00:00:00.000Z", "s1", "## Goal\nDo the thing.\n\nMore body.");
+    expect(readBackupContent(fp)).toBe("## Goal\nDo the thing.\n\nMore body.");
+  });
+
+  it("returns null for a missing file", () => {
+    expect(readBackupContent(path.join(tmp, "nope.md"))).toBeNull();
+  });
+
+  it("returns null for an empty body", () => {
+    const fp = writeBackup("empty.md", "2026-06-01T00:00:00.000Z", "s1", "");
+    expect(readBackupContent(fp)).toBeNull();
+  });
+});
+
+describe("buildRestoreMessage", () => {
+  it("wraps content with a restore header and tags the source", () => {
+    const m = buildRestoreMessage("## Goal\nDo thing.", "/path/bk.md");
+    expect(m.customType).toBe("smart-compact-restore");
+    expect(m.display).toBe(true);
+    expect(m.content).toContain("Restored pre-compaction context");
+    expect(m.content).toContain("## Goal\nDo thing.");
+    expect(m.details.source).toBe("/path/bk.md");
+    expect(typeof m.details.restoredAt).toBe("number");
+  });
+
+  it("preserves the original content verbatim (no truncation)", () => {
+    const body = "line1\nline2\nline3";
+    expect(buildRestoreMessage(body, "x").content).toContain(body);
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -119,6 +119,42 @@ describe("validateSmartCompactConfig", () => {
   it("has default minContextPercent of 60", () => {
     expect(DEFAULT_CONFIG.minContextPercent).toBe(60);
   });
+
+  it("deletes invalid backupDir (number)", () => {
+    const sc = { backupDir: 123 };
+    validateSmartCompactConfig(sc);
+    expect("backupDir" in sc).toBe(false);
+  });
+
+  it("deletes invalid backupDir (boolean)", () => {
+    const sc = { backupDir: true };
+    validateSmartCompactConfig(sc);
+    expect("backupDir" in sc).toBe(false);
+  });
+
+  it("keeps valid backupDir", () => {
+    const sc = { backupDir: "/custom/backup/dir" };
+    validateSmartCompactConfig(sc);
+    expect(sc.backupDir).toBe("/custom/backup/dir");
+  });
+
+  it("deletes invalid pinPaths (non-array)", () => {
+    const sc = { pinPaths: "src/a.ts" };
+    validateSmartCompactConfig(sc);
+    expect("pinPaths" in sc).toBe(false);
+  });
+
+  it("deletes invalid pinPaths (mixed types)", () => {
+    const sc = { pinPaths: ["src/a.ts", 42] };
+    validateSmartCompactConfig(sc);
+    expect("pinPaths" in sc).toBe(false);
+  });
+
+  it("keeps valid pinPaths", () => {
+    const sc = { pinPaths: ["src/auth.ts", "README.md"] };
+    validateSmartCompactConfig(sc);
+    expect(sc.pinPaths).toEqual(["src/auth.ts", "README.md"]);
+  });
 });
 
 describe("computeToolCharPercentage", () => {
@@ -131,6 +167,17 @@ describe("computeToolCharPercentage", () => {
       { message: { role: "toolResult", content: [{ type: "text", text: "tool" }] } },
     ];
     expect(computeToolCharPercentage(branch)).toBe(Math.round(4 / (9 + 4) * 100));
+  });
+
+  it("counts text blocks via .text and ignores a stray .content field", () => {
+    // A text block carries its payload in `.text`; a sibling `.content` must
+    // not be counted (guards against the removed dead branch).
+    const branch = [
+      { message: { role: "toolResult", content: [{ type: "text", text: "abc", content: "XXXXXXXXXXXXXXXXXX" }] } },
+    ];
+    // total = 3 (only .text "abc"), tool = 3 → 100%. If .content were
+    // counted, total would include the Xs and the share would drop.
+    expect(computeToolCharPercentage(branch)).toBe(100);
   });
 });
 

--- a/test/damage.test.ts
+++ b/test/damage.test.ts
@@ -78,6 +78,8 @@ describe("detectDamage", () => {
     const reReads = report.signals.filter(s => s.type === "re-read");
     expect(reReads).toHaveLength(1);
     expect(reReads[0].severity).toBe("medium");
+    // Remediation: the re-read path is collected for the next compaction.
+    expect(report.reReadFiles).toEqual(["src/auth.ts"]);
     // The score should reflect a medium-severity signal (10 points).
     expect(report.damageScore).toBe(10);
     expect(report.summary).toContain("1 re-read");
@@ -98,6 +100,7 @@ describe("detectDamage", () => {
     const report = detectDamage(messages, makeDetails());
     expect(report.signals.filter(s => s.type === "re-read")).toHaveLength(0);
     expect(report.damageScore).toBe(0);
+    expect(report.reReadFiles).toEqual([]);
   });
 
   it("detects a user complaint as a high-severity signal", () => {

--- a/test/exploration.test.ts
+++ b/test/exploration.test.ts
@@ -61,6 +61,55 @@ describe("buildExplorationReportFromParsed", () => {
   });
 });
 
+describe("buildExplorationReportFromParsed — boundary normalization", () => {
+  const fourMsgs: LlmMessage[] = [1, 2, 3, 4].map(() => ({ role: "user", content: "x" }));
+
+  it("clamps a negative afterIndex up to 0", () => {
+    const report = buildExplorationReportFromParsed(
+      { boundaries: [{ afterIndex: -5, topic: "X", priority: "normal", confidence: 0.5 }] }, [],
+    );
+    expect(report.boundaries[0].afterIndex).toBe(0);
+  });
+
+  it("clamps afterIndex down to llmLength - 2", () => {
+    const report = buildExplorationReportFromParsed(
+      { boundaries: [{ afterIndex: 100, topic: "X", priority: "normal", confidence: 0.5 }] }, fourMsgs,
+    );
+    // fourMsgs.length = 4 → maxIndex = max(0, 4 - 2) = 2
+    expect(report.boundaries[0].afterIndex).toBe(2);
+  });
+
+  it("falls back to 0.5 confidence when confidence is non-numeric", () => {
+    const report = buildExplorationReportFromParsed(
+      { boundaries: [{ afterIndex: 1, topic: "X", priority: "normal", confidence: "high" }] }, [],
+    );
+    expect(report.boundaries[0].confidence).toBe(0.5);
+  });
+
+  it("clamps a numeric confidence into [0, 1]", () => {
+    const over = buildExplorationReportFromParsed(
+      { boundaries: [{ afterIndex: 1, topic: "X", priority: "normal", confidence: 5 }] }, [],
+    );
+    expect(over.boundaries[0].confidence).toBe(1);
+    const under = buildExplorationReportFromParsed(
+      { boundaries: [{ afterIndex: 1, topic: "X", priority: "normal", confidence: -3 }] }, [],
+    );
+    expect(under.boundaries[0].confidence).toBe(0);
+  });
+
+  it("defaults an invalid priority to normal", () => {
+    const report = buildExplorationReportFromParsed(
+      { boundaries: [{ afterIndex: 1, topic: "X", priority: "urgent", confidence: 0.5 }] }, [],
+    );
+    expect(report.boundaries[0].priority).toBe("normal");
+  });
+
+  it("returns empty mainGoal for a non-string value", () => {
+    const report = buildExplorationReportFromParsed({ mainGoal: 42 }, []);
+    expect(report.mainGoal).toBe("");
+  });
+});
+
 describe("fallbackExplorationReport", () => {
   it("extracts main goal from messages", () => {
     const msgs: LlmMessage[] = [

--- a/test/pinned.test.ts
+++ b/test/pinned.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "bun:test";
+import { ensurePinnedPaths } from "../src/utils/state.ts";
+
+const BASE = "## Goal\nDo the thing.\n\n## Files Modified\n- src/a.ts\n\n## Files Read\n- lib/b.ts\n";
+
+describe("ensurePinnedPaths", () => {
+  it("returns the summary unchanged when no paths are pinned", () => {
+    expect(ensurePinnedPaths(BASE, [])).toBe(BASE);
+  });
+
+  it("is a no-op when every pinned path is already mentioned", () => {
+    expect(ensurePinnedPaths(BASE, ["src/a.ts", "lib/b.ts"])).toBe(BASE);
+  });
+
+  it("is case-insensitive when checking presence", () => {
+    // BASE already mentions src/a.ts; a differently-cased pin must not duplicate it.
+    expect(ensurePinnedPaths(BASE, ["SRC/A.TS"])).toBe(BASE);
+  });
+
+  it("appends missing pinned paths to Files Read", () => {
+    const out = ensurePinnedPaths(BASE, ["src/auth.ts", "config/secrets.env"]);
+    expect(out.toLowerCase()).toContain("src/auth.ts");
+    expect(out.toLowerCase()).toContain("config/secrets.env");
+    // existing structure preserved
+    expect(out).toContain("## Goal");
+    expect(out).toContain("## Files Modified");
+  });
+
+  it("creates a Files Read section when absent", () => {
+    const noRead = "## Goal\nDo the thing.\n\n## Files Modified\n- src/a.ts\n";
+    const out = ensurePinnedPaths(noRead, ["pinned/x.ts"]);
+    expect(out.toLowerCase()).toContain("pinned/x.ts");
+    expect(out).toContain("## Files Read");
+  });
+
+  it("skips empty / whitespace-only pinned entries", () => {
+    const out = ensurePinnedPaths(BASE, ["", "   ", "real/file.ts"]);
+    expect(out.toLowerCase()).toContain("real/file.ts");
+    // empty entries must not produce empty bullets
+    expect(out.match(/^- $/m)).toBeNull();
+    expect(out.match(/^- {2,}$/m)).toBeNull();
+  });
+});

--- a/test/remediation.test.ts
+++ b/test/remediation.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { writeRemediationHints, readRemediationHints } from "../src/utils/damage.ts";
+
+// Per-test HOME swap so remediation hint files never touch the user's real
+// ~/.pi/agent/.cache (mirrors backup-prune.test.ts / fingerprint.test.ts).
+let prevHome: string | undefined;
+let tmp: string;
+const PID = "proj-test-remediation";
+
+beforeEach(() => {
+  prevHome = process.env.HOME;
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "sc-rem-"));
+  process.env.HOME = tmp;
+});
+afterEach(() => {
+  process.env.HOME = prevHome;
+});
+
+describe("remediation hints", () => {
+  it("returns [] when no hints have been written", () => {
+    expect(readRemediationHints(PID)).toEqual([]);
+  });
+
+  it("writeRemediationHints is a no-op for empty input (no file created)", () => {
+    writeRemediationHints(PID, []);
+    expect(readRemediationHints(PID)).toEqual([]);
+  });
+
+  it("round-trips a set of re-read files, deduped and trimmed", () => {
+    writeRemediationHints(PID, ["src/a.ts", "src/a.ts", "  lib/b.ts  ", ""]);
+    expect(readRemediationHints(PID)).toEqual(["src/a.ts", "lib/b.ts"]);
+  });
+
+  it("overwrites (does not accumulate) on a subsequent write", () => {
+    writeRemediationHints(PID, ["src/a.ts", "lib/b.ts"]);
+    writeRemediationHints(PID, ["src/c.ts"]);
+    expect(readRemediationHints(PID)).toEqual(["src/c.ts"]);
+  });
+
+  it("returns [] when the cache file is malformed", () => {
+    fs.mkdirSync(path.join(tmp, ".pi", "agent", ".cache", "smart-compact"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, ".pi", "agent", ".cache", "smart-compact", "remediation-" + PID + ".json"),
+      "{ not valid json",
+    );
+    expect(readRemediationHints(PID)).toEqual([]);
+  });
+});

--- a/test/synthesize-fallback.test.ts
+++ b/test/synthesize-fallback.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "bun:test";
+import { assembleFallback, failedChunkSummary } from "../src/phases/synthesize.ts";
+import type { StructuredExtraction, ChunkSummary, LlmChunk, LlmMessage } from "../src/types.ts";
+
+function makeExtraction(partial: Partial<StructuredExtraction> = {}): StructuredExtraction {
+  return {
+    modifiedFiles: [], readFiles: [], deletedFiles: [],
+    errors: [], decisions: [], constraints: [], topics: [], timeline: [],
+    mainGoal: null, lastUserMessages: [], lastErrors: [], messageCount: 0,
+    ...partial,
+  };
+}
+
+const SECTIONS = [
+  "## Goal", "## Constraints & Preferences", "## Progress", "### Done",
+  "### In Progress", "### Blocked", "## Key Decisions", "## Files Modified",
+  "## Files Read", "## Next Steps", "## Critical Context", "## Topics Covered",
+];
+
+describe("assembleFallback (deterministic fallback when LLM assembly fails)", () => {
+  it("produces a complete structured summary even with empty input", () => {
+    const out = assembleFallback([], makeExtraction());
+    expect(out.startsWith("## Goal")).toBe(true);
+    for (const h of SECTIONS) expect(out).toContain(h);
+  });
+
+  it("uses the extracted mainGoal and falls back to a placeholder when absent", () => {
+    expect(assembleFallback([], makeExtraction({ mainGoal: "Ship auth" }))).toContain("Ship auth");
+    expect(assembleFallback([], makeExtraction({ mainGoal: null }))).toContain("See topics below.");
+  });
+
+  it("includes deterministically-extracted modified and read files", () => {
+    const out = assembleFallback([], makeExtraction({
+      modifiedFiles: [{ path: "src/a.ts", toolCalls: 1, lastModifiedIndex: 0 }],
+      readFiles: ["lib/b.ts"],
+    }));
+    expect(out).toContain("- src/a.ts");
+    expect(out).toContain("- lib/b.ts");
+  });
+
+  it("surfaces unresolved errors in Critical Context and high-priority topics in Progress", () => {
+    const summaries: ChunkSummary[] = [
+      { topic: "Auth", startIndex: 0, endIndex: 3, summary: "wiring jwt", keyDecisions: [], filesModified: [], filesRead: [], priority: "high" },
+      { topic: "Docs", startIndex: 4, endIndex: 6, summary: "readme", keyDecisions: [], filesModified: [], filesRead: [], priority: "low" },
+    ];
+    const out = assembleFallback(summaries, makeExtraction({
+      errors: [{ index: 2, tool: "bash", message: "test failed", retryAttempted: false, resolved: false }],
+    }));
+    expect(out).toContain("Unresolved error: test failed");
+    expect(out).toContain("wiring jwt");
+    expect(out).toContain("**Auth** [high]");
+    expect(out).toContain("**Docs** [low]");
+  });
+
+  it("preserves key decisions from extraction", () => {
+    const out = assembleFallback([], makeExtraction({
+      decisions: [{ index: 1, type: "explicit", summary: "Use JWT", userResponse: "yes" }],
+    }));
+    expect(out).toContain("Use JWT");
+  });
+});
+
+describe("failedChunkSummary (per-segment fallback when a batch LLM call fails)", () => {
+  const chunk: LlmChunk = {
+    topic: "Auth work", startIndex: 0, endIndex: 3, tokenEstimate: 100, priority: "high",
+    messages: [
+      { role: "user", content: "add login" } as LlmMessage,
+      { role: "assistant", content: [{ type: "text", text: "ok doing it" }] } as LlmMessage,
+    ],
+  };
+
+  it("preserves identity fields (topic / range / priority)", () => {
+    const s = failedChunkSummary(chunk);
+    expect(s.topic).toBe("Auth work");
+    expect(s.startIndex).toBe(0);
+    expect(s.endIndex).toBe(3);
+    expect(s.priority).toBe("high");
+  });
+
+  it("prefixes the summary with [Failed] and carries message text", () => {
+    const s = failedChunkSummary(chunk);
+    expect(s.summary.startsWith("[Failed]")).toBe(true);
+    expect(s.summary).toContain("add login");
+    expect(s.summary).toContain("ok doing it");
+  });
+
+  it("returns empty decision/file lists (nothing was successfully parsed)", () => {
+    const s = failedChunkSummary(chunk);
+    expect(s.keyDecisions).toEqual([]);
+    expect(s.filesModified).toEqual([]);
+    expect(s.filesRead).toEqual([]);
+  });
+
+  it("truncates very long message text to keep the placeholder bounded", () => {
+    const long: LlmChunk = {
+      ...chunk,
+      messages: [{ role: "user", content: "x".repeat(1000) } as LlmMessage],
+    };
+    const s = failedChunkSummary(long);
+    // "[Failed] " (9) + up to 300 chars of content
+    expect(s.summary.length).toBeLessThanOrEqual(9 + 300);
+  });
+});

--- a/test/type-guards.test.ts
+++ b/test/type-guards.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from "bun:test";
+import {
+  isTextBlock,
+  isToolCallBlock,
+  getToolCallNames,
+  filterToolCalls,
+  isValidSmartCompactDetails,
+  sanitizeSmartCompactDetails,
+} from "../src/utils/type-guards.ts";
+import type { SmartCompactDetails } from "../src/types.ts";
+
+/** A fully-populated details object that passes the validator. */
+function validDetails(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    method: "eesv",
+    chunkCount: 3,
+    topics: ["auth", "db"],
+    readFiles: ["a.ts"],
+    modifiedFiles: ["b.ts", "c.ts"],
+    totalMessages: 100,
+    totalTokensSummarized: 5000,
+    llmCalls: 4,
+    profile: "balanced",
+    backupPath: null,
+    tokensSaved: 2000,
+    verified: true,
+    gaps: [],
+    explorationRounds: 2,
+    explorationBoundaries: 3,
+    model: "anthropic/claude-sonnet-4",
+    qualityScore: 90,
+    tokensBefore: 7000,
+    ...overrides,
+  };
+}
+
+// ── Content block guards ────────────────────────────────────────────────────
+
+describe("isTextBlock", () => {
+  it("accepts a well-formed text block", () => {
+    expect(isTextBlock({ type: "text", text: "hello" })).toBe(true);
+  });
+  it("rejects non-object input", () => {
+    expect(isTextBlock(null)).toBe(false);
+    expect(isTextBlock("text")).toBe(false);
+    expect(isTextBlock(42)).toBe(false);
+    expect(isTextBlock(undefined)).toBe(false);
+  });
+  it("rejects wrong type discriminator", () => {
+    expect(isTextBlock({ type: "toolCall", text: "x" })).toBe(false);
+    expect(isTextBlock({ type: "image" })).toBe(false);
+  });
+  it("rejects when text is not a string", () => {
+    expect(isTextBlock({ type: "text", text: 123 })).toBe(false);
+    expect(isTextBlock({ type: "text" })).toBe(false);
+  });
+});
+
+describe("isToolCallBlock", () => {
+  it("accepts a well-formed tool call block", () => {
+    expect(isToolCallBlock({ type: "toolCall", name: "write", arguments: {} })).toBe(true);
+    expect(isToolCallBlock({ type: "toolCall", id: "1", name: "edit", arguments: { x: 1 } })).toBe(true);
+  });
+  it("rejects non-object input", () => {
+    expect(isToolCallBlock(null)).toBe(false);
+    expect(isToolCallBlock([])).toBe(false);
+  });
+  it("rejects wrong type discriminator", () => {
+    expect(isToolCallBlock({ type: "text", name: "x" })).toBe(false);
+  });
+  it("rejects when name is not a string", () => {
+    expect(isToolCallBlock({ type: "toolCall", arguments: {} })).toBe(false);
+    expect(isToolCallBlock({ type: "toolCall", name: 5, arguments: {} })).toBe(false);
+  });
+});
+
+describe("getToolCallNames / filterToolCalls", () => {
+  const content = [
+    { type: "text", text: "hi" },
+    { type: "toolCall", id: "1", name: "write", arguments: { path: "a" } },
+    { type: "toolCall", id: "2", name: "bash", arguments: { command: "ls" } },
+    { type: "text", text: "bye" },
+  ];
+  it("getToolCallNames returns only tool-call names in order", () => {
+    expect(getToolCallNames(content)).toEqual(["write", "bash"]);
+  });
+  it("getToolCallNames returns [] for non-array input", () => {
+    expect(getToolCallNames(null)).toEqual([]);
+    expect(getToolCallNames("x")).toEqual([]);
+    expect(getToolCallNames(undefined)).toEqual([]);
+  });
+  it("filterToolCalls returns only tool-call blocks", () => {
+    const out = filterToolCalls(content);
+    expect(out.length).toBe(2);
+    expect(out[0].name).toBe("write");
+    expect(out[1].name).toBe("bash");
+    expect(out[0].arguments).toEqual({ path: "a" });
+  });
+  it("filterToolCalls returns [] for non-array input", () => {
+    expect(filterToolCalls({})).toEqual([]);
+  });
+});
+
+// ── SmartCompactDetails validators (safety-critical for damage detection) ───
+
+describe("isValidSmartCompactDetails", () => {
+  it("accepts a fully-populated valid details object", () => {
+    expect(isValidSmartCompactDetails(validDetails())).toBe(true);
+  });
+  it("accepts a minimal object (only required fields)", () => {
+    expect(isValidSmartCompactDetails({
+      method: "heuristic",
+      profile: "aggressive",
+      qualityScore: 50,
+      totalMessages: 10,
+      modifiedFiles: [],
+      readFiles: [],
+      topics: [],
+    })).toBe(true);
+  });
+  it("accepts backupPath as null or string", () => {
+    expect(isValidSmartCompactDetails(validDetails({ backupPath: null }))).toBe(true);
+    expect(isValidSmartCompactDetails(validDetails({ backupPath: "/tmp/x.md" }))).toBe(true);
+  });
+
+  // Non-object rejection
+  it("rejects null, primitives, arrays", () => {
+    expect(isValidSmartCompactDetails(null)).toBe(false);
+    expect(isValidSmartCompactDetails(undefined)).toBe(false);
+    expect(isValidSmartCompactDetails("string")).toBe(false);
+    expect(isValidSmartCompactDetails(42)).toBe(false);
+    expect(isValidSmartCompactDetails([])).toBe(false);
+  });
+
+  // Required string-array fields (detectDamage iterates these → crash risk)
+  it("rejects missing/non-array modifiedFiles", () => {
+    expect(isValidSmartCompactDetails(validDetails({ modifiedFiles: undefined }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ modifiedFiles: "a.ts" }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ modifiedFiles: [1, 2] }))).toBe(false);
+  });
+  it("rejects missing/non-array readFiles", () => {
+    expect(isValidSmartCompactDetails(validDetails({ readFiles: undefined }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ readFiles: {} }))).toBe(false);
+  });
+  it("rejects missing/non-array topics", () => {
+    expect(isValidSmartCompactDetails(validDetails({ topics: undefined }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ topics: [42] }))).toBe(false);
+  });
+
+  // Enum fields
+  it("rejects unknown / non-string method", () => {
+    expect(isValidSmartCompactDetails(validDetails({ method: "magic" }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ method: 5 }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ method: undefined }))).toBe(false);
+  });
+  it("rejects unknown / non-string profile", () => {
+    expect(isValidSmartCompactDetails(validDetails({ profile: "turbo" }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ profile: null }))).toBe(false);
+  });
+
+  // Numeric fields
+  it("rejects missing / NaN / Infinity qualityScore", () => {
+    expect(isValidSmartCompactDetails(validDetails({ qualityScore: undefined }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ qualityScore: NaN }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ qualityScore: Infinity }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ qualityScore: "90" }))).toBe(false);
+  });
+  it("rejects missing / non-finite totalMessages", () => {
+    expect(isValidSmartCompactDetails(validDetails({ totalMessages: undefined }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ totalMessages: NaN }))).toBe(false);
+  });
+
+  // Optional-but-typed fields: present-and-wrong-type must reject
+  it("rejects present-but-wrong-type gaps", () => {
+    expect(isValidSmartCompactDetails(validDetails({ gaps: "not-array" }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ gaps: [1, 2] }))).toBe(false);
+    // missing gaps is fine
+    const { gaps: _drop, ...withoutGaps } = validDetails() as Record<string, unknown>;
+    expect(isValidSmartCompactDetails(withoutGaps)).toBe(true);
+  });
+  it("rejects present-but-non-boolean verified", () => {
+    expect(isValidSmartCompactDetails(validDetails({ verified: "yes" }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ verified: 1 }))).toBe(false);
+  });
+  it("rejects present-but-non-string non-null backupPath", () => {
+    expect(isValidSmartCompactDetails(validDetails({ backupPath: 42 }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ backupPath: false }))).toBe(false);
+  });
+});
+
+describe("sanitizeSmartCompactDetails", () => {
+  it("passes a valid object through unchanged (same reference)", () => {
+    const d = validDetails();
+    expect(sanitizeSmartCompactDetails(d)).toBe(d);
+  });
+  it("returns null for null / primitives / arrays", () => {
+    expect(sanitizeSmartCompactDetails(null)).toBe(null);
+    expect(sanitizeSmartCompactDetails(undefined)).toBe(null);
+    expect(sanitizeSmartCompactDetails("x")).toBe(null);
+    expect(sanitizeSmartCompactDetails(42)).toBe(null);
+    expect(sanitizeSmartCompactDetails([])).toBe(null);
+  });
+  it("returns null when the required string arrays are absent", () => {
+    expect(sanitizeSmartCompactDetails({ method: "eesv", profile: "balanced" })).toBe(null);
+    expect(sanitizeSmartCompactDetails({ modifiedFiles: "a.ts", readFiles: [], topics: [] })).toBe(null);
+    expect(sanitizeSmartCompactDetails({ modifiedFiles: [1], readFiles: [], topics: [] })).toBe(null);
+  });
+
+  it("repairs a legacy entry: arrays present, enums/numbers missing → safe defaults", () => {
+    const legacy = {
+      modifiedFiles: ["src/a.ts"],
+      readFiles: ["lib/b.ts"],
+      topics: ["auth"],
+      // method/profile/qualityScore/totalMessages all missing
+    };
+    const repaired = sanitizeSmartCompactDetails(legacy) as SmartCompactDetails | null;
+    expect(repaired).not.toBeNull();
+    expect(repaired!.method).toBe("heuristic");
+    expect(repaired!.profile).toBe("balanced");
+    expect(repaired!.qualityScore).toBe(0);
+    expect(repaired!.totalMessages).toBe(0);
+    expect(repaired!.model).toBe("unknown");
+    expect(repaired!.backupPath).toBeNull();
+    expect(repaired!.verified).toBe(false);
+    expect(repaired!.gaps).toEqual([]);
+    // preserved arrays
+    expect(repaired!.modifiedFiles).toEqual(["src/a.ts"]);
+    expect(repaired!.readFiles).toEqual(["lib/b.ts"]);
+    expect(repaired!.topics).toEqual(["auth"]);
+  });
+
+  it("coerces invalid enums to the safe defaults", () => {
+    const repaired = sanitizeSmartCompactDetails({
+      modifiedFiles: [], readFiles: [], topics: [],
+      method: "superturbo", profile: "ultra",
+    }) as SmartCompactDetails | null;
+    expect(repaired).not.toBeNull();
+    expect(repaired!.method).toBe("heuristic");
+    expect(repaired!.profile).toBe("balanced");
+  });
+
+  it("keeps valid enums and numbers during repair", () => {
+    const repaired = sanitizeSmartCompactDetails({
+      modifiedFiles: [], readFiles: [], topics: [],
+      method: "single-pass", profile: "light",
+      qualityScore: 77, totalMessages: 42, tokensSaved: 100, llmCalls: 3,
+      model: "openai/gpt-x", verified: true, backupPath: "/x.md",
+    }) as SmartCompactDetails | null;
+    expect(repaired).not.toBeNull();
+    expect(repaired!.method).toBe("single-pass");
+    expect(repaired!.profile).toBe("light");
+    expect(repaired!.qualityScore).toBe(77);
+    expect(repaired!.totalMessages).toBe(42);
+    expect(repaired!.tokensSaved).toBe(100);
+    expect(repaired!.llmCalls).toBe(3);
+    expect(repaired!.model).toBe("openai/gpt-x");
+    expect(repaired!.verified).toBe(true);
+    expect(repaired!.backupPath).toBe("/x.md");
+  });
+
+  it("the repaired result always passes isValidSmartCompactDetails", () => {
+    const repaired = sanitizeSmartCompactDetails({
+      modifiedFiles: ["a"], readFiles: ["b"], topics: ["c"],
+    });
+    expect(repaired).not.toBeNull();
+    expect(isValidSmartCompactDetails(repaired)).toBe(true);
+  });
+});


### PR DESCRIPTION
## v7.16.0 — minor release (3 new features, backward-compatible)

Verified green before opening: **typecheck exit 0 · 493 tests (414 → +79) · build**.

### Added
- **Pinned never-compact context** (`smartCompact.pinPaths`) — deterministic `ensurePinnedPaths` in `buildState`
- **Damage auto-remediation** — `reReadFiles` → remediation hints → re-preserve next compaction (closed loop)
- **`/smart-compact restore`** — list + view + fork-inject backups

### Fixed
- session-log timestamp (was `Date.now()` + dropped `toolName`)
- `batches[0]` empty-list guard, `backupDir` config validation, result-screen timer cleanup, negative boundary clamp, `computeToolCharPercentage` dead branch, `ctx.ui.notify` invalid `"success"` type, state.ts basename perf

### Changed
- **Message cast normalization** — explore loop builds native `Message[]`; recover/persist/extract use documented `asBranchMessage`/`asSerializableMessages` adapters (removes lossy casts + silent metadata drop)
- **Tools cast normalization** — `EXPLORATION_TOOLS` as native `Tool[]` via typebox (wire-identical, behavior-preserving)
- `any` → `unknown` in exploration parsing; `failedChunkSummary` co-located + exported

### Build
- pi runtime peers resolved 0.79.4 → 0.79.6; typebox 1.2.11 → 1.2.16 (lockfile). `*` wildcard ranges preserved (7.15.0 policy).

### Tests
- +79: type-guards validators, synthesize fallbacks, ai-messages adapters, pinned paths, remediation hints, backup restore, exploration normalization

### Docs
- README/ARCHITECTURE/CONTRIBUTING/SECURITY/SUPPORT/RELEASE/COC redesign + banner.svg

After merge: tag `v7.16.0` on the merge commit + GitHub release.