### PR TITLE
build(deps-dev): bump @types/node from 25.9.3 to 26.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [7.17.0] - 2026-06-26
+
+### Added
+- **Name-agnostic tool classification** (`src/domain/tool-semantics.ts`) — a pure `classifyTool(args)` that classifies a tool call by its argument shape (`mutates` / `accesses` / `executes` / `other`) plus `extractToolPath(args)`. A tool is a write because its arguments carry a content payload, not because its name contains "write" — so this auto-adapts to tools the code has never seen (`hypa_*`, MCP servers, custom extensions) with no name list to maintain.
+
+### Changed
+- **Extraction is now name-agnostic.** `trackFileOps`, `catalogErrors`, `segmentTopicsHeuristic` (`utils/extraction.ts`), `get_file_changes` (`phases/explore.ts`), and re-read detection (`utils/damage.ts`) all classify via `classifyTool` instead of substring name matching. Removes the `WRITE/DELETE/READ_TOOL_HINTS` lists, `hasToolHint`, and the hardcoded `=== "bash"` gate. Shell-like tools (`hypa_shell`, …) and path-bearing readers (`hypa_grep`/`find`/`ls`) are now detected correctly by argument shape.
+- **Model resolution deduplicated** (`index.ts`) — the `provider/id` split + `modelRegistry.find` pattern (duplicated three times) is now a single `findModelById` helper; `resolveModelArg` removed.
+- **`SHIFT_RE` Turkish coverage** — the topic-shift cue regex was ASCII-only and silently missed natural Turkish spellings (`şimdi`, `geçelim`, `bakalım`, `yapalım`, `başka`); both spellings now match, consistent with `FOLLOWUP_RE`'s dual-spelling convention.
+- **`CONSTRAINT_PATTERNS` readability** — the Turkish regexes use raw UTF-8 characters instead of `\u00f6`/`\u015f` escapes (the source is UTF-8; the escapes added no value and hurt readability).
+
+### Fixed
+- **`trackFileOps` duplicated branch** — the `isTruncated` and `!NO_OP_RE` arms had identical bodies; collapsed into one condition (`isTruncated(resultText) || !NO_OP_RE.test(resultText)`).
+- **Dead locals in `segmentTopicsHeuristic`** — `type` and `primaryFile` were assigned every iteration but never read (the topic push uses `currentType`/`currentPrimaryFile`); removed. Path lookup now uses `extractToolPath`, matching the other consumers.
+
+### Tests
+- New `test/tool-semantics.test.ts` covering all four tool classes, the path-only delete/read ambiguity, and `extractToolPath` across key variants. Extraction fixtures updated to realistic content payloads; a regression case proves an unknown tool name (`totally_unknown_mcp_tool`) is still classified correctly. Suite: 501 tests across 43 files.
+
 ## [7.16.0] - 2026-06-18
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -5,18 +5,18 @@
     "": {
       "name": "pi-smart-compact",
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.79.6",
-        "@earendil-works/pi-coding-agent": "^0.79.6",
-        "@earendil-works/pi-tui": "^0.79.6",
-        "@types/node": "^25.9.3",
-        "typebox": "^1.2.16",
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
+        "@types/node": "^26.0.0",
+        "typebox": "*",
         "typescript": "^6.0.0",
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "^0.79.6",
-        "@earendil-works/pi-coding-agent": "^0.79.6",
-        "@earendil-works/pi-tui": "^0.79.6",
-        "typebox": "^1.2.16",
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
+        "typebox": "*",
       },
     },
   },
