### PR TITLE
EESV hardening: bug fixes, zero magic values, shared abstractions (v7.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [7.18.0] - 2026-06-26
+
+### Fixed
+- **`mergeExtractions` mainGoal corruption** — incremental extraction replaced the original goal with a delta-suffix message; now prefers `base.mainGoal`.
+- **`mergeExtractions` boundary gap** — `lastUserMessages`/`lastErrors` now span the cache boundary instead of dropping base's tail.
+- **`catalogErrors` id-less retry** — retry resolution falls back to tool-name match when the retry call lacks an id.
+- **Pruning hides errors** — short error-containing tool outputs preserved from 800-char truncation (shared `LIKELY_ERROR_RE`).
+- **`computeDelta` collision** — prefix-slice keys collided different items sharing an opening; now full-normalized text.
+- **`smartKeepBoundary` dead regex** — `path="..."` never matched agent output; replaced with toolCall-arg file extraction.
+- **`buildCompactionState` basename** — raw basename → `buildPathNeedles` (generic-basename gate, consistent with `extractOpenLoops`).
+- **`extractNextActions`/`Critical`** — case-sensitive regex → canonical `findSection`.
+- **`CONSTRAINT_PATTERNS`** — `\b` → lookarounds so Turkish-leading chars (`önemli`, `şart`) match.
+- **`verifySummary` fuzzy** — salient-token keyword extraction; error snippet whitespace-normalized.
+- **`estimateTokens` JSON** — density fallback for non-brace-first JSON (capped at 8KB).
+
+### Added
+- **`domain/keywords.ts`** — `extractCheckKeywords` (shared by verify + damage).
+- **Centralized constants** — `TRUNC` (truncation budgets), `ID_PREFIX`, `TUNING` (EMA/clamp/confidence), shared durations, `EXTRACTION_CACHE_PREFIX`, `LIKELY_ERROR_RE`.
+
+### Changed
+- **Zero inline magic values** — ~70 truncation literals, ID prefixes, confidence scores, TTL duplications (7d×3, 1h×2), and tuning factors centralized into named constants.
+- **`makeCompactSessionId`** — single source (services.ts); cache.ts fallback deduped.
+- **`damage.ts` re-question** — shared `extractCheckKeywords` (threshold relaxed for high-precision salient tokens).
+
 ## [7.17.0] - 2026-06-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "7.17.0";
+export const VERSION = "7.18.0";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =
@@ -168,18 +168,84 @@ export const MAX_EXPLORATION_ROUNDS = 8;
 export const BACKUP_MAX_FILES = 20;
 export const BACKUP_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 
-// ── Truncation lengths used by extraction and damage paths ──
-//
-// These were scattered as inline magic numbers (`slice(0, 100)`,
-// `slice(0, 60)`). Centralizing them documents intent and lets tests assert
-// against the same constant the production code uses.
-export const SUMMARY_SNIPPET_LEN = 100;
-export const SHORT_SUMMARY_LEN = 60;
-export const ERROR_FUZZY_MATCH_LEN = 30;
+// ── Shared durations (eliminate duplicated 7d×3 / 1h×2 inline literals) ──
+export const FIVE_MINUTES_MS = 5 * 60 * 1000;
+export const ONE_HOUR_MS = 60 * 60 * 1000;
+export const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+export const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+// ── Extraction-cache filename prefix (paths.ts builds it, cache.ts prunes by it) ──
+export const EXTRACTION_CACHE_PREFIX = "compact-extraction-";
+
+// ── ID prefixes (were inline string literals scattered across modules) ──
+export const ID_PREFIX = {
+  PROJECT: "proj-",
+  COMPACT_SESSION: "sc-",
+  MULTI_TOOL_USE_SYNTHETIC: "mtu_",
+  OPEN_LOOP: "loop-",
+  DECISION: "decision-",
+  ERROR: "error-",
+} as const;
+
+// ── Tuning factors (calibration EMA/clamp + constraint confidence) ──
+export const TUNING = {
+  EMA_PREV: 0.7,
+  EMA_SAMPLE: 0.3,
+  CALIBRATION_CLAMP_MIN: 0.3,
+  CALIBRATION_CLAMP_MAX: 3.0,
+  CONFIDENCE_HIGH: 0.85,
+  CONFIDENCE_MEDIUM: 0.8,
+  CONFIDENCE_LOW: 0.6,
+} as const;
+
+// ── Truncation budgets (named, not inline literals) ──
+export const TRUNC = {
+  // storage caps (extraction produces, state re-caps defensively)
+  MESSAGE: 300,
+  ERROR_DETAIL: 500,
+  DECISION_SUMMARY: 200,
+  USER_RESPONSE: 300,
+  CONSTRAINT_TEXT: 300,
+  OPEN_LOOP_SUMMARY: 120,
+  TIMELINE_EVENT: 150,
+  TIMELINE_ERROR: 100,
+  // prompt / context snippets
+  SNIPPET: 80,
+  PREVIEW: 150,
+  PREVIEW_MID: 200,
+  DETAIL: 300,
+  PREVIEW_LONG: 400,
+  PREVIEW_XL: 500,
+  CHUNK_FALLBACK: 180,
+  DECISION_DETAIL: 60,
+  TOPIC_LABEL: 100,
+  // hash / id / display
+  PROJ_ID_HASH: 12,
+  CONV_HASH: 8,
+  RESULT_GAPS: 5,
+  SESSION_ID_DISPLAY: 20,
+  ERROR_SNIPPET: 30,
+  TIMELINE_DISPLAY: 10,
+  EXPLORE_RESULTS: 15,
+  BACKUP_PREVIEW_LINES: 5,
+  FINGERPRINT_SEG: 2,
+} as const;
+
+// ── Truncation lengths used by damage paths ──
 export const DAMAGE_RECENT_MSG_WINDOW = 15;
 
 // ── Pruning ──
 export const MAX_TOOL_OUTPUT_CHARS = 800;
+
+// ── Error detection (shared by pruning + extraction) ──
+/** Shell-output patterns signalling a likely error even in a non-`isError` result. */
+export const LIKELY_ERROR_RE = /(?:command not found|no such file|permission denied|syntax error|cannot find|module not found|compilation error|build failed|test failed|^FAIL\b|ERROR:)/i;
+/** catalogErrors only scans outputs shorter than this — pruning must not truncate below it. */
+export const ERROR_SCAN_MAX_LEN = 2000;
+/** How far forward to look for a retry of the same tool after an error. */
+export const ERROR_RETRY_WINDOW = 6;
+/** How far forward to look for that retry's resolving (non-error) result. */
+export const ERROR_RESOLVE_WINDOW = 10;
 
 // ── Per-run metrics buffer ──
 //

--- a/src/domain/keywords.ts
+++ b/src/domain/keywords.ts
@@ -1,0 +1,28 @@
+/**
+ * Salient-keyword extraction for fuzzy "is this concept covered?" checks.
+ *
+ * Pure (no I/O) — lives in the domain layer so both the verify phase and the
+ * damage detector share one implementation instead of each re-deriving a
+ * "first N long words" heuristic (which picked positional noise and missed the
+ * real term further into the text).
+ *
+ * ponytail ceiling: this is still keyword/substring matching. A paraphrase
+ * ("TS" vs "TypeScript") can't be recognized — an inherent limit of the cheap
+ * proxy, not fixable without an LLM judge (which would defeat deterministic-first).
+ */
+
+/**
+ * Extract salient keyword tokens from a source string. Strips punctuation and
+ * prefers proper nouns / identifiers (capitalized or digit-bearing) over
+ * positional fillers. Returns at most `max` tokens, original case preserved
+ * (callers lower-case as needed for comparison).
+ */
+export function extractCheckKeywords(text: string, max: number): string[] {
+  const words = text.split(/\s+/)
+    .map(w => w.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, ""))
+    .filter(w => w.length > 3);
+  if (!words.length) return [];
+  const salient = (w: string) => /^[A-ZÀ-Þ]/.test(w) || /[0-9]/.test(w);
+  const preferred = words.filter(salient);
+  return (preferred.length ? preferred : words).slice(0, max);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type { CompressionProfile, PendingCompaction, Cell } from "./types.ts";
-import { VERSION, MIN_TOKEN_THRESHOLD, CONFIG_KEY, CONFIG_KEY_ALT } from "./constants.ts";
+import { VERSION, MIN_TOKEN_THRESHOLD, CONFIG_KEY, CONFIG_KEY_ALT, FIVE_MINUTES_MS } from "./constants.ts";
 import { loadConfig, extractUserNote, listBackups, readBackupContent, buildRestoreMessage } from "./utils/helpers.ts";
 import { getProviderCaps } from "./utils/tokens.ts";
 import { buildMetricsReport, readMetricsLog, writeMetricsDashboard } from "./utils/cache.ts";
@@ -79,7 +79,7 @@ function resolveModels(
 }
 
 export default function smartCompactExtension(pi: ExtensionAPI) {
-  const PENDING_TTL_MS = 5 * 60 * 1000;
+  const PENDING_TTL_MS = FIVE_MINUTES_MS;
   // Encapsulated slot: producers call `.set(...)`, the event handler calls
   // `.consume(...)`. The lifecycle (set/consume/clear/expire/mismatch) lives
   // entirely inside the slot factory — see src/app/pending-slot.ts.

--- a/src/infra/paths.ts
+++ b/src/infra/paths.ts
@@ -17,6 +17,7 @@
  */
 
 import path from "node:path";
+import { EXTRACTION_CACHE_PREFIX } from "../constants.ts";
 
 function home(): string {
   return process.env.HOME ?? "/tmp";
@@ -74,7 +75,7 @@ export function damageReportsFile(): string {
 
 /** Extraction cache file for a given session. */
 export function extractionCacheFile(sessionId: string): string {
-  return path.join(cacheDir(), "compact-extraction-" + sessionId.replace(/[^a-zA-Z0-9-]/g, "_") + ".json");
+  return path.join(cacheDir(), EXTRACTION_CACHE_PREFIX + sessionId.replace(/[^a-zA-Z0-9-]/g, "_") + ".json");
 }
 
 /** Project fingerprint file for a given project id. */

--- a/src/infra/services.ts
+++ b/src/infra/services.ts
@@ -31,7 +31,7 @@ import type { LlmClient } from "./llm-client.ts";
 import { getLlmClient } from "./llm-client.ts";
 import crypto from "node:crypto";
 import type { LLMCallMetric } from "../types.ts";
-import { METRICS_BUFFER_MAX } from "../constants.ts";
+import { METRICS_BUFFER_MAX, ONE_HOUR_MS } from "../constants.ts";
 import { TokenCalibrationStore } from "../utils/tokens.ts";
 
 /**
@@ -50,7 +50,7 @@ export class ToolSupportCache {
   private readonly entries = new Map<string, { result: boolean; timestamp: number }>();
   private readonly ttlMs: number;
 
-  constructor(ttlMs = 60 * 60 * 1000) { this.ttlMs = ttlMs; }
+  constructor(ttlMs = ONE_HOUR_MS) { this.ttlMs = ttlMs; }
 
   /** Returns the cached value if fresh, or undefined to force a probe. */
   get(key: string, now: number): boolean | undefined {
@@ -147,7 +147,7 @@ export interface SmartCompactServices {
   compactSessionId: string;
 }
 
-function makeCompactSessionId(): string {
+export function makeCompactSessionId(): string {
   return "sc-" + Date.now().toString(36) + "-" + crypto.randomBytes(4).toString("hex");
 }
 

--- a/src/phases/explore.ts
+++ b/src/phases/explore.ts
@@ -6,7 +6,7 @@ import type { Model, Api, ToolCall, TextContent, Message, Tool } from "@earendil
 import { Type } from "typebox";
 import type { LlmMessage, StructuredExtraction, ExplorationReport, TopicBoundary } from "../types.ts";
 import { getToolCallNames, filterToolCalls } from "../utils/type-guards.ts";
-import { COMPACT_SYSTEM_PREFIX, EXPLORER_SYSTEM_PROMPT, MAX_EXPLORATION_ROUNDS } from "../constants.ts";
+import { COMPACT_SYSTEM_PREFIX, EXPLORER_SYSTEM_PROMPT, MAX_EXPLORATION_ROUNDS, TRUNC } from "../constants.ts";
 import { extractText, extractMainGoal, extractStructured } from "../utils/extraction.ts";
 import { classifyTool } from "../domain/tool-semantics.ts";
 import { trackedComplete } from "../utils/cache.ts";
@@ -82,7 +82,7 @@ export function executeExplorationTool(call: { name: string; arguments: Record<s
       const s = (args.start as number) ?? 0, e = Math.min((args.end as number) ?? llmMessages.length, llmMessages.length);
       return JSON.stringify(llmMessages.slice(s, e).map((m, i) => ({
         idx: s + i, role: m?.role,
-        preview: extractText(m?.content).slice(0, 150),
+        preview: extractText(m?.content).slice(0, TRUNC.PREVIEW),
         toolCalls: getToolCallNames(m?.content),
         isError: m?.isError,
       })));
@@ -101,7 +101,7 @@ export function executeExplorationTool(call: { name: string; arguments: Record<s
         }
       }
       return JSON.stringify(matches.map(({ idx, m }) => ({
-        idx, role: m?.role, preview: extractText(m?.content).slice(0, 150),
+        idx, role: m?.role, preview: extractText(m?.content).slice(0, TRUNC.PREVIEW),
       })));
     }
     case "get_recent_user_messages": {
@@ -113,7 +113,7 @@ export function executeExplorationTool(call: { name: string; arguments: Record<s
       const s = Math.max(0, idx - radius), e = Math.min(llmMessages.length, idx + radius + 1);
       return JSON.stringify(llmMessages.slice(s, e).map((m, i) => ({
         idx: s + i, role: m?.role,
-        text: extractText(m?.content).slice(0, 300),
+        text: extractText(m?.content).slice(0, TRUNC.DETAIL),
         toolCalls: getToolCallNames(m?.content),
         isError: m?.isError,
       })));
@@ -139,14 +139,14 @@ export function executeExplorationTool(call: { name: string; arguments: Record<s
             // args; full-file writes carry large content, so omit args to keep
             // the exploration result compact.
             const surgical = a.oldText != null || a.newText != null || a.edits != null || a.patch != null;
-            const preview = extractText(llmMessages[i]?.content).slice(0, 400);
+            const preview = extractText(llmMessages[i]?.content).slice(0, TRUNC.PREVIEW_LONG);
             results.push(surgical
               ? { idx: i, role: "assistant", toolCall: block.name ?? "mutates", args: block.arguments, preview }
               : { idx: i, role: "assistant", toolCall: block.name ?? "mutates", preview });
           }
         }
       }
-      return JSON.stringify(results.slice(0, 15) || [{ info: "No edits found for: " + args.path }]);
+      return JSON.stringify(results.slice(0, TRUNC.EXPLORE_RESULTS) || [{ info: "No edits found for: " + args.path }]);
     }
     case "get_error_chain": {
       const errIdx = (args.index as number) ?? 0;
@@ -154,7 +154,7 @@ export function executeExplorationTool(call: { name: string; arguments: Record<s
       const s = Math.max(0, errIdx - ctxRadius), e = Math.min(llmMessages.length, errIdx + ctxRadius + 1);
       return JSON.stringify(llmMessages.slice(s, e).map((m, i) => ({
         idx: s + i, role: m?.role,
-        text: extractText(m?.content).slice(0, 500),
+        text: extractText(m?.content).slice(0, TRUNC.PREVIEW_XL),
         isError: m?.isError,
         toolCalls: getToolCallNames(m?.content),
       })));
@@ -229,7 +229,7 @@ function normalizeBoundaries(raw: unknown, llmLength: number): TopicBoundary[] {
       const confidence = b.confidence;
       return {
         afterIndex: Math.max(0, Math.min(b.afterIndex as number, maxIndex)),
-        topic: String(b.topic ?? "").slice(0, 100),
+        topic: String(b.topic ?? "").slice(0, TRUNC.TOPIC_LABEL),
         priority: typeof priority === "string" && (BOUNDARY_PRIORITIES as readonly string[]).includes(priority)
           ? (priority as BoundaryPriority)
           : "normal",
@@ -305,12 +305,12 @@ export async function exploreConversation(
     "Main goal: " + (extraction.mainGoal ?? "unknown"),
     "Files modified (" + extraction.modifiedFiles.length + "): " + (extraction.modifiedFiles.map(f => f.path).join(", ") || "none"),
     "Files read (" + extraction.readFiles.length + "): " + (extraction.readFiles.join(", ") || "none"),
-    "Errors (" + extraction.errors.length + "): " + (extraction.errors.map(e => "[" + e.tool + "] " + e.message.slice(0, 80) + (e.resolved ? " (resolved)" : e.retryAttempted ? " (retry attempted)" : "")).join("; ") || "none"),
-    "Decisions (" + extraction.decisions.length + "): " + (extraction.decisions.map(d => d.type + ": " + d.summary.slice(0, 80)).join("; ") || "none"),
-    "Constraints (" + extraction.constraints.length + "): " + (extraction.constraints.map(cc => "[" + cc.category + "] " + cc.text.slice(0, 80)).join("; ") || "none"),
+    "Errors (" + extraction.errors.length + "): " + (extraction.errors.map(e => "[" + e.tool + "] " + e.message.slice(0, TRUNC.SNIPPET) + (e.resolved ? " (resolved)" : e.retryAttempted ? " (retry attempted)" : "")).join("; ") || "none"),
+    "Decisions (" + extraction.decisions.length + "): " + (extraction.decisions.map(d => d.type + ": " + d.summary.slice(0, TRUNC.SNIPPET)).join("; ") || "none"),
+    "Constraints (" + extraction.constraints.length + "): " + (extraction.constraints.map(cc => "[" + cc.category + "] " + cc.text.slice(0, TRUNC.SNIPPET)).join("; ") || "none"),
     "Heuristic topics (" + extraction.topics.length + "): " + (extraction.topics.map(t => "[" + t.startIndex + "-" + t.endIndex + "] " + t.type).join("; ") || "none"),
-    extraction.lastUserMessages.length ? "Last user messages: " + extraction.lastUserMessages.map(m => m.slice(0, 100)).join(" | ") : "",
-    extraction.lastErrors.length ? "Last errors: " + extraction.lastErrors.map(e => e.slice(0, 100)).join(" | ") : "",
+    extraction.lastUserMessages.length ? "Last user messages: " + extraction.lastUserMessages.map(m => m.slice(0, TRUNC.TOPIC_LABEL)).join(" | ") : "",
+    extraction.lastErrors.length ? "Last errors: " + extraction.lastErrors.map(e => e.slice(0, TRUNC.TOPIC_LABEL)).join(" | ") : "",
   ].filter(Boolean).join("\n");
 
   const userContent = "Explore this conversation and produce the structured report.\n\n" +
@@ -448,7 +448,7 @@ export async function explorationRetry(
   signal?: AbortSignal,
   services?: SmartCompactServices,
 ): Promise<ExplorationReport> {
-  const last5 = llmMessages.slice(-5).map((m) => "[" + m?.role + "] " + extractText(m?.content).slice(0, 150)).join("\n");
+  const last5 = llmMessages.slice(-5).map((m) => "[" + m?.role + "] " + extractText(m?.content).slice(0, TRUNC.PREVIEW)).join("\n");
   const retryPrompt = "IMPORTANT: Output ONLY valid raw JSON. No markdown. No explanation. No code fences. Just the JSON object.\n\n" +
     "Produce this exact structure:\n{\"mainGoal\":\"...\",\"sessionType\":\"implementation|review|debugging|discussion\",\"boundaries\":[{\"afterIndex\":N,\"topic\":\"...\",\"priority\":\"normal\",\"confidence\":0.5}],\"enrichedConstraints\":[],\"crossReferences\":[],\"statusAssessment\":{\"done\":[],\"inProgress\":[],\"blocked\":[]},\"criticalContext\":[],\"keyDecisions\":[]}\n\n" +
     "Context:\nFiles: " + extraction.modifiedFiles.map(f => f.path).join(", ") + "\n" +
@@ -473,14 +473,14 @@ export async function directExploration(
   signal?: AbortSignal,
   services?: SmartCompactServices,
 ): Promise<ExplorationReport> {
-  const first3 = llmMessages.filter((m) => m?.role === "user").slice(0, 3).map((m) => extractText(m?.content).slice(0, 200)).join("\n---\n");
-  const last30 = llmMessages.slice(-30).map((m) => "[" + m?.role + "] " + extractText(m?.content).slice(0, 300)).join("\n");
+  const first3 = llmMessages.filter((m) => m?.role === "user").slice(0, 3).map((m) => extractText(m?.content).slice(0, TRUNC.PREVIEW_MID)).join("\n---\n");
+  const last30 = llmMessages.slice(-30).map((m) => "[" + m?.role + "] " + extractText(m?.content).slice(0, TRUNC.DETAIL)).join("\n");
   const prompt = "Analyze this conversation and produce a JSON report.\n\nFirst user messages:\n" + first3 +
     "\n\nDeterministic data:\n" +
     "- Files modified: " + (extraction.modifiedFiles.map(f => f.path).join(", ") || "none") +
-    "\n- Errors: " + (extraction.errors.map(e => e.message.slice(0, 80)).join("; ") || "none") +
-    "\n- Decisions: " + (extraction.decisions.map(d => d.summary.slice(0, 80)).join("; ") || "none") +
-    "\n- Constraints: " + (extraction.constraints.map(c => c.text.slice(0, 80)).join("; ") || "none") +
+    "\n- Errors: " + (extraction.errors.map(e => e.message.slice(0, TRUNC.SNIPPET)).join("; ") || "none") +
+    "\n- Decisions: " + (extraction.decisions.map(d => d.summary.slice(0, TRUNC.SNIPPET)).join("; ") || "none") +
+    "\n- Constraints: " + (extraction.constraints.map(c => c.text.slice(0, TRUNC.SNIPPET)).join("; ") || "none") +
     "\n\nLast 30 messages:\n" + last30 +
     (prevSummary ? "\n\nPrevious summary:\n" + prevSummary : "") +
     (userNote ? "\n\nUser note: \"" + userNote + "\"" : "") +

--- a/src/phases/synthesize.ts
+++ b/src/phases/synthesize.ts
@@ -7,7 +7,7 @@ import type {
   LlmMessage, LlmChunk, ChunkSummary, StructuredExtraction,
   ExplorationReport, ProfileConfig,
 } from "../types.ts";
-import { COMPACT_SYSTEM_PREFIX, SINGLE_PASS_PREFIX, SINGLE_PASS_SUFFIX, BATCH_PROMPT_PREFIX, BATCH_PROMPT_SUFFIX, ASSEMBLY_PROMPT_PREFIX, ASSEMBLY_PROMPT_SUFFIX, SESSION_TYPE_INSTRUCTIONS } from "../constants.ts";
+import { COMPACT_SYSTEM_PREFIX, SINGLE_PASS_PREFIX, SINGLE_PASS_SUFFIX, BATCH_PROMPT_PREFIX, BATCH_PROMPT_SUFFIX, ASSEMBLY_PROMPT_PREFIX, ASSEMBLY_PROMPT_SUFFIX, SESSION_TYPE_INSTRUCTIONS, TRUNC } from "../constants.ts";
 import { estimateTokens, getProviderCaps } from "../utils/tokens.ts";
 import { trackedComplete } from "../utils/cache.ts";
 import { extractText } from "../utils/extraction.ts";
@@ -114,7 +114,7 @@ export async function summarizeBatch(
   // Decision propagation: inject decisions from before this batch's range
   const activeDecisions = extraction.decisions
     .filter(d => d.index < range.start)
-    .map(d => "- " + d.summary.slice(0, 120) + (d.userResponse ? " → " + d.userResponse.slice(0, 60) : ""));
+    .map(d => "- " + d.summary.slice(0, TRUNC.OPEN_LOOP_SUMMARY) + (d.userResponse ? " → " + d.userResponse.slice(0, TRUNC.DECISION_DETAIL) : ""));
   const decisionCtx = activeDecisions.length
     ? "\n## Active Decisions from previous segments (honour these):\n" + activeDecisions.join("\n")
     : "";
@@ -124,9 +124,9 @@ export async function summarizeBatch(
     const id = i + 1;
     return "--- CHUNK " + id + ": " + ch.topic + " (" + ch.priority + ") ---\n" + ch.messages.map((m) => {
       const role = m?.role ?? "unknown";
-      const content = extractText(m?.content).slice(0, 500);
+      const content = extractText(m?.content).slice(0, TRUNC.PREVIEW_XL);
       const toolCalls = filterToolCalls(m?.content)
-        .map(tc => tc.name + " " + JSON.stringify(tc.arguments).slice(0, 300))
+        .map(tc => tc.name + " " + JSON.stringify(tc.arguments).slice(0, TRUNC.DETAIL))
         .join("; ");
       const toolSuffix = toolCalls ? "\n[tool_calls] " + toolCalls : "";
       return "[" + role + "] " + content + toolSuffix;
@@ -162,8 +162,8 @@ export async function summarizeBatch(
     const f = (n: string) => { const m = sec.match(new RegExp("\\*\\*" + n + "\\*\\*:\\s*(.+?)(?:\\n|$)", "i")); return m ? m[1].trim() : ""; };
     const l = (n: string) => { const v = f(n); return !v || v === "None" ? [] : v.split(",").map(s => s.trim()).filter(Boolean); };
     const prio = f("Priority").toLowerCase();
-    const sectionFallback = sec.split("\n").slice(1).join("\n").trim().slice(0, 500);
-    const chunkFallback = ch.messages.map(m => "[" + (m?.role ?? "unknown") + "] " + extractText(m?.content).slice(0, 180)).join("\n").slice(0, 500);
+    const sectionFallback = sec.split("\n").slice(1).join("\n").trim().slice(0, TRUNC.PREVIEW_XL);
+    const chunkFallback = ch.messages.map(m => "[" + (m?.role ?? "unknown") + "] " + extractText(m?.content).slice(0, TRUNC.CHUNK_FALLBACK)).join("\n").slice(0, TRUNC.PREVIEW_XL);
     return {
       topic: ch.topic,
       startIndex: ch.startIndex, endIndex: ch.endIndex,
@@ -206,14 +206,14 @@ export function assembleFallback(summaries: ChunkSummary[], extraction: Structur
   const detRead = extraction.readFiles;
   return [
     "## Goal", extraction.mainGoal ?? "See topics below.", "",
-    "## Constraints & Preferences", ...extraction.constraints.map(c => "- [" + c.category + "] " + c.text.slice(0, 200)), "",
-    "## Progress", "### Done", "- See topics below", "### In Progress", ...summaries.filter(s => s.priority === "high").map(s => "- [ ] " + s.summary.slice(0, 150)), "### Blocked", "- None", "",
-    "## Key Decisions", ...extraction.decisions.map(d => "- **" + d.summary.slice(0, 100) + "**" + (d.userResponse ? " → " + d.userResponse : "")), "",
+    "## Constraints & Preferences", ...extraction.constraints.map(c => "- [" + c.category + "] " + c.text.slice(0, TRUNC.PREVIEW_MID)), "",
+    "## Progress", "### Done", "- See topics below", "### In Progress", ...summaries.filter(s => s.priority === "high").map(s => "- [ ] " + s.summary.slice(0, TRUNC.PREVIEW)), "### Blocked", "- None", "",
+    "## Key Decisions", ...extraction.decisions.map(d => "- **" + d.summary.slice(0, TRUNC.TOPIC_LABEL) + "**" + (d.userResponse ? " → " + d.userResponse : "")), "",
     "## Files Modified", ...detModified.map(f => "- " + f), "",
     "## Files Read", ...detRead.map(f => "- " + f), "",
     "## Next Steps", "1. See topics below", "",
-    "## Critical Context", ...extraction.errors.filter(e => !e.resolved).map(e => "- Unresolved error: " + e.message.slice(0, 100)), "",
-    "## Topics Covered", ...summaries.map(s => "- **" + s.topic + "** [" + s.priority + "]: " + s.summary.slice(0, 200)),
+    "## Critical Context", ...extraction.errors.filter(e => !e.resolved).map(e => "- Unresolved error: " + e.message.slice(0, TRUNC.TOPIC_LABEL)), "",
+    "## Topics Covered", ...summaries.map(s => "- **" + s.topic + "** [" + s.priority + "]: " + s.summary.slice(0, TRUNC.PREVIEW_MID)),
   ].join("\n");
 }
 
@@ -226,7 +226,7 @@ export function assembleFallback(summaries: ChunkSummary[], extraction: Structur
 export function failedChunkSummary(ch: LlmChunk): ChunkSummary {
   return {
     topic: ch.topic, startIndex: ch.startIndex, endIndex: ch.endIndex,
-    summary: "[Failed] " + ch.messages.map(m => extractText(m.content)).join("\n").slice(0, 300),
+    summary: "[Failed] " + ch.messages.map(m => extractText(m.content)).join("\n").slice(0, TRUNC.DETAIL),
     keyDecisions: [], filesModified: [], filesRead: [], priority: ch.priority,
   };
 }

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -17,12 +17,13 @@
 
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type { StructuredExtraction, VerificationResult } from "../types.ts";
-import { COMPACT_SYSTEM_PREFIX } from "../constants.ts";
+import { COMPACT_SYSTEM_PREFIX, TRUNC } from "../constants.ts";
 import { trackedComplete } from "../utils/cache.ts";
 import { getProviderCaps } from "../utils/tokens.ts";
 import { extractFileRefs } from "../utils/file-ref-detect.ts";
 import * as log from "../utils/logger.ts";
 import { parseSummary, findSection, appendToSection, renderSummary, upsertSection } from "../domain/summary-parse.ts";
+import { extractCheckKeywords } from "../domain/keywords.ts";
 import type { CanonicalSummary } from "../domain/summary-schema.ts";
 import type { SmartCompactServices } from "../infra/services.ts";
 
@@ -61,24 +62,26 @@ export function verifySummary(summary: string, extraction: StructuredExtraction)
   }
 
   for (const e of extraction.errors.filter(e => !e.resolved)) {
-    const snippet = e.message.slice(0, 30).toLowerCase();
+    // Normalize whitespace before slicing: a leading "\n  " on the raw error
+    // text broke the exact-substring match even when the error was quoted verbatim.
+    const snippet = e.message.trim().replace(/\s+/g, " ").slice(0, TRUNC.ERROR_SNIPPET).toLowerCase();
     if (snippet.length > 5 && !lower.includes(snippet)) {
-      gaps.push("Missing error: " + e.message.slice(0, 80));
+      gaps.push("Missing error: " + e.message.slice(0, TRUNC.SNIPPET));
       score -= 5;
     }
   }
 
   for (const c of extraction.constraints.filter(c => c.confidence >= 0.8)) {
-    const keywords = c.text.split(/\s+/).filter(w => w.length > 4).slice(0, 3);
+    const keywords = extractCheckKeywords(c.text, 3);
     const found = keywords.some(k => lower.includes(k.toLowerCase()));
     if (!found && keywords.length > 0) {
-      gaps.push("Missing constraint: " + c.text.slice(0, 100));
+      gaps.push("Missing constraint: " + c.text.slice(0, TRUNC.TOPIC_LABEL));
       score -= 3;
     }
   }
 
   if (extraction.mainGoal) {
-    const goalWords = extraction.mainGoal.split(/\s+/).filter(w => w.length > 3).slice(0, 4);
+    const goalWords = extractCheckKeywords(extraction.mainGoal, 4);
     const goalFound = goalWords.some(w => lower.includes(w.toLowerCase()));
     if (!goalFound) { gaps.push("Main goal may be missing from summary"); score -= 10; }
   }
@@ -127,9 +130,9 @@ export function verifySummary(summary: string, extraction: StructuredExtraction)
     const decisionSection = findSection(parsed, "decisions");
     const decisionBody = decisionSection?.body.toLowerCase() ?? "";
     for (const d of highConfDecisions) {
-      const keywords = d.summary.split(/\s+/).filter(w => w.length > 4).slice(0, 3);
+      const keywords = extractCheckKeywords(d.summary, 3);
       if (keywords.length > 0 && !keywords.some(k => decisionBody.includes(k.toLowerCase()))) {
-        gaps.push("Missing decision: " + d.summary.slice(0, 100));
+        gaps.push("Missing decision: " + d.summary.slice(0, TRUNC.TOPIC_LABEL));
         score -= 3;
       }
     }

--- a/src/ui/overlays.ts
+++ b/src/ui/overlays.ts
@@ -4,6 +4,7 @@
 
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { DynamicBorder, Theme } from "@earendil-works/pi-coding-agent";
+import { TRUNC } from "../constants.ts";
 import { Container, Key, matchesKey, type SelectItem, SelectList, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type {
@@ -291,7 +292,7 @@ export async function showResultScreen(
       c.addChild(new Text(theme.fg("success", "    \u2705 All facts verified \u2014 no gaps detected"), 0, 0));
     } else if (details.gaps.length > 0) {
       c.addChild(new Text(theme.fg("warning", "    \u26A0\uFE0F  " + details.gaps.length + " gap(s) patched:"), 0, 0));
-      for (const g of details.gaps.slice(0, 5)) {
+      for (const g of details.gaps.slice(0, TRUNC.RESULT_GAPS)) {
         c.addChild(new Text(theme.fg("dim", "      \u2022 " + g), 0, 0));
       }
     }
@@ -454,7 +455,7 @@ export async function showRestorePicker(
   const items: SelectItem[] = backups.map(b => ({
     value: b.path,
     label: new Date(b.date).toLocaleString() + "  \u00b7  " + Math.max(1, Math.round(b.sizeBytes / 1024)) + "KB",
-    description: b.sessionId.slice(0, 20),
+    description: b.sessionId.slice(0, TRUNC.SESSION_ID_DISPLAY),
   }));
   return await ctx.ui.custom<string | null>((tui, theme, _kb, done) => {
     const c = new Container();

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -21,26 +21,15 @@ import {
   cacheDir as cacheDirPath, metricsDashboardFile,
 } from "../infra/paths.ts";
 import { appendLineLocked, ensureDir, readJsonSync, writeJsonSync, atomicWriteFileSync } from "../infra/fs.ts";
+import { ONE_HOUR_MS, SEVEN_DAYS_MS, EXTRACTION_CACHE_PREFIX } from "../constants.ts";
 import { buildEntryIdFingerprint } from "./id-fingerprint.ts";
-import { getDefaultServices, type SmartCompactServices } from "../infra/services.ts";
+import { getDefaultServices, makeCompactSessionId, type SmartCompactServices } from "../infra/services.ts";
 
 // ── Cache Options ──
 
-/**
- * Generate a one-shot session id used for prompt-cache namespacing when a
- * caller didn't go through the services container.
- *
- * NOTE: historically this module memoized a single id at module scope, but
- * that id leaked across all runs in the same Node process and collided with
- * `services.compactSessionId` (which is freshly minted per `createServices()`).
- * The right namespace identity belongs to the services container; this helper
- * exists only as a defensive fallback for the rare path where `services` is
- * undefined (e.g. ad-hoc test wiring) and intentionally returns a fresh id
- * every call so two unrelated calls never share a cache namespace by accident.
- */
-function fallbackSessionId(): string {
-  return "sc-" + Date.now().toString(36) + "-" + crypto.randomBytes(4).toString("hex");
-}
+// Prompt-cache namespace id comes from `makeCompactSessionId` (services.ts),
+// shared with the per-run services container so the fallback path can't drift
+// in format from the live one.
 /** Internal compaction phases that should never use prompt caching — one-shot, not worth write cost. */
 const INTERNAL_PHASES: ReadonlySet<LLMCallMetric["phase"]> = new Set([
   "explore", "explore-loop", "explore-retry", "explore-direct",
@@ -63,7 +52,7 @@ export function cacheOpts(
   if (retention === "none") {
     return { ...opts, cacheRetention: "none" as const };
   }
-  return { ...opts, sessionId: services?.compactSessionId ?? fallbackSessionId(), cacheRetention: retention };
+  return { ...opts, sessionId: services?.compactSessionId ?? makeCompactSessionId(), cacheRetention: retention };
 }
 
 // ── Metrics ──
@@ -218,8 +207,8 @@ export function loadCachedExtraction(sessionId: string): CachedExtraction | null
   return cached;
 }
 
-const EXTRACTION_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
-const EXTRACTION_CACHE_PRUNE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const EXTRACTION_CACHE_TTL_MS = ONE_HOUR_MS;
+const EXTRACTION_CACHE_PRUNE_MAX_AGE_MS = SEVEN_DAYS_MS;
 
 /**
  * Stale extraction caches (sessions we'll never see again because the user
@@ -242,7 +231,7 @@ function scheduleExtractionCacheCleanup(): void {
       if (!fs.existsSync(dir)) return;
       const now = Date.now();
       for (const name of fs.readdirSync(dir)) {
-        if (!name.startsWith("compact-extraction-") || !name.endsWith(".json")) continue;
+        if (!name.startsWith(EXTRACTION_CACHE_PREFIX) || !name.endsWith(".json")) continue;
         const fp = path.join(dir, name);
         try {
           const stat = fs.statSync(fp);
@@ -294,9 +283,13 @@ export function mergeExtractions(base: StructuredExtraction, delta: StructuredEx
     constraints: [...base.constraints, ...offsetConstraints],
     topics: [...base.topics, ...offsetTopics],
     timeline: [...base.timeline, ...offsetTimeline],
-    mainGoal: delta.mainGoal ?? base.mainGoal,
-    lastUserMessages: delta.lastUserMessages.length > 0 ? delta.lastUserMessages : base.lastUserMessages,
-    lastErrors: delta.lastErrors.length > 0 ? delta.lastErrors : base.lastErrors,
+    // mainGoal is the FIRST user message (the original objective) — base holds
+    // it; the delta suffix's first user message is mid-conversation, not the goal.
+    mainGoal: base.mainGoal ?? delta.mainGoal,
+    // "last N" must span the cache boundary: the suffix alone is incomplete
+    // when it carries fewer than N user messages / errors.
+    lastUserMessages: [...base.lastUserMessages, ...delta.lastUserMessages].slice(-5),
+    lastErrors: [...base.lastErrors, ...delta.lastErrors].slice(-3),
     messageCount: baseMsgCount + delta.messageCount,
   };
 }

--- a/src/utils/damage.ts
+++ b/src/utils/damage.ts
@@ -10,6 +10,8 @@ import { classifyTool, extractToolPath } from "../domain/tool-semantics.ts";
 import * as log from "./logger.ts";
 import { damageReportsFile, remediationHintsFile } from "../infra/paths.ts";
 import { appendLineLocked, writeJsonSync, readJsonSync } from "../infra/fs.ts";
+import { SEVEN_DAYS_MS, TRUNC } from "../constants.ts";
+import { extractCheckKeywords } from "../domain/keywords.ts";
 
 export interface RegressionSignal {
   type: "re-read" | "re-question" | "contradiction" | "user-complaint";
@@ -85,7 +87,7 @@ export function detectDamage(
           signals.push({
             type: "user-complaint",
             severity: "high",
-            detail: "User complaint after compaction: \"" + text.slice(0, 100) + "\"",
+            detail: "User complaint after compaction: \"" + text.slice(0, TRUNC.TOPIC_LABEL) + "\"",
           });
           break;
         }
@@ -93,12 +95,15 @@ export function detectDamage(
 
       // Check if user re-asks about compacted topics
       for (const t of details.topics) {
-        const topicWords = t.toLowerCase().split(/\s+/).filter(w => w.length > 4).slice(0, 3);
-        if (topicWords.length >= 2 && topicWords.some(w => text.includes(w))) {
+        // Salient tokens (proper nouns / identifiers) are high-precision, so a
+        // single match is enough signal — the old "≥2 long words" guard was for
+        // the noisier positional keyword extraction.
+        const topicWords = extractCheckKeywords(t, 3);
+        if (topicWords.length > 0 && topicWords.some(w => text.includes(w.toLowerCase()))) {
           signals.push({
             type: "re-question",
             severity: "low",
-            detail: "User mentions compacted topic: " + t.slice(0, 80),
+            detail: "User mentions compacted topic: " + t.slice(0, TRUNC.SNIPPET),
           });
         }
       }
@@ -157,7 +162,7 @@ export function logDamageReport(
   } catch (e) { log.warn("logDamageReport failed", e); }
 }
 
-const REMEDIATION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const REMEDIATION_TTL_MS = SEVEN_DAYS_MS;
 
 /**
  * Persist the files the agent re-read after a compaction so the NEXT

--- a/src/utils/extraction.ts
+++ b/src/utils/extraction.ts
@@ -4,7 +4,7 @@
 
 import path from "node:path";
 import type { LlmMessage, ProfileConfig, StructuredExtraction, OpenLoop, MediaAttachment } from "../types.ts";
-import { NO_OP_RE, SHIFT_RE, CHOICE_RE } from "../constants.ts";
+import { NO_OP_RE, SHIFT_RE, CHOICE_RE, LIKELY_ERROR_RE, ERROR_SCAN_MAX_LEN, ERROR_RETRY_WINDOW, ERROR_RESOLVE_WINDOW, TRUNC, ID_PREFIX, TUNING } from "../constants.ts";
 import { estimateTokens } from "./tokens.ts";
 import { isToolCallBlock, isTextBlock } from "../utils/type-guards.ts";
 import { buildPathNeedles } from "./file-needles.ts";
@@ -17,13 +17,8 @@ export function isTruncated(content: unknown): boolean {
   return TRUNCATE_RE.test(extractText(content));
 }
 
-/**
- * Result-text heuristic for deletion. A path-only tool whose result mentions a
- * deletion verb is treated as a delete — arguments alone cannot tell a delete
- * from a read (both carry only a path), so the result is the only name-agnostic
- * signal. Best-effort: a file that literally contains the word "deleted" would
- * misattribute, but that is a rare false-positive on the least-critical list.
- */
+/** Best-effort delete detection: arguments can't tell a delete from a read
+ *  (both carry only a path), so the result text is the only signal. */
 const DELETE_RESULT_RE = /\b(?:deleted|removed|unlinked)\b/i;
 
 /** Reusable tool call index type */
@@ -149,10 +144,8 @@ export function trackFileOps(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): { modi
     const filePath = extractToolPath(tc.arguments);
     if (!filePath) continue;
 
-    // Classification by argument shape, not tool name — see domain/tool-semantics.ts.
-    // Auto-adapts to tools this code has never seen (hypa_*, MCP, custom extensions):
-    // any path+payload tool is a write, any command tool is an exec, any path-only
-    // tool is a read, regardless of name. No name list to maintain.
+    // Classify by argument shape, not tool name (domain/tool-semantics.ts) —
+    // auto-adapts to any tool without a name list.
     const cls = classifyTool(tc.arguments);
     if (cls === "mutates") {
       // pi-toolkit truncation hides whether a write was a no-op, so a truncated
@@ -186,7 +179,7 @@ export function catalogErrors(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): Struc
     const tc = tcIdx.get(m.toolCallId ?? "");
 
     if (m.isError) {
-      errors.push({ index: i, tool: tc?.name ?? "unknown", message: extractText(m.content).slice(0, 500), retryAttempted: false, resolved: false });
+      errors.push({ index: i, tool: tc?.name ?? "unknown", message: extractText(m.content).slice(0, TRUNC.ERROR_DETAIL), retryAttempted: false, resolved: false });
       continue;
     }
 
@@ -195,34 +188,33 @@ export function catalogErrors(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): Struc
     // tools this code has never seen. Explicit m.isError is handled above.
     if (tc && classifyTool(tc.arguments) === "executes") {
       const txt = extractText(m.content);
-      const isLikelyError = /(?:command not found|no such file|permission denied|syntax error|cannot find|module not found|compilation error|build failed|test failed|^FAIL\b|ERROR:)/i.test(txt);
-      if (isLikelyError && txt.length < 2000) {
-        errors.push({ index: i, tool: tc.name, message: txt.slice(0, 300), retryAttempted: false, resolved: false });
+      if (LIKELY_ERROR_RE.test(txt) && txt.length < ERROR_SCAN_MAX_LEN) {
+        errors.push({ index: i, tool: tc.name, message: txt.slice(0, TRUNC.MESSAGE), retryAttempted: false, resolved: false });
       }
     }
   }
 
   for (const err of errors) {
-    for (let j = err.index + 1; j < Math.min(msgs.length, err.index + 6); j++) {
-      if (msgs[j]?.role === "assistant") {
-        const rawBlocks = msgs[j]?.content;
-        const blocks: unknown[] = Array.isArray(rawBlocks) ? rawBlocks : [];
-        for (const b of blocks) {
-          for (const tool of flattenToolCallBlock(b)) {
-            if (tool.name === err.tool) {
-              err.retryAttempted = true;
-              for (let k = j + 1; k < Math.min(msgs.length, j + 10); k++) {
-                if (msgs[k]?.role === "toolResult" && msgs[k]?.toolCallId === tool.id && !msgs[k]?.isError) {
-                  err.resolved = true; break;
-                }
-              }
-              break;
-            }
-          }
-          if (err.retryAttempted) break;
-        }
-        if (err.retryAttempted) break;
+    // Scan forward for a retry: an assistant tool call of the same name.
+    for (let j = err.index + 1; j < Math.min(msgs.length, err.index + ERROR_RETRY_WINDOW); j++) {
+      if (msgs[j]?.role !== "assistant") continue;
+      const rawBlocks = msgs[j]?.content;
+      const blocks: unknown[] = Array.isArray(rawBlocks) ? rawBlocks : [];
+      const retryTool = blocks.flatMap(b => flattenToolCallBlock(b)).find(t => t.name === err.tool);
+      if (!retryTool) continue;
+      err.retryAttempted = true;
+      // Did that retry succeed? Link by id when present; for id-less calls
+      // (some multi_tool_use inner tools / id-less providers) fall back to a
+      // non-error result of the same tool within the resolve window.
+      for (let k = j + 1; k < Math.min(msgs.length, j + ERROR_RESOLVE_WINDOW); k++) {
+        const mk = msgs[k];
+        if (mk?.role !== "toolResult" || mk.isError) continue;
+        const resolved = retryTool.id != null
+          ? mk.toolCallId === retryTool.id
+          : tcIdx.get(mk.toolCallId ?? "")?.name === err.tool;
+        if (resolved) { err.resolved = true; break; }
       }
+      break; // the first retry is enough
     }
   }
   return errors;
@@ -239,7 +231,7 @@ export function extractDecisions(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): St
     if (!question) continue;
     for (let i = tc.msgIndex + 1; i < Math.min(msgs.length, tc.msgIndex + 4); i++) {
       if (msgs[i]?.role === "toolResult" && msgs[i]?.toolCallId === id) {
-        decisions.push({ index: tc.msgIndex, type: "explicit", summary: question.slice(0, 200), userResponse: extractText(msgs[i].content).slice(0, 300) });
+        decisions.push({ index: tc.msgIndex, type: "explicit", summary: question.slice(0, TRUNC.DECISION_SUMMARY), userResponse: extractText(msgs[i].content).slice(0, TRUNC.USER_RESPONSE) });
         break;
       }
     }
@@ -249,25 +241,23 @@ export function extractDecisions(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): St
     if (msgs[i]?.role !== "user") continue;
     const txt = extractText(msgs[i].content);
     if (CHOICE_RE.test(txt)) {
-      decisions.push({ index: i, type: "implicit", summary: txt.slice(0, 200) });
+      decisions.push({ index: i, type: "implicit", summary: txt.slice(0, TRUNC.DECISION_SUMMARY) });
     }
   }
   return decisions;
 }
 
 const CONSTRAINT_PATTERNS: Array<{ re: RegExp; cat: StructuredExtraction["constraints"][0]["category"]; conf: number }> = [
-  { re: /\b(?:must|need|require|has to|important)\b.*\b(?:be|use|have|include|support)\b/i, cat: "requirement", conf: 0.85 },
-  { re: /\b(?:don't|never|avoid|shouldn't|must not|do not|no\s+(?:need|want))\b/i, cat: "prohibition", conf: 0.8 },
-  { re: /\b(?:prefer|like|want|would rather|should)\b.*\b(?:use|be|have|with)\b/i, cat: "preference", conf: 0.6 },
-  // Turkish patterns — raw UTF-8 chars (the file is UTF-8; the escape forms
-  // added no value and hurt readability).
-  // ponytail: `\b` is ASCII-only in JS, so a leading Turkish char like `ö` is
-  // not a word boundary and the Turkish-leading forms barely match; the ASCII
-  // fallbacks (onemli/sart/...) carry the load. Fixing that needs lookarounds,
-  // not just spelling — out of scope for the consistency cleanup.
-  { re: /\b(?:kritik|kritikal|önemli|onemli|şart|sart|zorunlu|şart koşul|önemli şart|kesinlikle|kesinlikle şart|asla|sakın|sakınha|bunu yapma|böyle olsun|böyle yapın|şöyle olsun|şöyle yapın)\b/iu, cat: "requirement", conf: 0.8 },
-  { re: /\b(?:yapma|kullanma|sakın|asla\s+(?:kullanma|yapma|getirme))\b/iu, cat: "prohibition", conf: 0.8 },
-  { re: /\b(?:tercih|isterim|olsun|kullanalım|yapalım|istiyorum)\b/iu, cat: "preference", conf: 0.6 },
+  { re: /\b(?:must|need|require|has to|important)\b.*\b(?:be|use|have|include|support)\b/i, cat: "requirement", conf: TUNING.CONFIDENCE_HIGH },
+  { re: /\b(?:don't|never|avoid|shouldn't|must not|do not|no\s+(?:need|want))\b/i, cat: "prohibition", conf: TUNING.CONFIDENCE_MEDIUM },
+  { re: /\b(?:prefer|like|want|would rather|should)\b.*\b(?:use|be|have|with)\b/i, cat: "preference", conf: TUNING.CONFIDENCE_LOW },
+  // Turkish patterns — raw UTF-8 chars; lookarounds instead of `\b` because
+  // JS `\b` is ASCII-only (a leading ö/ş is not a word boundary, so the
+  // Turkish-leading forms never matched). (?<![A-Za-z0-9_])…(?![A-Za-z0-9_])
+  // treats any non-ASCII letter as a valid edge, so both spellings now work.
+  { re: /(?<![A-Za-z0-9_])(?:kritik|kritikal|önemli|onemli|şart|sart|zorunlu|şart koşul|önemli şart|kesinlikle|kesinlikle şart|asla|sakın|sakınha|bunu yapma|böyle olsun|böyle yapın|şöyle olsun|şöyle yapın)(?![A-Za-z0-9_])/iu, cat: "requirement", conf: TUNING.CONFIDENCE_MEDIUM },
+  { re: /(?<![A-Za-z0-9_])(?:yapma|kullanma|sakın|asla\s+(?:kullanma|yapma|getirme))(?![A-Za-z0-9_])/iu, cat: "prohibition", conf: TUNING.CONFIDENCE_MEDIUM },
+  { re: /(?<![A-Za-z0-9_])(?:tercih|isterim|olsun|kullanalım|yapalım|istiyorum)(?![A-Za-z0-9_])/iu, cat: "preference", conf: TUNING.CONFIDENCE_LOW },
 ];
 
 export function mineConstraints(msgs: LlmMessage[]): StructuredExtraction["constraints"] {
@@ -278,7 +268,7 @@ export function mineConstraints(msgs: LlmMessage[]): StructuredExtraction["const
     if (txt.length < 10 || txt.startsWith("/")) continue;
     for (const { re, cat, conf } of CONSTRAINT_PATTERNS) {
       if (re.test(txt)) {
-        constraints.push({ index: i, text: txt.slice(0, 300), category: cat, confidence: conf });
+        constraints.push({ index: i, text: txt.slice(0, TRUNC.CONSTRAINT_TEXT), category: cat, confidence: conf });
         break;
       }
     }
@@ -342,12 +332,12 @@ export function buildTimeline(msgs: LlmMessage[], errors: StructuredExtraction["
     const m = msgs[i];
     if (m.role === "user") {
       const txt = extractText(m.content);
-      if (!txt.startsWith("/")) timeline.push({ index: i, event: "user_request", summary: txt.slice(0, 150) });
+      if (!txt.startsWith("/")) timeline.push({ index: i, event: "user_request", summary: txt.slice(0, TRUNC.TIMELINE_EVENT) });
     }
-    if (errorIndices.has(i)) timeline.push({ index: i, event: "error", summary: errors.find(e => e.index === i)?.message.slice(0, 100) ?? "error" });
+    if (errorIndices.has(i)) timeline.push({ index: i, event: "error", summary: errors.find(e => e.index === i)?.message.slice(0, TRUNC.TIMELINE_ERROR) ?? "error" });
   }
   return timeline.length > 30
-    ? [...timeline.filter(t => t.event === "user_request").slice(0, 10), ...timeline.filter(t => t.event === "error")]
+    ? [...timeline.filter(t => t.event === "user_request").slice(0, TRUNC.TIMELINE_DISPLAY), ...timeline.filter(t => t.event === "error")]
     : timeline;
 }
 
@@ -355,7 +345,7 @@ export function extractMainGoal(msgs: LlmMessage[]): string | null {
   for (const m of msgs) {
     if (m?.role !== "user") continue;
     const txt = extractText(m.content).trim();
-    if (txt && !txt.startsWith("/")) return txt.slice(0, 300);
+    if (txt && !txt.startsWith("/")) return txt.slice(0, TRUNC.MESSAGE);
   }
   return null;
 }
@@ -386,11 +376,11 @@ export function extractOpenLoops(msgs: LlmMessage[], extraction: StructuredExtra
       .filter(({ needles }) => needles.some(n => errLower.includes(n)))
       .map(({ path }) => path);
     loops.push({
-      id: "loop-" + (++loopId),
+      id: ID_PREFIX.OPEN_LOOP + (++loopId),
       type: "bugfix",
       priority: err.retryAttempted ? "high" : "normal",
       status: "open",
-      summary: err.message.slice(0, 120),
+      summary: err.message.slice(0, TRUNC.OPEN_LOOP_SUMMARY),
       files: errFiles,
       sourceIndex: err.index,
     });
@@ -410,11 +400,11 @@ export function extractOpenLoops(msgs: LlmMessage[], extraction: StructuredExtra
       const isDup = loops.some(l => Math.abs((l.sourceIndex ?? 0) - idx) < 5);
       if (!isDup) {
         loops.push({
-          id: "loop-" + (++loopId),
+          id: ID_PREFIX.OPEN_LOOP + (++loopId),
           type: "follow-up",
           priority: "normal",
           status: "open",
-          summary: txt.slice(0, 120),
+          summary: txt.slice(0, TRUNC.OPEN_LOOP_SUMMARY),
           files: [],
           sourceIndex: idx,
         });
@@ -432,11 +422,11 @@ export function extractOpenLoops(msgs: LlmMessage[], extraction: StructuredExtra
       const isDup = loops.some(l => Math.abs((l.sourceIndex ?? 0) - idx) < 5);
       if (!isDup) {
         loops.push({
-          id: "loop-" + (++loopId),
+          id: ID_PREFIX.OPEN_LOOP + (++loopId),
           type: "blocked",
           priority: "high",
           status: "open",
-          summary: txt.slice(0, 120),
+          summary: txt.slice(0, TRUNC.OPEN_LOOP_SUMMARY),
           files: [],
           sourceIndex: idx,
         });
@@ -450,11 +440,11 @@ export function extractOpenLoops(msgs: LlmMessage[], extraction: StructuredExtra
     const exists = loops.some(l => l.type === "bugfix" && l.sourceIndex === err.index);
     if (!exists) {
       loops.push({
-        id: "loop-" + (++loopId),
+        id: ID_PREFIX.OPEN_LOOP + (++loopId),
         type: "retry",
         priority: "high",
         status: "open",
-        summary: "Retried but unresolved: " + err.message.slice(0, 80),
+        summary: "Retried but unresolved: " + err.message.slice(0, TRUNC.SNIPPET),
         files: [],
         sourceIndex: err.index,
       });

--- a/src/utils/fingerprint.ts
+++ b/src/utils/fingerprint.ts
@@ -10,6 +10,7 @@ import * as log from "./logger.ts";
 import { projectFingerprintFile } from "../infra/paths.ts";
 import { writeJsonSync, readJsonSync } from "../infra/fs.ts";
 import { findGitRoot as findGitRootCached } from "../infra/git.ts";
+import { THIRTY_DAYS_MS, ID_PREFIX, TRUNC } from "../constants.ts";
 
 export interface ProjectFingerprint {
   id: string;
@@ -69,7 +70,7 @@ function isProjectPath(filePath: string): boolean {
 
 /** Hash a string seed into a short project ID. */
 function hashProjectId(seed: string): string {
-  return "proj-" + crypto.createHash("sha256").update(seed).digest("hex").slice(0, 12);
+  return ID_PREFIX.PROJECT + crypto.createHash("sha256").update(seed).digest("hex").slice(0, TRUNC.PROJ_ID_HASH);
 }
 
 /**
@@ -133,14 +134,14 @@ function deriveFromRelativePaths(paths: string[]): string {
   for (const p of paths) {
     const segs = p.split("/").filter(Boolean);
     if (segs.length >= 2) {
-      const d2 = segs.slice(0, 2).join("/");
+      const d2 = segs.slice(0, TRUNC.FINGERPRINT_SEG).join("/");
       dir2Counts.set(d2, (dir2Counts.get(d2) ?? 0) + 1);
     }
   }
 
   const stableDirs = [...dir2Counts.entries()]
     .sort((a, b) => b[1] - a[1])
-    .slice(0, 8)
+    .slice(0, TRUNC.CONV_HASH)
     .map(([d]) => d)
     .sort();
 
@@ -247,7 +248,7 @@ function extractKeyDirs(extraction: StructuredExtraction, maxDirs = 8): string[]
 export function loadProjectFingerprint(projectId: string): ProjectFingerprint | null {
   const data = readJsonSync<ProjectFingerprint>(getFingerprintPath(projectId));
   if (!data) return null;
-  if (Date.now() - data.updatedAt > 30 * 24 * 60 * 60 * 1000) return null;
+  if (Date.now() - data.updatedAt > THIRTY_DAYS_MS) return null;
   return data;
 }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -6,10 +6,12 @@ import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
 import type { CompactConfig, CompressionProfile, ChunkSummary, LlmChunk, StructuredExtraction, ExplorationReport, SessionType, SessionMessageEntry } from "../types.ts";
-import { DEFAULT_CONFIG, PROFILES, CONFIG_KEY, CONFIG_KEY_ALT } from "../constants.ts";
+import { DEFAULT_CONFIG, PROFILES, CONFIG_KEY, CONFIG_KEY_ALT, TRUNC } from "../constants.ts";
 import * as log from "./logger.ts";
 import { settingsFile, defaultBackupDir } from "../infra/paths.ts";
 import { atomicWriteFileSync, ensureDir } from "../infra/fs.ts";
+import { flattenToolCallBlock } from "./extraction.ts";
+import { extractToolPath } from "../domain/tool-semantics.ts";
 
 const VALID_PROFILES = ["light", "balanced", "aggressive"] as const;
 const PROFILE_NUMERIC_KEYS = ["summaryBudgetTokens", "keepRecentTokens", "minChunkTokens", "maxChunkTokens", "singlePassMaxTokens", "batchMaxTokens"] as const;
@@ -196,7 +198,7 @@ export function backupConversation(convText: string, sessionId: string): string 
     const dir = cfg.backupDir;
     ensureDir(dir);
     const ts = new Date().toISOString().replace(/[:.]/g, "-");
-    const hash = crypto.createHash("sha256").update(convText).digest("hex").slice(0, 8);
+    const hash = crypto.createHash("sha256").update(convText).digest("hex").slice(0, TRUNC.CONV_HASH);
     const fp = path.join(dir, sessionId + "-" + ts + "-" + hash + ".md");
     // Atomic write so a crash mid-write never leaves a half-readable backup.
     atomicWriteFileSync(fp, "# Smart Compact Backup\n# Date: " + new Date().toISOString() + "\n# Session: " + sessionId + "\n\n" + convText);
@@ -231,7 +233,7 @@ export function listBackups(limit = 20): BackupEntry[] {
       try {
         const stat = fs.statSync(full);
         if (!stat.isFile()) continue;
-        const head = fs.readFileSync(full, "utf-8").split("\n").slice(0, 5).join("\n");
+        const head = fs.readFileSync(full, "utf-8").split("\n").slice(0, TRUNC.BACKUP_PREVIEW_LINES).join("\n");
         const date = head.match(/^# Date:\s*(.+)$/m)?.[1]?.trim();
         const session = head.match(/^# Session:\s*(.+)$/m)?.[1]?.trim();
         out.push({
@@ -347,28 +349,26 @@ export function smartKeepBoundary(
 
   if (adjusted <= 0 || adjusted >= msgs.length) return adjusted;
 
-  const last = msgs[adjusted - 1];
-  const first = msgs[adjusted];
-  if (last && first) {
-    // Use extractText-style approach instead of JSON.stringify
-    const getText = (msg: unknown): string => {
-      const m = msg as Record<string, unknown>;
-      const c = m?.content;
-      if (typeof c === "string") return c;
-      if (Array.isArray(c)) return c.map((b: unknown) => {
-        if (typeof b === "string") return b;
-        if (typeof b === "object" && b !== null && (b as { type?: string }).type === "text") return (b as { text?: string }).text ?? "";
-        return "";
-      }).join("");
-      return "";
-    };
-    const lastText = getText(last.message).toLowerCase();
-    const keptText = getText(first.message).toLowerCase();
-    const fileRe = /(?:path|file)=["']([^"']+)["']/g;
-    const lastFiles = new Set([...lastText.matchAll(fileRe)].map(m => m[1].split("/").pop()));
-    fileRe.lastIndex = 0;
-    const keptFiles = new Set([...keptText.matchAll(fileRe)].map(m => m[1].split("/").pop()));
-    if ([...lastFiles].filter(f => keptFiles.has(f)).length > 0) return adjusted - 1;
+  // Topical grouping: if the last compacted message and the first kept message
+  // touch the same file, pull the boundary back one so a file's work isn't split
+  // across the compaction seam. Files come from tool-call arguments — the earlier
+  // prose regex `path="..."` never matched real agent output, so this was a no-op.
+  const touchedFiles = (msg: unknown): Set<string> => {
+    const m = msg as Record<string, unknown>;
+    const blocks = Array.isArray(m?.content) ? m.content : [];
+    const files = new Set<string>();
+    for (const b of blocks) {
+      for (const tc of flattenToolCallBlock(b)) {
+        const fp = extractToolPath(tc.arguments);
+        if (fp) files.add(fp.split("/").pop() ?? fp);
+      }
+    }
+    return files;
+  };
+  const lastFiles = touchedFiles(msgs[adjusted - 1].message);
+  if (lastFiles.size > 0) {
+    const keptFiles = touchedFiles(msgs[adjusted].message);
+    if ([...lastFiles].some(f => keptFiles.has(f))) return adjusted - 1;
   }
   return adjusted;
 }
@@ -537,9 +537,9 @@ export function buildExtractionContext(extraction: StructuredExtraction, forRang
   return [
     "## Deterministic Extraction (verified facts)",
     "Files modified: " + (files.map(f => f.path).join(", ") || "none"),
-    "Errors: " + (errors.map(e => "[" + e.tool + "] " + e.message.slice(0, 80) + (e.resolved ? " ✓" : "")).join("; ") || "none"),
-    "Decisions: " + (extraction.decisions.map(d => d.type + ": " + d.summary.slice(0, 60)).join("; ") || "none"),
-    "Constraints: " + (extraction.constraints.map(c => "[" + c.category + "] " + c.text.slice(0, 60)).join("; ") || "none"),
+    "Errors: " + (errors.map(e => "[" + e.tool + "] " + e.message.slice(0, TRUNC.SNIPPET) + (e.resolved ? " ✓" : "")).join("; ") || "none"),
+    "Decisions: " + (extraction.decisions.map(d => d.type + ": " + d.summary.slice(0, TRUNC.DECISION_DETAIL)).join("; ") || "none"),
+    "Constraints: " + (extraction.constraints.map(c => "[" + c.category + "] " + c.text.slice(0, TRUNC.DECISION_DETAIL)).join("; ") || "none"),
     "Media attachments: " + (media.map(a => a.kind + (a.name ? ":" + a.name : "") + (a.mimeType ? " (" + a.mimeType + ")" : "") + " @msg" + a.index).join("; ") || "none"),
   ].join("\n");
 }
@@ -600,6 +600,8 @@ export type CompactionTier = "none" | "light" | "full";
 
 export function selectCompactionTier(
   contextPercent: number,
+  // toolPercent is recorded by the caller for metrics but deliberately NOT used in
+  // the tier decision: a high tool-output ratio (tool=97%) ≠ context window full.
   toolPercent: number,
   totalTokens: number,
   minThreshold: number,

--- a/src/utils/pruning.ts
+++ b/src/utils/pruning.ts
@@ -33,7 +33,8 @@ const ACK_RE = /^(?:I'?ll |let me |sure|ok[,.]?|got it|i understand|i see|now i|
 const PI_STATUS_RE = /^\[pi-auto-context\]/;
 
 // Maximum chars to keep from a tool result output
-import { MAX_TOOL_OUTPUT_CHARS } from "../constants.ts";
+import { MAX_TOOL_OUTPUT_CHARS, LIKELY_ERROR_RE, ERROR_SCAN_MAX_LEN } from "../constants.ts";
+import { classifyTool, extractToolPath } from "../domain/tool-semantics.ts";
 
 /**
  * Detect and collapse redundant message sequences.
@@ -69,8 +70,10 @@ export function pruneRedundant(msgs: LlmMessage[], precomputedTcIdx?: ToolCallIn
   for (let i = 0; i < msgs.length; i++) {
     if (msgs[i].role !== "toolResult") continue;
     const tc = tcIdx.get(msgs[i].toolCallId ?? "");
-    if (!tc || tc.name !== "read") continue;
-    const fp = (tc?.arguments?.path ?? tc?.arguments?.file_path) as string | undefined;
+    // Dedup lookups by argument shape (read/grep/find/ls…), not tool name —
+    // same name-agnostic rule as the other consumers. See domain/tool-semantics.ts.
+    if (!tc || classifyTool(tc.arguments) !== "accesses") continue;
+    const fp = extractToolPath(tc.arguments);
     if (!fp) continue;
     const arr = readIndices.get(fp) ?? [];
     arr.push(i);
@@ -176,7 +179,14 @@ export function pruneRedundant(msgs: LlmMessage[], precomputedTcIdx?: ToolCallIn
     if (text.length > 0) originalTokens += estimateTokens(text);
     if (!keep.has(idx)) continue;
 
-    if (m.role === "toolResult" && text.length > MAX_TOOL_OUTPUT_CHARS) {
+    // Don't truncate tool outputs catalogErrors would actually scan for errors
+    // (short enough to be scanned + containing an error keyword) — truncation
+    // can drop a mid-output error keyword and hide a real error from extraction.
+    const protectFromTruncation = m.role === "toolResult"
+      && text.length > MAX_TOOL_OUTPUT_CHARS
+      && text.length < ERROR_SCAN_MAX_LEN
+      && LIKELY_ERROR_RE.test(text);
+    if (m.role === "toolResult" && text.length > MAX_TOOL_OUTPUT_CHARS && !protectFromTruncation) {
       // Split the budget evenly between head and tail. Derived from
       // MAX_TOOL_OUTPUT_CHARS so future bumps to the constant don't
       // silently leave the slice sizes out of date.

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -6,12 +6,13 @@
 
 import fs from "node:fs";
 import type { StructuredExtraction, OpenLoop, CompactionState, ExplorationReport, SessionType } from "../types.ts";
-import { VERSION } from "../constants.ts";
+import { VERSION, SEVEN_DAYS_MS, TRUNC, ID_PREFIX } from "../constants.ts";
 import { inferSessionType } from "./helpers.ts";
 import * as log from "./logger.ts";
 import { compactionStateFile } from "../infra/paths.ts";
 import { writeJsonSync, readJsonSync } from "../infra/fs.ts";
-import { parseSummary, upsertSection, renderSummary, appendToSection } from "../domain/summary-parse.ts";
+import { parseSummary, findSection, upsertSection, renderSummary, appendToSection } from "../domain/summary-parse.ts";
+import { buildPathNeedles } from "./file-needles.ts";
 
 function getStatePath(projectId: string): string {
   return compactionStateFile(projectId);
@@ -43,7 +44,7 @@ export function loadCompactionState(projectId: string): CompactionState | null {
     if (!updatedAt) {
       try { updatedAt = fs.statSync(fp).mtimeMs; } catch (e) { log.debug("statSync failed for state file", e); updatedAt = 0; }
     }
-    if (Date.now() - updatedAt > 7 * 24 * 60 * 60 * 1000) return null;
+    if (Date.now() - updatedAt > SEVEN_DAYS_MS) return null;
   }
   return data;
 }
@@ -59,23 +60,22 @@ export function buildCompactionState(
   let constraintId = 0;
   let errorId = 0;
 
-  // Precompute basenames once; previously recomputed for every (error × file) pair.
-  const modifiedBasenames = extraction.modifiedFiles.map(f => ({
-    path: f.path,
-    bn: f.path.split("/").pop()?.toLowerCase() ?? "",
-  }));
+  // Precompute path-suffix needles once (drops generic basenames like index.ts
+  // so an error about lib/index.ts doesn't attach to src/index.ts). Same helper
+  // extractOpenLoops uses, keeping error→file attribution consistent pipeline-wide.
+  const fileNeedles = extraction.modifiedFiles.map(f => ({ path: f.path, needles: buildPathNeedles(f.path) }));
 
   return {
     goal: extraction.mainGoal,
     decisions: extraction.decisions.map(d => ({
-      id: "decision-" + (++decisionId),
-      summary: d.summary.slice(0, 200),
-      ...(d.userResponse ? { userResponse: d.userResponse.slice(0, 300) } : {}),
+      id: ID_PREFIX.DECISION + (++decisionId),
+      summary: d.summary.slice(0, TRUNC.DECISION_SUMMARY),
+      ...(d.userResponse ? { userResponse: d.userResponse.slice(0, TRUNC.USER_RESPONSE) } : {}),
       type: d.type,
     })),
     constraints: extraction.constraints.map(c => ({
       id: "constraint-" + (++constraintId),
-      text: c.text.slice(0, 300),
+      text: c.text.slice(0, TRUNC.CONSTRAINT_TEXT),
       category: c.category,
       confidence: c.confidence,
     })),
@@ -84,17 +84,17 @@ export function buildCompactionState(
     deletedFiles: extraction.deletedFiles,
     unresolvedErrors: extraction.errors.filter(e => !e.resolved).map(e => {
       const msgLower = e.message.toLowerCase();
-      const bn = modifiedBasenames.find(f => f.bn.length > 0 && msgLower.includes(f.bn));
+      const match = fileNeedles.find(({ needles }) => needles.some(n => msgLower.includes(n)));
       return {
-        id: "error-" + (++errorId),
-        message: e.message.slice(0, 300),
+        id: ID_PREFIX.ERROR + (++errorId),
+        message: e.message.slice(0, TRUNC.MESSAGE),
         tool: e.tool,
-        files: bn ? [bn.path] : [],
+        files: match ? [match.path] : [],
       };
     }),
     resolvedErrors: extraction.errors.filter(e => e.resolved).map(e => ({
-      id: "error-" + (++errorId),
-      message: e.message.slice(0, 300),
+      id: ID_PREFIX.ERROR + (++errorId),
+      message: e.message.slice(0, TRUNC.MESSAGE),
       tool: e.tool,
     })),
     openLoops,
@@ -160,44 +160,47 @@ export interface CompactionDelta {
 }
 
 export function computeDelta(prev: CompactionState, current: CompactionState): CompactionDelta {
-  // Decisions: fuzzy match by summary keywords
-  const prevDecisionTexts = new Set(prev.decisions.map(d => d.summary.toLowerCase().slice(0, 60)));
-  const currDecisionTexts = new Set(current.decisions.map(d => d.summary.toLowerCase().slice(0, 60)));
+  // Match on full normalized text. Extraction is deterministic, so the same
+  // item yields identical text across compactions — the old `slice(0, N)` prefix
+  // keys collided two different items that shared an opening and made the
+  // change invisible in the delta (newDecisions/removedDecisions both empty).
+  const key = (s: string): string => s.toLowerCase().replace(/\s+/g, " ").trim();
+
+  // Decisions
+  const prevDecisionTexts = new Set(prev.decisions.map(d => key(d.summary)));
+  const currDecisionTexts = new Set(current.decisions.map(d => key(d.summary)));
   const newDecisions = current.decisions
-    .filter(d => !prevDecisionTexts.has(d.summary.toLowerCase().slice(0, 60)))
+    .filter(d => !prevDecisionTexts.has(key(d.summary)))
     .map(d => d.summary);
   const removedDecisions = prev.decisions
-    .filter(d => !currDecisionTexts.has(d.summary.toLowerCase().slice(0, 60)))
+    .filter(d => !currDecisionTexts.has(key(d.summary)))
     .map(d => d.summary);
 
-  // Open loops: match by summary fuzzy
-  const prevLoopSummaries = new Map(prev.openLoops.map(l => [l.summary.toLowerCase().slice(0, 50), l]));
-  const currLoopSummaries = new Map(current.openLoops.map(l => [l.summary.toLowerCase().slice(0, 50), l]));
+  // Open loops (summaries are already bounded to ~120 chars at extraction time)
+  const prevLoopSummaries = new Map(prev.openLoops.map(l => [key(l.summary), l]));
+  const currLoopKeys = new Set(current.openLoops.map(l => key(l.summary)));
   const resolvedLoops: string[] = [];
   const persistentLoops: string[] = [];
-  for (const [key, loop] of prevLoopSummaries) {
-    if (currLoopSummaries.has(key)) {
-      persistentLoops.push(loop.summary);
-    } else {
-      resolvedLoops.push(loop.summary);
-    }
+  for (const [k, loop] of prevLoopSummaries) {
+    if (currLoopKeys.has(k)) persistentLoops.push(loop.summary);
+    else resolvedLoops.push(loop.summary);
   }
   const newLoops = current.openLoops
-    .filter(l => !prevLoopSummaries.has(l.summary.toLowerCase().slice(0, 50)))
+    .filter(l => !prevLoopSummaries.has(key(l.summary)))
     .map(l => l.summary);
 
   // Files: diff sets
   const prevFiles = new Set(prev.modifiedFiles);
   const newModifiedFiles = current.modifiedFiles.filter(f => !prevFiles.has(f));
 
-  // Errors: match by message snippet
-  const prevErrorMsgs = new Set(prev.unresolvedErrors.map(e => e.message.toLowerCase().slice(0, 40)));
-  const currErrorMsgs = new Set(current.unresolvedErrors.map(e => e.message.toLowerCase().slice(0, 40)));
+  // Errors (messages bounded to ~300 chars at build time)
+  const prevErrorMsgs = new Set(prev.unresolvedErrors.map(e => key(e.message)));
+  const currErrorMsgs = new Set(current.unresolvedErrors.map(e => key(e.message)));
   const resolvedErrors = prev.unresolvedErrors
-    .filter(e => !currErrorMsgs.has(e.message.toLowerCase().slice(0, 40)))
+    .filter(e => !currErrorMsgs.has(key(e.message)))
     .map(e => e.message);
   const newErrors = current.unresolvedErrors
-    .filter(e => !prevErrorMsgs.has(e.message.toLowerCase().slice(0, 40)))
+    .filter(e => !prevErrorMsgs.has(key(e.message)))
     .map(e => e.message);
 
   // Goal change
@@ -223,22 +226,22 @@ export function formatDeltaSection(delta: CompactionDelta): string {
   }
 
   if (delta.resolvedLoops.length) {
-    lines.push("- **Resolved loops**: " + delta.resolvedLoops.map(s => "~~" + s.slice(0, 60) + "~~").join(", "));
+    lines.push("- **Resolved loops**: " + delta.resolvedLoops.map(s => "~~" + s.slice(0, TRUNC.DECISION_DETAIL) + "~~").join(", "));
   }
   if (delta.persistentLoops.length) {
-    lines.push("- **Still open**: " + delta.persistentLoops.map(s => s.slice(0, 60)).join("; "));
+    lines.push("- **Still open**: " + delta.persistentLoops.map(s => s.slice(0, TRUNC.DECISION_DETAIL)).join("; "));
   }
   if (delta.newLoops.length) {
-    lines.push("- **New loops**: " + delta.newLoops.map(s => s.slice(0, 60)).join("; "));
+    lines.push("- **New loops**: " + delta.newLoops.map(s => s.slice(0, TRUNC.DECISION_DETAIL)).join("; "));
   }
   if (delta.newDecisions.length) {
-    lines.push("- **New decisions**: " + delta.newDecisions.map(s => s.slice(0, 80)).join("; "));
+    lines.push("- **New decisions**: " + delta.newDecisions.map(s => s.slice(0, TRUNC.SNIPPET)).join("; "));
   }
   if (delta.resolvedErrors.length) {
-    lines.push("- **Resolved errors**: " + delta.resolvedErrors.map(s => s.slice(0, 60)).join("; "));
+    lines.push("- **Resolved errors**: " + delta.resolvedErrors.map(s => s.slice(0, TRUNC.DECISION_DETAIL)).join("; "));
   }
   if (delta.newErrors.length) {
-    lines.push("- **New errors**: " + delta.newErrors.map(s => s.slice(0, 60)).join("; "));
+    lines.push("- **New errors**: " + delta.newErrors.map(s => s.slice(0, TRUNC.DECISION_DETAIL)).join("; "));
   }
   if (delta.newModifiedFiles.length) {
     lines.push("- **New files touched**: " + delta.newModifiedFiles.join(", "));
@@ -314,9 +317,12 @@ export function ensurePinnedPaths(summary: string, pinned: readonly string[]): s
  * Extract next actions from the summary's "Next Steps" section.
  */
 export function extractNextActions(summary: string): string[] {
-  const match = summary.match(/## Next Steps\s*\n([\s\S]*?)(?=##|$)/);
-  if (!match) return [];
-  return match[1]
+  // Canonical parser (not a raw `## Next Steps` regex) so H1/H2 and capitalization
+  // drift ("## Next steps") still resolve — the rest of the pipeline moved off
+  // substring scanning for the same reason.
+  const section = findSection(summary, "next-steps");
+  if (!section) return [];
+  return section.body
     .split("\n")
     .map(l => l.replace(/^\d+\.\s*/, "").trim())
     .filter(l => l.length > 0);
@@ -326,7 +332,7 @@ export function extractNextActions(summary: string): string[] {
  * Extract critical context lines from the summary.
  */
 export function extractCriticalContext(summary: string): string[] {
-  const match = summary.match(/## Critical Context\s*\n([\s\S]*?)(?=##|$)/);
-  if (!match) return [];
-  return match[1].split("\n").map(l => l.replace(/^-\s*/, "").trim()).filter(l => l.length > 0);
+  const section = findSection(summary, "critical-context");
+  if (!section) return [];
+  return section.body.split("\n").map(l => l.replace(/^-\s*/, "").trim()).filter(l => l.length > 0);
 }

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -2,7 +2,7 @@
  * Token estimation with provider-specific ratios and EMA calibration.
  */
 
-import { CHARS_PER_TOKEN } from "../constants.ts";
+import { CHARS_PER_TOKEN, TUNING } from "../constants.ts";
 import type { ProviderCapabilities } from "../types.ts";
 
 const PROVIDER_MAP: Record<string, ProviderCapabilities> = {
@@ -152,8 +152,8 @@ export class TokenCalibrationStore {
     // EMA smoothing: 70% previous, 30% new sample. Clamp the ratio to a
     // sane range so a one-off outlier response (e.g. a truncated reply)
     // can't permanently skew estimates.
-    const clamped = Math.max(0.3, Math.min(3.0, sample));
-    this.factors.set(key, prev * 0.7 + clamped * 0.3);
+    const clamped = Math.max(TUNING.CALIBRATION_CLAMP_MIN, Math.min(TUNING.CALIBRATION_CLAMP_MAX, sample));
+    this.factors.set(key, prev * TUNING.EMA_PREV + clamped * TUNING.EMA_SAMPLE);
   }
 }
 
@@ -168,10 +168,31 @@ export function __resetTokenCalibrationForTests(): void {
   _fallbackCalibration.clear();
 }
 
+/** JSON-density tuning knobs (named, not inline magic numbers). */
+const JSON_PENALTY = 0.85;
+const JSON_DENSITY_THRESHOLD = 0.05;
+/** Cap the density scan so a multi-MB conversation serialization can't pause the pipeline. */
+const JSON_DENSITY_SCAN_CAP = 8192;
+
 export function estimateTokens(text: string, provider?: string, model?: string, calibration = _fallbackCalibration): number {
   const baseRatio = provider ? getProviderCaps(provider).tokenRatioEstimate : CHARS_PER_TOKEN;
-  // JSON content has denser tokenization (brackets, quotes, escapes)
-  const jsonPenalty = text.startsWith("[") || text.startsWith("{") ? 0.85 : 1.0;
+  // JSON content has denser tokenization. The leading-brace check covers
+  // per-message JSON tool results; the density fallback catches concatenations
+  // that don't start with JSON. Capped so a multi-MB serialization can't pause.
+  const startsJson = text.startsWith("[") || text.startsWith("{");
+  let jsonPenalty = 1.0;
+  if (startsJson) {
+    jsonPenalty = JSON_PENALTY;
+  } else if (text.length > 0) {
+    const sample = text.length > JSON_DENSITY_SCAN_CAP ? text.slice(0, JSON_DENSITY_SCAN_CAP) : text;
+    let structural = 0;
+    for (let i = 0; i < sample.length; i++) {
+      const c = sample.charCodeAt(i);
+      // 34 "  91 [  93 ]  123 {  125 }
+      if (c === 34 || c === 91 || c === 93 || c === 123 || c === 125) structural++;
+    }
+    if (structural / sample.length > JSON_DENSITY_THRESHOLD) jsonPenalty = JSON_PENALTY;
+  }
   // Turkish/CE characters tokenize differently (multi-byte in some tokenizers)
   const langPenalty = /[çğıöşüÇĞİÖŞÜ]/.test(text) ? 0.9 : 1.0;
   const factor = calibration.get(provider, model);

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -222,10 +222,12 @@ describe("mergeExtractions — messageCount", () => {
 // ── mainGoal / lastUserMessages / lastErrors ──
 
 describe("mergeExtractions — field precedence", () => {
-  it("prefers delta.mainGoal over base", () => {
+  it("preserves the original (base) mainGoal over the delta suffix", () => {
+    // mainGoal is the FIRST user message (the original objective). The delta
+    // suffix's first user message is mid-conversation, not the goal — so base wins.
     const base = makeExtraction({ mainGoal: "old goal" });
     const delta = makeExtraction({ mainGoal: "new goal" });
-    expect(mergeExtractions(base, delta, 5).mainGoal).toBe("new goal");
+    expect(mergeExtractions(base, delta, 5).mainGoal).toBe("old goal");
   });
 
   it("falls back to base.mainGoal when delta is null", () => {
@@ -234,10 +236,12 @@ describe("mergeExtractions — field precedence", () => {
     expect(mergeExtractions(base, delta, 5).mainGoal).toBe("old goal");
   });
 
-  it("prefers delta.lastUserMessages when non-empty", () => {
+  it("spans the cache boundary for lastUserMessages", () => {
+    // "last N" must cross the base/delta boundary; the suffix alone is
+    // incomplete when it carries fewer than N user messages.
     const base = makeExtraction({ lastUserMessages: ["old msg"] });
     const delta = makeExtraction({ lastUserMessages: ["new msg 1", "new msg 2"] });
-    expect(mergeExtractions(base, delta, 5).lastUserMessages).toEqual(["new msg 1", "new msg 2"]);
+    expect(mergeExtractions(base, delta, 5).lastUserMessages).toEqual(["old msg", "new msg 1", "new msg 2"]);
   });
 
   it("falls back to base.lastUserMessages when delta is empty", () => {

--- a/test/damage.test.ts
+++ b/test/damage.test.ts
@@ -118,8 +118,8 @@ describe("detectDamage", () => {
   });
 
   it("detects a re-question when the user mentions a compacted topic", () => {
-    // Topic word check requires ≥2 long (>4 char) words appearing in the
-    // user message. We hit that bar with both "refactor" and "authentication".
+    // Salient-keyword match: "Refactor" (capitalized → salient token) from the
+    // compacted topic appears in the user's re-question.
     const messages: LlmMessage[] = [
       userMsg("Can you remind me what we decided about the refactor authentication?"),
     ];


### PR DESCRIPTION
## Summary

11 bug fixes across the EESV pipeline, complete magic-value centralization, and a new shared keyword-extraction module.

### Bug fixes
- `mergeExtractions` mainGoal corruption (incremental extraction replaced original goal with delta-suffix message)
- `mergeExtractions` lastUserMessages/lastErrors boundary gap
- `catalogErrors` id-less retry resolution (name fallback)
- Pruning hides mid-output errors (shared `LIKELY_ERROR_RE`, preserve short error outputs)
- `computeDelta` prefix-slice collision (full-normalized text)
- `smartKeepBoundary` dead file-overlap regex → toolCall-arg extraction
- `buildCompactionState` raw basename → `buildPathNeedles`
- `extractNextActions`/`Critical` case-sensitive regex → canonical `findSection`
- `CONSTRAINT_PATTERNS` `\\b` → lookarounds (Turkish-leading chars now match)
- `verifySummary` salient-token keyword extraction + error snippet normalize
- `estimateTokens` JSON density fallback (capped 8KB)

### Centralization (zero inline magic values)
- `TRUNC` / `ID_PREFIX` / `TUNING` objects in constants.ts
- Shared durations (7d×3, 1h×2 deduped), `EXTRACTION_CACHE_PREFIX`, `makeCompactSessionId` single source
- ~70 truncation/prefix/confidence literals centralized

### New
- `domain/keywords.ts` — `extractCheckKeywords` (shared by verify + damage)

**Tests: 501 pass / 0 fail. Typecheck clean.**