### PR TITLE
docs: document v7.16.0 features + restore tab-completion

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,7 +168,7 @@ reusable state.
 | Damage detection | `utils/damage.ts` | best-effort post-compaction regression signals |
 
 **Important TTLs:** pending in-memory compaction 5 min · exploration
-tool-support cache 30 min · extraction cache 1 h · compaction state 7 d.
+tool-support cache 30 min · extraction cache 1 h · compaction state 7 d · remediation hints 7 d.
 
 ## Concurrency & safety model
 
@@ -306,6 +306,7 @@ All external-world interaction.
 | `infra/llm-retry.ts` | 429/5xx exponential backoff + jitter + Retry-After |
 | `infra/services.ts` | per-run services container |
 | `infra/session-identity.ts` | robust session-id resolution with opaque `unresolved:` fallback |
+| `infra/ai-messages.ts` | boundary adapters between `LlmMessage` and pi-ai `Message` |
 
 ### Utility layer (`src/utils/`)
 
@@ -313,11 +314,11 @@ All external-world interaction.
 | --- | --- |
 | `utils/extraction.ts` | deterministic fact extraction (files, errors, decisions) |
 | `utils/pruning.ts` | redundancy removal on the message list |
-| `utils/state.ts` | structured state, open loops, delta |
-| `utils/helpers.ts` | config, backups, batching, shared helpers |
+| `utils/state.ts` | structured state, open loops, delta, pinned-path preservation |
+| `utils/helpers.ts` | config, backups, batching, shared helpers, backup list/restore |
 | `utils/cache.ts` | metrics log + extraction prefix cache + dashboards |
 | `utils/fingerprint.ts` | project fingerprinting (language, framework, deps) |
-| `utils/damage.ts` | post-compaction regression signals |
+| `utils/damage.ts` | post-compaction regression signals + remediation hints |
 | `utils/id-fingerprint.ts` | compact SHA-256 fingerprint of entry-id arrays |
 | `utils/file-needles.ts` | path-suffix needles for error→file attribution |
 | `utils/file-ref-detect.ts` | fabricated file-reference detection (SemVer-rejecting) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ src/
     steps/                 10 stage modules (prepare … metrics)
   domain/             pure semantics, no I/O (summary schema + parse)
   phases/             algorithms (explore / synthesize / verify)
-  infra/              external-world interaction (fs, git, services, llm, …)
+  infra/              external-world interaction + boundary adapters (fs, git, services, llm, ai-messages, …)
   ui/                 TUI overlays + dashboard
   utils/              focused helpers (extraction, state, tokens, cache, …)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ pi install git:github.com/alpertarhan/pi-smart-compact
 /smart-compact "focus on auth + unresolved follow-ups"
 /smart-compact metrics                      # profile / provider comparison
 /smart-compact dashboard                    # interactive TUI dashboard
+/smart-compact restore                      # list + view + restore backups
 ```
 
 Or let the agent call it as a tool on long sessions:
@@ -175,6 +176,7 @@ Add to `~/.pi/agent/settings.json`:
 | `backupEnabled` | `boolean` | `true` |
 | `backupDir` | `string` | `~/.pi/agent/compact-backups` |
 | `profiles` | per-profile overrides | built-ins |
+| `pinPaths` | `string[]` | `[]` (paths always preserved) |
 
 ### Profiles
 
@@ -194,10 +196,12 @@ The legacy config key `semanticCompact` is still accepted.
 - Verification scoring with deterministic patching **before** LLM patching
 - Hallucinated file-reference detection (SemVer-aware)
 - Open-loop injection + cross-compaction delta tracking
+- Pinned-path preservation (`pinPaths`) — a deterministic, LLM-free guarantee
+- Damage auto-remediation — re-read files feed forward and get re-preserved next compaction
 
 **Safety**
 
-- Conversation backups before compaction (retention-pruned)
+- Conversation backups before compaction (retention-pruned), browsable + restorable via `/smart-compact restore`
 - `toolCall` / `toolResult` pair integrity at the compaction boundary
 - Cross-session leak guard on the pending summary
 - Session-log recovery that bypasses truncation of older tool results
@@ -246,6 +250,7 @@ The extension writes under `~/.pi/agent/`:
 | `.cache/smart-compact/projects/<projectId>.json` | project fingerprint |
 | `.cache/smart-compact/states/<projectId>.json` | reusable compaction state |
 | `.cache/smart-compact/damage-reports.jsonl` | regression signals |
+| `.cache/smart-compact/remediation-<projectId>.json` | files to re-preserve after damage |
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,9 +89,9 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
   const isRunning: Cell<boolean> = { value: false };
 
   pi.registerCommand("smart-compact", {
-    description: "EESV smart compaction v" + VERSION + ". Usage: /smart-compact [model] [light|balanced|aggressive] [verbose|debug|dry-run] [note]",
+    description: "EESV smart compaction v" + VERSION + ". Usage: /smart-compact [model] [light|balanced|aggressive] [verbose|debug|dry-run|restore|metrics|dashboard] [note]",
     getArgumentCompletions: (prefix: string) => {
-      const m = ["verbose", "debug", "dry-run", "metrics", "dashboard", "light", "balanced", "aggressive"].filter(o => o.startsWith(prefix)).map(o => ({ value: o, label: o }));
+      const m = ["verbose", "debug", "dry-run", "metrics", "dashboard", "restore", "light", "balanced", "aggressive"].filter(o => o.startsWith(prefix)).map(o => ({ value: o, label: o }));
       return m.length ? m : null;
     },
     handler: async (args, ctx) => {


### PR DESCRIPTION
Folds the missed doc updates into v7.16.0 (not yet on npm):
- README: pinPaths, /smart-compact restore, damage auto-remediation, remediation-hints artifact
- index.ts: restore tab-completion + command description (UX gap fix)
- ARCHITECTURE/CONTRIBUTING: ai-messages.ts + updated function descriptions

After merge: move v7.16.0 tag here (folding in, since v7.16.0 is not yet published to npm).