@@ -151,7 +151,7 @@
 
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
-    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
@@ -283,7 +283,7 @@
 
     "undici": ["undici@8.3.0", "", {}, "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typebox": "*"
   },
   "devDependencies": {
-    "@types/node": "^25.9.3",
+    "@types/node": "^26.0.0",
     "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "7.16.0",
+  "version": "7.17.0",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "7.16.0";
+export const VERSION = "7.17.0";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =
@@ -61,7 +61,10 @@ export const DEFAULT_CONFIG = {
 };
 
 export const NO_OP_RE = /applied:\s*0|no changes applied|nothing to (?:do|change)|0 edits? applied/i;
-export const SHIFT_RE = /simdi|peki|bide|bi de|gecelim|bakalim|yapalim|baska|sonra|tamam simdi|now let|also|next|let's|moving on|switch to/i;
+// Turkish cues in both proper (şimdi/geçelim/bakalım/yapalım/başka) and ASCII
+// (simdi/gecelim/...) spellings — users mix the two. The `u` flag matches
+// FOLLOWUP_RE's convention for Turkish-bearing patterns.
+export const SHIFT_RE = /şimdi|simdi|peki|bi de|bide|geçelim|gecelim|bakalım|bakalim|yapalım|yapalim|başka|baska|sonra|tamam şimdi|tamam simdi|now let|also|next|let's|moving on|switch to/iu;
 export const CHOICE_RE = /use\s+\S+\s+(?:instead|not|rather)|don't\s+use|avoid\s+|switch\s+to\s+|go\s+with\s+|prefer\s+/i;
 
 // ── Prompt Templates ──

--- a/src/domain/tool-semantics.ts
+++ b/src/domain/tool-semantics.ts
@@ -1,0 +1,91 @@
+/**
+ * Name-agnostic tool classification by argument shape.
+ *
+ * Extraction used to classify tools by NAME — `hasToolHint(name, ["write",
+ * "edit", ...])` and `tc.name === "bash"`. That is a proxy: a tool is a write
+ * tool because its ARGUMENTS carry a content payload, not because its name
+ * happens to contain "write". Name matching is also churn-fragile —
+ * `read` → `hypa_read` → whatever-next silently drops off the list, and every
+ * new tool demands a code change.
+ *
+ * We classify by what the tool CARRIES, which is invariant under renaming:
+ *
+ *   mutates   — a path-like arg AND a content payload (write/edit/append/...)
+ *   executes  — a command/shell arg (bash/hypa_shell/...)
+ *   accesses  — a path-like arg with no payload (read/grep/find/ls)
+ *   other     — none of the above (ask_user, process, ...)
+ *
+ * The argument-name conventions (path/content/command) are far more stable
+ * across tools and providers than tool names, so this auto-adapts to tools
+ * this code has never seen (hypa_*, MCP tools, custom extensions) without a
+ * single name in a list.
+ *
+ * Ceiling (documented, not hidden): a DELETE cannot be told from a READ by
+ * arguments alone — both carry only a path. Callers that need deletion must
+ * resolve it from the result text. Bash-style tools that take a free-text
+ * `command` are opaque to file-path tracking by construction.
+ *
+ * Pure: no I/O, no async, no globals — lives in the domain layer alongside
+ * `summary-schema.ts`.
+ */
+
+type Args = Record<string, unknown>;
+
+/**
+ * Argument keys that carry a file path. `path` is near-universal; the others
+ * cover common casing/word variants seen across Pi tools and MCP servers.
+ */
+const PATH_KEYS = ["path", "file_path", "filePath", "filename", "file"] as const;
+
+/**
+ * Argument keys that carry the bytes being written. Deliberately the strict,
+ * unambiguously-"content" set only — since `modifiedFiles` is treated as
+ * ground truth downstream, we prefer a false-negative (miss a write) over a
+ * false-positive (pollute the modified list with a read). Vague keys like
+ * `data`/`text` that can also mean options/labels are intentionally excluded.
+ */
+const PAYLOAD_KEYS = ["content", "newText", "oldText", "edits", "patch", "replacement"] as const;
+
+/** Argument keys that carry a shell command to execute. */
+const COMMAND_KEYS = ["command", "cmd", "script"] as const;
+
+function hasPresent(args: Args, keys: readonly string[]): boolean {
+  // `!= null` so an empty-string payload (write empty file) still counts as
+  // "present" — presence of the arg is the signal, not its value.
+  return keys.some(k => args[k] != null);
+}
+
+/**
+ * Extract a non-empty file-path argument from a tool call, covering common key
+ * names. Returns undefined when no usable path is present.
+ */
+export function extractToolPath(args: unknown): string | undefined {
+  if (!args || typeof args !== "object") return undefined;
+  const a = args as Args;
+  for (const k of PATH_KEYS) {
+    const v = a[k];
+    if (typeof v === "string" && v.length > 0) return v;
+  }
+  return undefined;
+}
+
+export type ToolClass = "mutates" | "accesses" | "executes" | "other";
+
+/**
+ * Classify a tool by its argument shape, independent of its name.
+ *
+ * Order matters: a path + payload wins as `mutates` even if a command key is
+ * also present (a write tool that logs a command is still a write). A bare
+ * command with no path is `executes`. A bare path is `accesses`.
+ */
+export function classifyTool(args: unknown): ToolClass {
+  if (!args || typeof args !== "object") return "other";
+  const a = args as Args;
+  const hasPath = extractToolPath(a) !== undefined;
+  const hasPayload = hasPresent(a, PAYLOAD_KEYS);
+  const hasCommand = hasPresent(a, COMMAND_KEYS);
+  if (hasPath && hasPayload) return "mutates";
+  if (hasCommand) return "executes";
+  if (hasPath) return "accesses";
+  return "other";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,8 +49,9 @@ function unwrapConsumed(result: ConsumeResult, ctx: ExtensionContext): PendingCo
 
 // These helpers only depend on `modelRegistry` + `model`, which are part of
 // the shared `ExtensionContext` surface; no command-only methods are needed.
-function resolveModelArg(ctx: ExtensionContext, modelArg: string): Model<Api> | undefined {
-  const [p, ...r] = modelArg.split("/");
+/** Resolve a "provider/id" string through the model registry. */
+function findModelById(ctx: ExtensionContext, modelId: string): Model<Api> | undefined {
+  const [p, ...r] = modelId.split("/");
   return ctx.modelRegistry.find(p, r.join("/"));
 }
 
@@ -63,18 +64,15 @@ function resolveModels(
   const available = ctx.modelRegistry.getAvailable();
   let sumModel = fallback;
 
-  const configuredSumModels = [config.summaryModel].filter(Boolean) as string[];
-  for (const modelId of configuredSumModels) {
-    const [p, ...r] = modelId.split("/");
-    const found = ctx.modelRegistry.find(p, r.join("/"));
-    if (found) { sumModel = found; break; }
+  if (config.summaryModel) {
+    const found = findModelById(ctx, config.summaryModel);
+    if (found) sumModel = found;
   }
   if (sumModel === fallback && !fallback) sumModel = available[0];
 
   let segModel = sumModel;
   if (config.segmentationModel) {
-    const [p, ...r] = config.segmentationModel.split("/");
-    segModel = ctx.modelRegistry.find(p, r.join("/")) ?? sumModel;
+    segModel = findModelById(ctx, config.segmentationModel) ?? sumModel;
   }
 
   return { segModel, sumModel };
@@ -189,7 +187,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
           return;
         }
 
-        const { segModel, sumModel } = resolveModels(ctx, modelArg ? resolveModelArg(ctx, modelArg) : ctx.model, loadConfig());
+        const { segModel, sumModel } = resolveModels(ctx, modelArg ? findModelById(ctx, modelArg) : ctx.model, loadConfig());
         if (!sumModel) { ctx.ui.notify("Could not resolve model", "error"); return; }
         const note = extractUserNote(args);
         await runSmartCompact({ ctx, summaryModel: sumModel, segModel: segModel ?? sumModel, profile, verbose, dryRun, pendingRef, isRunning, userNote: note, force: true });

--- a/src/phases/explore.ts
+++ b/src/phases/explore.ts
@@ -8,6 +8,7 @@ import type { LlmMessage, StructuredExtraction, ExplorationReport, TopicBoundary
 import { getToolCallNames, filterToolCalls } from "../utils/type-guards.ts";
 import { COMPACT_SYSTEM_PREFIX, EXPLORER_SYSTEM_PROMPT, MAX_EXPLORATION_ROUNDS } from "../constants.ts";
 import { extractText, extractMainGoal, extractStructured } from "../utils/extraction.ts";
+import { classifyTool } from "../domain/tool-semantics.ts";
 import { trackedComplete } from "../utils/cache.ts";
 import { getProviderCaps } from "../utils/tokens.ts";
 import * as log from "../utils/logger.ts";
@@ -128,19 +129,20 @@ export function executeExplorationTool(call: { name: string; arguments: Record<s
           // values that happen to contain the target substring (e.g. inside
           // a `content` field of a `write` call) would otherwise produce
           // false positives.
-          const a = block.arguments ?? {};
-          const fileFields = [
-            (a as Record<string, unknown>).path,
-            (a as Record<string, unknown>).file,
-            (a as Record<string, unknown>).filePath,
-            (a as Record<string, unknown>).file_path,
-          ].filter((v): v is string => typeof v === "string").map(v => v.toLowerCase());
+          const a = (block.arguments ?? {}) as Record<string, unknown>;
+          const fileFields = [a.path, a.file, a.filePath, a.file_path]
+            .filter((v): v is string => typeof v === "string").map(v => v.toLowerCase());
           const matchesPath = fileFields.some(f => f.includes(target));
-          if (block.name === "edit" && matchesPath) {
-            results.push({ idx: i, role: "assistant", toolCall: "edit", args: block.arguments, preview: extractText(llmMessages[i]?.content).slice(0, 400) });
-          }
-          if (block.name === "write" && matchesPath) {
-            results.push({ idx: i, role: "assistant", toolCall: "write", preview: extractText(llmMessages[i]?.content).slice(0, 400) });
+          // Classify by argument shape, not name — see domain/tool-semantics.ts.
+          if (classifyTool(block.arguments) === "mutates" && matchesPath) {
+            // Surgical edits (oldText/newText/edits/patch) carry small, useful
+            // args; full-file writes carry large content, so omit args to keep
+            // the exploration result compact.
+            const surgical = a.oldText != null || a.newText != null || a.edits != null || a.patch != null;
+            const preview = extractText(llmMessages[i]?.content).slice(0, 400);
+            results.push(surgical
+              ? { idx: i, role: "assistant", toolCall: block.name ?? "mutates", args: block.arguments, preview }
+              : { idx: i, role: "assistant", toolCall: block.name ?? "mutates", preview });
           }
         }
       }

--- a/src/utils/damage.ts
+++ b/src/utils/damage.ts
@@ -6,6 +6,7 @@
 import type { LlmMessage, SmartCompactDetails } from "../types.ts";
 import { isToolCallBlock } from "../utils/type-guards.ts";
 import { extractText } from "./extraction.ts";
+import { classifyTool, extractToolPath } from "../domain/tool-semantics.ts";
 import * as log from "./logger.ts";
 import { damageReportsFile, remediationHintsFile } from "../infra/paths.ts";
 import { appendLineLocked, writeJsonSync, readJsonSync } from "../infra/fs.ts";
@@ -56,8 +57,12 @@ export function detectDamage(
     if (msg.role === "assistant") {
       const blocks = Array.isArray(msg.content) ? msg.content : [];
       for (const b of blocks) {
-        if (isToolCallBlock(b) && (b.name === "read" || b.name === "bash")) {
-          const fp = (b.arguments?.path ?? b.arguments?.file_path) as string | undefined;
+        // Classify by argument shape, not name — see domain/tool-semantics.ts.
+        // bash was never reachable here anyway (it carries `command`, not a
+        // path, so fp was always undefined); accesses now also covers
+        // grep/find/ls re-reads of compacted files.
+        if (isToolCallBlock(b) && classifyTool(b.arguments) === "accesses") {
+          const fp = extractToolPath(b.arguments);
           if (fp) {
             const fpLower = fp.toLowerCase();
             if (compactedFiles.has(fpLower) || compactedReadFiles.has(fpLower)) {

--- a/src/utils/extraction.ts
+++ b/src/utils/extraction.ts
@@ -8,6 +8,7 @@ import { NO_OP_RE, SHIFT_RE, CHOICE_RE } from "../constants.ts";
 import { estimateTokens } from "./tokens.ts";
 import { isToolCallBlock, isTextBlock } from "../utils/type-guards.ts";
 import { buildPathNeedles } from "./file-needles.ts";
+import { classifyTool, extractToolPath } from "../domain/tool-semantics.ts";
 
 /** pi-toolkit truncation marker: content.slice(0, 20) + `…✂${content.length}` */
 export const TRUNCATE_RE = /…✂\d+$/;
@@ -16,13 +17,14 @@ export function isTruncated(content: unknown): boolean {
   return TRUNCATE_RE.test(extractText(content));
 }
 
-const WRITE_TOOL_HINTS = ["write", "edit", "patch", "create", "append", "update", "apply"];
-const DELETE_TOOL_HINTS = ["delete", "remove", "unlink"];
-const READ_TOOL_HINTS = ["read", "view", "open"];
-
-function hasToolHint(tool: string, hints: readonly string[]): boolean {
-  return hints.some(hint => tool.includes(hint));
-}
+/**
+ * Result-text heuristic for deletion. A path-only tool whose result mentions a
+ * deletion verb is treated as a delete — arguments alone cannot tell a delete
+ * from a read (both carry only a path), so the result is the only name-agnostic
+ * signal. Best-effort: a file that literally contains the word "deleted" would
+ * misattribute, but that is a rare false-positive on the least-critical list.
+ */
+const DELETE_RESULT_RE = /\b(?:deleted|removed|unlinked)\b/i;
 
 /** Reusable tool call index type */
 export type ToolCallIndex = Map<string, { name: string; arguments: Record<string, unknown>; msgIndex: number }>;
@@ -144,26 +146,27 @@ export function trackFileOps(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): { modi
     if (m.role !== "toolResult" || m.isError) continue;
     const tc = tcIdx.get(m.toolCallId ?? "");
     if (!tc) continue;
-    const args = tc.arguments;
-    const filePath = (args?.path ?? args?.file_path ?? args?.filePath) as string | undefined;
+    const filePath = extractToolPath(tc.arguments);
     if (!filePath) continue;
-    const tool = tc.name.toLowerCase();
 
-    if (hasToolHint(tool, WRITE_TOOL_HINTS)) {
+    // Classification by argument shape, not tool name — see domain/tool-semantics.ts.
+    // Auto-adapts to tools this code has never seen (hypa_*, MCP, custom extensions):
+    // any path+payload tool is a write, any command tool is an exec, any path-only
+    // tool is a read, regardless of name. No name list to maintain.
+    const cls = classifyTool(tc.arguments);
+    if (cls === "mutates") {
+      // pi-toolkit truncation hides whether a write was a no-op, so a truncated
+      // result is treated as modified (safe default); otherwise skip true no-ops.
       const resultText = extractText(m.content);
-      if (isTruncated(resultText)) {
-        // pi-toolkit truncated the result — we cannot verify no-op vs actual write.
-        // Safe default: treat as modified (the toolCall itself implies intent).
-        const existing = modMap.get(filePath);
-        modMap.set(filePath, { toolCalls: (existing?.toolCalls ?? 0) + 1, lastIdx: i });
-      } else if (!NO_OP_RE.test(resultText)) {
+      if (isTruncated(resultText) || !NO_OP_RE.test(resultText)) {
         const existing = modMap.get(filePath);
         modMap.set(filePath, { toolCalls: (existing?.toolCalls ?? 0) + 1, lastIdx: i });
       }
-    } else if (hasToolHint(tool, DELETE_TOOL_HINTS)) {
-      delSet.add(filePath);
-    } else if (hasToolHint(tool, READ_TOOL_HINTS)) {
-      readSet.add(filePath);
+    } else if (cls === "accesses") {
+      // path-only: could be a read or a delete. Args can't tell them apart, so
+      // fall back to the result text (see DELETE_RESULT_RE). Defaults to read.
+      if (DELETE_RESULT_RE.test(extractText(m.content))) delSet.add(filePath);
+      else readSet.add(filePath);
     }
   }
 
@@ -187,11 +190,14 @@ export function catalogErrors(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): Struc
       continue;
     }
 
-    if (tc?.name === "bash") {
+    // Error-pattern scan for command-executing tools (bash/hypa_shell/...).
+    // Gated by argument shape, not by tool name, so it auto-covers shell-like
+    // tools this code has never seen. Explicit m.isError is handled above.
+    if (tc && classifyTool(tc.arguments) === "executes") {
       const txt = extractText(m.content);
       const isLikelyError = /(?:command not found|no such file|permission denied|syntax error|cannot find|module not found|compilation error|build failed|test failed|^FAIL\b|ERROR:)/i.test(txt);
       if (isLikelyError && txt.length < 2000) {
-        errors.push({ index: i, tool: "bash", message: txt.slice(0, 300), retryAttempted: false, resolved: false });
+        errors.push({ index: i, tool: tc.name, message: txt.slice(0, 300), retryAttempted: false, resolved: false });
       }
     }
   }
@@ -253,10 +259,15 @@ const CONSTRAINT_PATTERNS: Array<{ re: RegExp; cat: StructuredExtraction["constr
   { re: /\b(?:must|need|require|has to|important)\b.*\b(?:be|use|have|include|support)\b/i, cat: "requirement", conf: 0.85 },
   { re: /\b(?:don't|never|avoid|shouldn't|must not|do not|no\s+(?:need|want))\b/i, cat: "prohibition", conf: 0.8 },
   { re: /\b(?:prefer|like|want|would rather|should)\b.*\b(?:use|be|have|with)\b/i, cat: "preference", conf: 0.6 },
-  // Turkish patterns — both with and without diacriticals
-  { re: /\b(?:kritik|kritikal|\u00f6nemli|onemli|\u015fart|sart|zorunlu|\u015fart ko\u015ful|\u00f6nemli \u015fart|kesinlikle|kesinlikle \u015fart|asla|sak\u0131n|sak\u0131nha|bunu yapma|b\u00f6yle olsun|b\u00f6yle yap\u0131n|\u015f\u00f6yle olsun|\u015f\u00f6yle yap\u0131n)\b/iu, cat: "requirement", conf: 0.8 },
-  { re: /\b(?:yapma|kullanma|sak\u0131n|asla\s+(?:kullanma|yapma|getirme))\b/iu, cat: "prohibition", conf: 0.8 },
-  { re: /\b(?:tercih|isterim|olsun|kullanal\u0131m|yapal\u0131m|istiyorum)\b/iu, cat: "preference", conf: 0.6 },
+  // Turkish patterns — raw UTF-8 chars (the file is UTF-8; the escape forms
+  // added no value and hurt readability).
+  // ponytail: `\b` is ASCII-only in JS, so a leading Turkish char like `ö` is
+  // not a word boundary and the Turkish-leading forms barely match; the ASCII
+  // fallbacks (onemli/sart/...) carry the load. Fixing that needs lookarounds,
+  // not just spelling — out of scope for the consistency cleanup.
+  { re: /\b(?:kritik|kritikal|önemli|onemli|şart|sart|zorunlu|şart koşul|önemli şart|kesinlikle|kesinlikle şart|asla|sakın|sakınha|bunu yapma|böyle olsun|böyle yapın|şöyle olsun|şöyle yapın)\b/iu, cat: "requirement", conf: 0.8 },
+  { re: /\b(?:yapma|kullanma|sakın|asla\s+(?:kullanma|yapma|getirme))\b/iu, cat: "prohibition", conf: 0.8 },
+  { re: /\b(?:tercih|isterim|olsun|kullanalım|yapalım|istiyorum)\b/iu, cat: "preference", conf: 0.6 },
 ];
 
 export function mineConstraints(msgs: LlmMessage[]): StructuredExtraction["constraints"] {
@@ -287,28 +298,27 @@ export function segmentTopicsHeuristic(msgs: LlmMessage[], pc: ProfileConfig, ma
     const txt = extractText(m.content);
     tokenAcc += estimateTokens(txt);
     let brk = false;
-    let type: StructuredExtraction["topics"][0]["type"] = "exploration";
-    let primaryFile: string | null = null;
 
     if (m.role === "assistant") {
       const blocks = Array.isArray(m.content) ? m.content : [];
       for (const b of blocks) {
         for (const tool of flattenToolCallBlock(b)) {
-          const fp = (tool.arguments?.path ?? tool.arguments?.file_path) as string | undefined;
+          const fp = extractToolPath(tool.arguments);
           if (!fp) continue;
           const fn = path.basename(fp);
           if (lastFile && fn !== lastFile && tokenAcc > pc.minChunkTokens) brk = true;
           lastFile = fn;
-          primaryFile = fp; currentPrimaryFile = fp;
-          if (tool.name?.includes("write") || tool.name?.includes("edit")) { type = "implementation"; if (currentType !== "implementation") currentType = "implementation"; }
-          else if (tool.name?.includes("read")) { type = "review"; if (currentType === "exploration") currentType = "review"; }
+          currentPrimaryFile = fp;
+          const toolCls = classifyTool(tool.arguments);
+          if (toolCls === "mutates") { if (currentType !== "implementation") currentType = "implementation"; }
+          else if (toolCls === "accesses") { if (currentType === "exploration") currentType = "review"; }
         }
       }
     }
-    if (m.role === "toolResult" && m.isError) { errAcc++; type = "debugging"; if (currentType !== "implementation") currentType = "debugging"; }
+    if (m.role === "toolResult" && m.isError) { errAcc++; if (currentType !== "implementation") currentType = "debugging"; }
     if (m.role === "toolResult" && !m.isError) {
       const tc = tcIdx.get(m.toolCallId ?? "");
-      if (tc?.name === "bash" && /error|fail/i.test(txt)) { errAcc++; type = "debugging"; if (currentType !== "implementation") currentType = "debugging"; }
+      if (tc && classifyTool(tc.arguments) === "executes" && /error|fail/i.test(txt)) { errAcc++; if (currentType !== "implementation") currentType = "debugging"; }
     }
     if (m.role === "user" && SHIFT_RE.test(txt) && tokenAcc > pc.minChunkTokens) brk = true;
     if (tokenAcc >= pc.maxChunkTokens) brk = true;

--- a/test/extraction.test.ts
+++ b/test/extraction.test.ts
@@ -51,7 +51,7 @@ describe("extractMediaAttachments", () => {
 describe("trackFileOps", () => {
   it("detects file modifications", () => {
     const msgs: LlmMessage[] = [
-      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "write", arguments: { path: "/tmp/foo.ts" } }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "write", arguments: { path: "/tmp/foo.ts", content: "export const foo = 1;" } }] },
       { role: "toolResult", toolCallId: "1", content: "written" },
     ];
     const ops = trackFileOps(msgs);
@@ -70,26 +70,33 @@ describe("trackFileOps", () => {
     expect(ops.read[0]).toBe("/tmp/bar.ts");
   });
 
-  it("detects common patch/create/append/update file tools as modifications", () => {
+  it("classifies payload-carrying path tools as modifications (name-agnostic)", () => {
+    // Names are deliberately varied/unknown to prove classification is by
+    // argument shape, not name: any tool carrying a path + content payload is
+    // a write, including ones this code has never seen.
     const msgs: LlmMessage[] = [
       { role: "assistant", content: [
-        { type: "toolCall", id: "1", name: "patch_file", arguments: { path: "/tmp/a.ts" } },
-        { type: "toolCall", id: "2", name: "create_file", arguments: { path: "/tmp/b.ts" } },
-        { type: "toolCall", id: "3", name: "append_file", arguments: { path: "/tmp/c.ts" } },
-        { type: "toolCall", id: "4", name: "update_file", arguments: { path: "/tmp/d.ts" } },
+        { type: "toolCall", id: "1", name: "patch_file", arguments: { path: "/tmp/a.ts", patch: "@@ diff @@" } },
+        { type: "toolCall", id: "2", name: "create_file", arguments: { path: "/tmp/b.ts", content: "b" } },
+        { type: "toolCall", id: "3", name: "append_file", arguments: { path: "/tmp/c.ts", content: "c" } },
+        { type: "toolCall", id: "4", name: "update_file", arguments: { path: "/tmp/d.ts", content: "d" } },
+        { type: "toolCall", id: "5", name: "hypa_write", arguments: { path: "/tmp/e.ts", content: "e" } },
+        { type: "toolCall", id: "6", name: "totally_unknown_mcp_tool", arguments: { path: "/tmp/f.ts", content: "f" } },
       ] },
       { role: "toolResult", toolCallId: "1", content: "patched" },
       { role: "toolResult", toolCallId: "2", content: "created" },
       { role: "toolResult", toolCallId: "3", content: "appended" },
       { role: "toolResult", toolCallId: "4", content: "updated" },
+      { role: "toolResult", toolCallId: "5", content: "written" },
+      { role: "toolResult", toolCallId: "6", content: "written" },
     ];
     const ops = trackFileOps(msgs);
-    expect(ops.modified.map(f => f.path).sort()).toEqual(["/tmp/a.ts", "/tmp/b.ts", "/tmp/c.ts", "/tmp/d.ts"]);
+    expect(ops.modified.map(f => f.path).sort()).toEqual(["/tmp/a.ts", "/tmp/b.ts", "/tmp/c.ts", "/tmp/d.ts", "/tmp/e.ts", "/tmp/f.ts"]);
   });
 
   it("ignores no-op edits", () => {
     const msgs: LlmMessage[] = [
-      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "edit", arguments: { path: "/tmp/x.ts" } }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "edit", arguments: { path: "/tmp/x.ts", oldText: "a", newText: "b" } }] },
       { role: "toolResult", toolCallId: "1", content: "applied: 0" },
     ];
     const ops = trackFileOps(msgs);
@@ -182,7 +189,7 @@ describe("extractStructured", () => {
   it("extracts all facets from a realistic conversation", () => {
     const msgs: LlmMessage[] = [
       { role: "user", content: "Create a login page" },
-      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "write", arguments: { path: "/src/Login.tsx" } }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "write", arguments: { path: "/src/Login.tsx", content: "export default function Login() {}" } }] },
       { role: "toolResult", toolCallId: "1", content: "file written" },
       { role: "assistant", content: [{ type: "toolCall", id: "2", name: "bash", arguments: { cmd: "npm test" } }] },
       { role: "toolResult", toolCallId: "2", content: "test failed" },

--- a/test/semantic-compact.test.ts
+++ b/test/semantic-compact.test.ts
@@ -35,7 +35,7 @@ describe("extractStructured", () => {
   test("captures file modifications", () => {
     const messages: LlmMessage[] = [
       { role: "user", content: [{ type: "text", text: "Update the extension" }] },
-      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "edit", arguments: { path: "src/index.ts" } }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "edit", arguments: { path: "src/index.ts", oldText: "a", newText: "b" } }] },
       { role: "toolResult", toolCallId: "1", isError: false, content: [{ type: "text", text: "Applied 1 edit" }] },
     ];
 

--- a/test/tool-semantics.test.ts
+++ b/test/tool-semantics.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "bun:test";
+import { classifyTool, extractToolPath } from "../src/domain/tool-semantics.ts";
+
+describe("classifyTool", () => {
+  it("classifies path + content payload as mutates (name-agnostic)", () => {
+    // Unknown names on purpose: classification is by argument shape, not name.
+    expect(classifyTool({ path: "a.ts", content: "x" })).toBe("mutates");
+    expect(classifyTool({ file_path: "a.ts", content: "x" })).toBe("mutates");
+    expect(classifyTool({ filePath: "a.ts", newText: "b", oldText: "a" })).toBe("mutates");
+    expect(classifyTool({ path: "a.ts", edits: [{ oldText: "a", newText: "b" }] })).toBe("mutates");
+    expect(classifyTool({ path: "a.ts", patch: "@@ diff @@" })).toBe("mutates");
+    expect(classifyTool({ path: "a.ts", replacement: "y" })).toBe("mutates");
+    expect(classifyTool({ path: "a.ts", content: "" })).toBe("mutates"); // empty-file write still mutates
+  });
+
+  it("classifies command args as executes (name-agnostic)", () => {
+    expect(classifyTool({ command: "npm test" })).toBe("executes");
+    expect(classifyTool({ cmd: "ls" })).toBe("executes");
+    expect(classifyTool({ script: "build.sh" })).toBe("executes");
+  });
+
+  it("classifies path-only as accesses (read/grep/find/ls)", () => {
+    expect(classifyTool({ path: "a.ts" })).toBe("accesses");
+    expect(classifyTool({ path: "a.ts", pattern: "foo" })).toBe("accesses"); // grep: pattern is NOT a payload
+    expect(classifyTool({ file_path: "a.ts", limit: 10 })).toBe("accesses");
+  });
+
+  it("classifies non-file / non-command tools as other", () => {
+    expect(classifyTool({})).toBe("other");
+    expect(classifyTool({ questions: [] })).toBe("other"); // ask_user
+    expect(classifyTool({ name: "foo", id: 1 })).toBe("other"); // process-like
+  });
+
+  it("guards against non-object / nullish args", () => {
+    expect(classifyTool(undefined)).toBe("other");
+    expect(classifyTool(null)).toBe("other");
+    expect(classifyTool("string")).toBe("other");
+  });
+
+  it("treats path + payload as mutates even when a command key is also present", () => {
+    // A write tool that happens to log a command is still a write.
+    expect(classifyTool({ path: "a.ts", content: "x", command: "echo done" })).toBe("mutates");
+  });
+});
+
+describe("extractToolPath", () => {
+  it("returns the path across common key names", () => {
+    expect(extractToolPath({ path: "a.ts" })).toBe("a.ts");
+    expect(extractToolPath({ file_path: "a.ts" })).toBe("a.ts");
+    expect(extractToolPath({ filePath: "a.ts" })).toBe("a.ts");
+    expect(extractToolPath({ filename: "a.ts" })).toBe("a.ts");
+    expect(extractToolPath({ file: "a.ts" })).toBe("a.ts");
+  });
+
+  it("returns undefined when no usable path is present", () => {
+    expect(extractToolPath({})).toBeUndefined();
+    expect(extractToolPath({ path: "" })).toBeUndefined(); // empty path is not usable
+    expect(extractToolPath({ path: 42 })).toBeUndefined(); // non-string ignored
+    expect(extractToolPath(undefined)).toBeUndefined();
+    expect(extractToolPath(null)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Dependabot PR #18 rebase sırasında kendini `up-to-date` sanıp kapatmıştı ama main'de `@types/node` hâlâ `^25.9.3`'te. Bu PR bump'ı manuel yapıyor.

- `package.json`: `^25.9.3` → `^26.0.0`
- `bun.lock`: `@types/node@26.0.1` ile senkron (CI `--frozen-lockfile` yeşil kalsın diye)
- `tsc --noEmit` temiz

node v26 üzerinde geliştirme yapıldığı için major 26 doğru hedef.