### PR TITLE
fix: audit fixes — persist wiring, UTF-8 streaming, lock race, explicit metrics DI (v7.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [7.18.1] - 2026-07-09
+
+### Fixed
+- **TUI model selection override** — when `summaryModel` was set in config, picking a different model in the compact picker still ran the configured default; explicit selections (TUI picker / CLI model arg) now win over `config.summaryModel`. Auto-trigger and tool paths still fall back to the configured default.
+
+### Changed
+- **Dependencies** — bumped `@earendil-works/*` 0.79.6 → 0.80.3, `typebox` 1.2.16 → 1.3.6, `@types/node` 26.0.1 → 26.1.1, `typescript` 6.0.3 → 7.0.2.
+- **`complete` import** — pi-ai 0.80 removed the standalone `complete()`/`stream()` from the package root; now imported from `@earendil-works/pi-ai/compat` (the host's `ModelRegistry` is itself compat-backed, so this is the extension-correct path until the host's ModelManager migration lands).
+
 ## [7.18.0] - 2026-06-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [7.19.0] - 2026-07-10
+
+### Fixed
+- **Durable state never persisted on auto/tool paths (C1)** — `persistDurableState` only ran from `applyCompaction`'s `onComplete`, which auto-trigger and tool runs never reach (early return on `skipCompact || autoTriggered`). Project fingerprint, compaction state, and the whole cross-compaction delta/damage-baseline chain silently never ran on the most common path. `PendingCompaction` now carries `projectId` + `extraction`, and the new `persistConsumedState` persists exactly once at the `session_before_compact` consume point — the single apply moment shared by all three run types.
+- **UTF-8 corruption in session-log streaming (C2)** — `streamJsonlLines` decoded each 64KB chunk with a bare `toString("utf-8")`; a multi-byte character split across the chunk boundary became U+FFFD and silently failed that line's `JSON.parse`, dropping the message to its truncated branch copy. Now uses `StringDecoder`.
+- **Lock stale-reclaim race (M3)** — two waiters both observing a stale `.lock` could end up co-holding it (`rmdir` of a freshly reclaimed lock). Reclaim now goes through an atomic rename-steal; exactly one thief wins, and a stolen-but-live lock is restored.
+- **Typo'd model arg silently ignored (M5)** — `/smart-compact provider/bad-model` fell back to the current model without warning. Unresolvable model args with a known provider prefix now fail loudly; note tokens like `src/auth.ts` are unaffected.
+- **`BLOCKED_RE` over-matching** — bare `depend` flagged routine "dependency" mentions as high-priority blocked loops; narrowed to `\bdepends? on\b`, added the same min-length/command guard as the follow-up scan, and fixed the `bağlı` diacritic form.
+- **Timeline dropped the newest user requests** — the >30-event trim kept the *first* N requests and clumped errors at the end; now keeps the most recent N and re-sorts chronologically.
+- **Success metric recorded before apply (m8)** — manual runs logged `success` before `ctx.compact()` could still fail, inflating dashboard reliability. Manual outcomes now come from the native compact's own callbacks (`onComplete` → success, `onError` → error); auto/tool runs still record at staging.
+- **Tool `dry_run` reported failure** — the empty pending slot after a dry-run produced "no summary was generated"; now reports the dry run as the success it is.
+- **`createServices` captured the LLM client eagerly** — a `setLlmClient` installed after the bag was created was ignored, breaking the seam's call-time-resolution contract; the bag now holds a lazy delegate.
+
+### Changed
+- **Metrics surface migrated to explicit DI** — removed the module-level compatibility shims (`resetMetrics`, `getMetrics`, `resetExtractionCacheStats`) and the hidden `getDefaultServices()` fallbacks on `recordMetric`/`getMetricsSummary`/`appendMetricsLog`/`getExtractionCacheStats`/`cacheOpts`. All consumers pass the run-scoped services bag; the single sanctioned fallback lives at the top of `trackedComplete`.
+- **Backup prune deferral is a real macrotask** — `queueMicrotask` ran before control returned to the event loop, so the readdir+stat scan still blocked the triggering turn; now `setTimeout(0)`.
+- **Perf** — dropped the write-only `prunedToolCallIndex` from `RunContext`; capped `estimateTokens`' Turkish-character scan to the same 8KB sample as the JSON-density check; removed a per-ref Set re-materialization in `verifySummary`.
+
 ## [7.18.2] - 2026-07-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [7.18.2] - 2026-07-09
+
+### Fixed
+- **Extension load failure after 7.18.1** — 7.18.1 imported `complete` from the `@earendil-works/pi-ai/compat` subpath statically, which is not aliased by some host builds and crashed the extension at load time (`Cannot find module .../dist/index.js/compat`). `complete` is now resolved with a dynamic `import("@earendil-works/pi-ai/compat")` on first use, which is aliased by the host loader and resolves directly in raw node — works in both host and test contexts, and can never break extension loading.
+
 ## [7.18.1] - 2026-07-09
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,12 @@
     "": {
       "name": "pi-smart-compact",
       "devDependencies": {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*",
-        "@earendil-works/pi-tui": "*",
-        "@types/node": "^26.0.0",
-        "typebox": "*",
-        "typescript": "^6.0.0",
+        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-coding-agent": "^0.80.3",
+        "@earendil-works/pi-tui": "^0.80.3",
+        "@types/node": "^26.1.1",
+        "typebox": "^1.3.6",
+        "typescript": "^7.0.0",
       },
       "peerDependencies": {
         "@earendil-works/pi-ai": "*",
@@ -75,13 +75,13 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.6", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.6", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-SXZc4rQI+3zgUmAJDbU0GzFEHCPHbhItjN7QLsahj3TKfQAon4guwCqsrwZBLH5lPcub2+evTojPNrPItL62tA=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.3", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.3", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.6", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-KGepEdgEeWDs7Imwlp96tBsO8TjSIpcDBvazsCDtHRa81+uwJI/YGetTegI52pMlKhVpJFLIGajRi4PCGC5MUg=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.79.6", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.79.6", "@earendil-works/pi-ai": "^0.79.6", "@earendil-works/pi-tui": "^0.79.6", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.3.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-xPQDoA3+4Q8UsInST8OGFHPHyi7JQIbx51ku5kf2VuhXrrTv/npjVTXYD3A3D5xs6QRebV0B2mQqHfXaxQAplw=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.3", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.3", "@earendil-works/pi-ai": "^0.80.3", "@earendil-works/pi-tui": "^0.80.3", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.79.6", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-6JCq780X0UuqvJsUDSJmi4V54ObB8qSwFQiBOI1jhPpC+Ydusd8SEXn2HtyIqve/utMgwcZT9aOyZM72m26A0w=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.3", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
@@ -107,9 +107,13 @@
 
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
 
-    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
 
     "@nodable/entities": ["@nodable/entities@2.1.1", "", {}, "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.42.0", "", {}, "sha512-icc5xCzndZfhuJMy5oqk5AvloWquR7jtae74qzpkKkhGp8BivK+oCcEXgGnjCdTfp8hA44l+w8gE8yYJbocJJw=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -151,9 +155,49 @@
 
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
-    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -277,11 +321,11 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typebox": ["typebox@1.2.16", "", {}, "sha512-p85YWtR1RznP2kt/sftmj1leGiObfHVJwkK2hkDdEKhbtQONeUeBtbYdK0x9tLPh+5AaEPD62APv189Cy+/C2g=="],
+    "typebox": ["typebox@1.3.6", "", {}, "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA=="],
 
-    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
-    "undici": ["undici@8.3.0", "", {}, "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q=="],
+    "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "7.18.2",
+  "version": "7.19.0",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "7.18.0",
+  "version": "7.18.1",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",
@@ -61,12 +61,12 @@
     "typebox": "*"
   },
   "devDependencies": {
-    "@types/node": "^26.0.0",
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*",
-    "typebox": "*",
-    "typescript": "^6.0.0"
+    "@types/node": "^26.1.1",
+    "@earendil-works/pi-ai": "^0.80.3",
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3",
+    "typebox": "^1.3.6",
+    "typescript": "^7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/app/run-context.ts
+++ b/src/app/run-context.ts
@@ -176,12 +176,6 @@ export interface ExtractedExt extends TieredExt {
   pruning: PruningResult;
   currentEntryIds: string[];
   currentKeptEntryIds: string[];
-  /**
-   * ToolCallIndex over the **pruned** message list. Built once in
-   * `extractWithCache` and reused by extraction. Keyed against pruned offsets,
-   * not the unpruned message list — do not confuse with `pruning.toolCallIndex`.
-   */
-  prunedToolCallIndex: import("../utils/extraction.ts").ToolCallIndex;
   extraction: StructuredExtraction;
   extractionCacheMissReason?: string;
   prevContext: string;

--- a/src/app/run-smart-compact.ts
+++ b/src/app/run-smart-compact.ts
@@ -247,7 +247,13 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
     runDamageDetection(stated);
     markPhase(stated, "damage");
 
-    recordSuccessMetrics(stated, "success");
+    // Metric ordering: for auto/tool runs the pipeline's job ends at staging
+    // (Pi applies via session_before_compact), so "success" is recorded now.
+    // Manual runs go through applyCompaction below, which records success or
+    // error from the native compact's own callbacks — recording here would
+    // claim success for an apply that can still fail.
+    const willApply = !stated.flags.skipCompact && !stated.flags.autoTriggered;
+    if (!willApply) recordSuccessMetrics(stated, "success");
 
     if (!stated.flags.autoTriggered) {
       try {

--- a/src/app/steps/extract.ts
+++ b/src/app/steps/extract.ts
@@ -165,7 +165,6 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
     pruning: PruningResult;
     currentEntryIds: string[];
     currentKeptEntryIds: string[];
-    prunedToolCallIndex: ToolCallIndex;
     extraction: StructuredExtraction;
     extractionCacheMissReason?: string;
     prevContext: string;
@@ -178,7 +177,6 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
   out.pruning = pruning;
   out.currentEntryIds = currentEntryIds;
   out.currentKeptEntryIds = currentKeptEntryIds;
-  out.prunedToolCallIndex = prunedTcIdx;
   out.extraction = extraction;
   out.extractionCacheMissReason = missReason;
   out.prevContext = prevContext;

--- a/src/app/steps/persist.ts
+++ b/src/app/steps/persist.ts
@@ -24,23 +24,30 @@ import { saveProjectFingerprint } from "../../utils/fingerprint.ts";
 import { saveCompactionState } from "../../utils/state.ts";
 import { detectDamage, logDamageReport, writeRemediationHints } from "../../utils/damage.ts";
 import { sanitizeSmartCompactDetails } from "../../utils/type-guards.ts";
+import { recordSuccessMetrics, recordFailureMetrics } from "./metrics.ts";
+import type { StatedRc } from "../run-context.ts";
 import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { asBranchMessage } from "../../infra/ai-messages.ts";
 import { markPhase } from "../run-context.ts";
 import * as log from "../../utils/logger.ts";
 
 /**
- * Persist project fingerprint + compaction state. Pulled into its own function
- * so the post-compact onComplete callback in the orchestrator can invoke it
- * exactly once after the native compact succeeds.
+ * Persist durable state for a *consumed* pending payload.
  *
- * `RunContext` is the final `StatedRc` stage, so both `extraction` and
- * `compactionState` are statically known to be present here — no defensive
- * `!` or runtime guards needed.
+ * Single persist point for every run type. All three paths (manual, auto,
+ * tool) apply the summary through `session_before_compact` consuming the
+ * slot — the manual path's `ctx.compact()` fires that same event. Persisting
+ * at consume therefore covers every path exactly once; persisting anywhere
+ * else either misses the auto/tool paths (the old onComplete-only wiring) or
+ * double-writes on manual (incrementing the fingerprint sessionCount twice).
+ * Best-effort: never throws.
  */
-export function persistDurableState(rc: RunContext): void {
-  saveProjectFingerprint(rc.projectId, rc.extraction);
-  saveCompactionState(rc.projectId, rc.compactionState);
+export function persistConsumedState(pending: PendingCompaction): void {
+  if (!pending.projectId) return;
+  try {
+    if (pending.extraction) saveProjectFingerprint(pending.projectId, pending.extraction);
+    if (pending.compactionState) saveCompactionState(pending.projectId, pending.compactionState);
+  } catch (e) { log.warn("persistConsumedState failed", e); }
 }
 
 /** Run post-compaction damage detection. Best-effort — never throws. */
@@ -96,6 +103,8 @@ export function stagePendingCompaction(rc: RunContext): PendingCompaction {
     tokensBefore: rc.totalTokens,
     details: rc.details,
     compactionState: rc.compactionState,
+    projectId: rc.projectId,
+    extraction: rc.extraction,
     sessionId: rc.sessionId,
   };
   rc.pendingRef.set(pending);
@@ -103,26 +112,35 @@ export function stagePendingCompaction(rc: RunContext): PendingCompaction {
 }
 
 /**
- * Trigger Pi's native compact in non-auto/non-tool runs. The state-persist
- * callback fires on success; failure clears the pendingRef so the next
- * compact event cannot grab a stale summary (audit P1 #4).
+ * Trigger Pi's native compact in non-auto/non-tool runs. Failure clears the
+ * pendingRef so the next compact event cannot grab a stale summary (audit
+ * P1 #4).
+ *
+ * The run's outcome metric is recorded HERE, not before the apply: a
+ * "success" row written pre-apply would inflate dashboard reliability when
+ * the native compact then rejects. onComplete → success; onError → error.
  */
-export function applyCompaction(rc: RunContext): void {
+export function applyCompaction(rc: StatedRc): void {
   if (rc.flags.skipCompact || rc.flags.autoTriggered) return;
   rc.ctx.compact({
     customInstructions: "Use pre-computed smart summary from /smart-compact",
     onComplete: () => {
-      // Defer durable state until Pi confirms the compaction was applied
-      // (audit P1 #5: previously this state was written before apply, so a
-      // failed compact would leave the cache claiming success).
-      try { persistDurableState(rc); } catch (e) { log.warn("persistDurableState failed", e); }
+      // Durable state is persisted when `session_before_compact` consumes
+      // the pending slot (see persistConsumedState) — doing it here as well
+      // would double-increment the project fingerprint's sessionCount.
       markPhase(rc, "persist");
+      recordSuccessMetrics(rc, "success");
       rc.ctx.ui.notify("Applied \u2713", "info");
     },
     onError: e => {
       // Clear the pending summary so a later `session_before_compact` event
       // can't apply a half-rotten payload that Pi already refused.
       rc.pendingRef.clear();
+      recordFailureMetrics(rc, e, {
+        sessionId: rc.sessionId, tier: rc.tier, contextPercent: rc.contextPercent,
+        toolPercent: rc.toolPercent, totalTokens: rc.totalTokens,
+        methodForMetrics: rc.method, profile: rc.profile,
+      });
       rc.ctx.ui.notify("Failed: " + e.message, "error");
     },
   });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "7.18.1";
+export const VERSION = "7.18.2";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "7.18.2";
+export const VERSION = "7.19.0";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "7.18.0";
+export const VERSION = "7.18.1";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,21 +50,25 @@ function unwrapConsumed(result: ConsumeResult, ctx: ExtensionContext): PendingCo
 // These helpers only depend on `modelRegistry` + `model`, which are part of
 // the shared `ExtensionContext` surface; no command-only methods are needed.
 /** Resolve a "provider/id" string through the model registry. */
-function findModelById(ctx: ExtensionContext, modelId: string): Model<Api> | undefined {
+export function findModelById(ctx: ExtensionContext, modelId: string): Model<Api> | undefined {
   const [p, ...r] = modelId.split("/");
   return ctx.modelRegistry.find(p, r.join("/"));
 }
 
-function resolveModels(
+export function resolveModels(
   ctx: ExtensionContext,
   primary: Model<Api> | undefined,
   config: ReturnType<typeof loadConfig>,
+  explicit = false,
 ): { segModel: Model<Api> | undefined; sumModel: Model<Api> | undefined } {
   const fallback = primary ?? ctx.model;
   const available = ctx.modelRegistry.getAvailable();
   let sumModel = fallback;
 
-  if (config.summaryModel) {
+  // An explicit user selection (TUI picker or CLI model arg) wins over the
+  // configured default; only fall back to config.summaryModel when no model
+  // was explicitly chosen (auto-trigger / tool path).
+  if (!explicit && config.summaryModel) {
     const found = findModelById(ctx, config.summaryModel);
     if (found) sumModel = found;
   }
@@ -181,13 +185,13 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
           const defIdx = cur ? opts.findIndex(o => o.value === cur.provider + "/" + cur.id) : 0;
           const selected = await showCompactUI(ctx, { contextTokens: totalTokens, contextPercent: pct, currentModel: cur ? cur.provider + "/" + cur.id : "?", defaultModelIndex: defIdx >= 0 ? defIdx : 0 });
           if (!selected) { ctx.ui.notify("Cancelled", "info"); return; }
-          const { segModel, sumModel } = resolveModels(ctx, selected.model.model, loadConfig());
+          const { segModel, sumModel } = resolveModels(ctx, selected.model.model, loadConfig(), true);
           if (!sumModel) { ctx.ui.notify("Could not resolve model", "error"); return; }
           await runSmartCompact({ ctx, summaryModel: sumModel, segModel: segModel ?? sumModel, profile: selected.profile, pendingRef, isRunning, force: true });
           return;
         }
 
-        const { segModel, sumModel } = resolveModels(ctx, modelArg ? findModelById(ctx, modelArg) : ctx.model, loadConfig());
+        const { segModel, sumModel } = resolveModels(ctx, modelArg ? findModelById(ctx, modelArg) : ctx.model, loadConfig(), Boolean(modelArg));
         if (!sumModel) { ctx.ui.notify("Could not resolve model", "error"); return; }
         const note = extractUserNote(args);
         await runSmartCompact({ ctx, summaryModel: sumModel, segModel: segModel ?? sumModel, profile, verbose, dryRun, pendingRef, isRunning, userNote: note, force: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { runSmartCompact } from "./app/run-smart-compact.ts";
 import { showCompactUI, showMetricsDashboardUI, showRestorePicker, showBackupViewer, showRestoreAction } from "./ui/overlays.ts";
 import { resolveSessionId, isUnresolvedSessionId } from "./infra/session-identity.ts";
 import { createPendingSlot, type PendingSlot, type ConsumeResult } from "./app/pending-slot.ts";
+import { persistConsumedState } from "./app/steps/persist.ts";
 import * as log from "./utils/logger.ts";
 
 /**
@@ -31,6 +32,11 @@ import * as log from "./utils/logger.ts";
 function unwrapConsumed(result: ConsumeResult, ctx: ExtensionContext): PendingCompaction | null {
   switch (result.kind) {
     case "ok":
+      // Durable state (project fingerprint + compaction state) is persisted
+      // here — consume is the single moment, on every path (manual, auto,
+      // tool), where we know Pi is about to apply the payload. Persisting
+      // anywhere earlier would record success for a compact that never ran.
+      persistConsumedState(result.pending);
       return result.pending;
     case "empty":
       return null;
@@ -170,7 +176,15 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
           }
           return;
         }
-        const modelArg = tokens.find(t => t.includes("/"));
+        // A token is a model arg when it resolves in the registry, or when
+        // its provider prefix is a known provider (i.e. a typo'd model id we
+        // must reject loudly rather than let fall through as note text).
+        // Note tokens like "src/auth.ts" have no registered provider prefix
+        // and pass through to extractUserNote untouched.
+        const knownProviders = new Set(ctx.modelRegistry.getAvailable().map(m => m.provider));
+        const modelArg = tokens.find(t =>
+          /^[a-z0-9_.-]+\/[a-z0-9_.:-]+$/i.test(t) &&
+          (findModelById(ctx, t) || knownProviders.has(t.split("/")[0])));
         const profileArg = tokens.find(t => ["light", "balanced", "aggressive"].includes(t)) as CompressionProfile | undefined;
         const profile = profileArg ?? loadConfig().profile;
 
@@ -191,7 +205,15 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
           return;
         }
 
-        const { segModel, sumModel } = resolveModels(ctx, modelArg ? findModelById(ctx, modelArg) : ctx.model, loadConfig(), Boolean(modelArg));
+        // An explicit model arg that doesn't resolve must fail loudly —
+        // silently falling back to ctx.model would compact with a model the
+        // user did not choose (the old behaviour).
+        const explicitModel = modelArg ? findModelById(ctx, modelArg) : undefined;
+        if (modelArg && !explicitModel) {
+          ctx.ui.notify("Unknown model: " + modelArg + " — check available models", "error");
+          return;
+        }
+        const { segModel, sumModel } = resolveModels(ctx, explicitModel ?? ctx.model, loadConfig(), Boolean(modelArg));
         if (!sumModel) { ctx.ui.notify("Could not resolve model", "error"); return; }
         const note = extractUserNote(args);
         await runSmartCompact({ ctx, summaryModel: sumModel, segModel: segModel ?? sumModel, profile, verbose, dryRun, pendingRef, isRunning, userNote: note, force: true });
@@ -236,10 +258,11 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         // still mid-applyCompaction.
         const cancellationOut: { value: import("./app/run-smart-compact.ts").ExternalCancellation | null } = { value: null };
         const timeoutId = setTimeout(() => {
-          // Fire well before the inner deadline so the inner pipeline never
-          // hits applyCompaction past the deadline. +100 was the old margin;
-          // we keep that semantics but assert through the shared flag instead
-          // of through Promise.race.
+          // Fires 100ms AFTER the inner deadline — this is the outer backstop
+          // for providers that ignore AbortSignal, not the primary timeout.
+          // The inner setTimeout in prepareRun (at effectiveTimeoutMs) is what
+          // normally aborts the run; this one only acts when that abort was
+          // swallowed.
           if (cancellationOut.value && !cancellationOut.value.timedOut) {
             log.warn("Smart compact auto-trigger hard timeout after " + effectiveTimeoutMs + "ms");
             cancellationOut.value.abort();
@@ -336,6 +359,11 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         const staged = pendingRef.peek();
         if (staged) {
           return { content: [{ type: "text", text: "Smart summary prepared (" + resolvedProfile + "). Tokens: " + (staged.tokensBefore ?? 0).toLocaleString() + " — summary cached for " + Math.round(PENDING_TTL_MS / 60000) + " min. The next /compact will use this summary automatically." }], details: undefined };
+        }
+        // Dry-run returns before staging, so an empty slot is the *expected*
+        // outcome — not a failure. Report it as such.
+        if (dryRun) {
+          return { content: [{ type: "text", text: "Dry run finished (" + resolvedProfile + ", " + toolSecs + "s). Pipeline ran successfully; no summary was staged (dry-run skips staging by design)." }], details: undefined };
         }
         return { content: [{ type: "text", text: "Compaction finished (" + resolvedProfile + ") but no summary was generated." }], details: undefined };
       } catch (error) {

--- a/src/infra/fs.ts
+++ b/src/infra/fs.ts
@@ -116,25 +116,44 @@ export function acquireLockSync(target: string): () => void {
       try {
         const stat = fs.statSync(lockDir);
         if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
-          try { fs.rmdirSync(lockDir); } catch { /* ignore */ }
+          // Reclaim via rename-steal, not rmdir. A bare `rmdirSync(lockDir)`
+          // has a classic race: two waiters both observe staleness, waiter A
+          // reclaims (rmdir + mkdir), then waiter B's delayed rmdir deletes
+          // A's FRESH lock and both end up holding it. `renameSync` is
+          // atomic, so exactly one thief wins the steal; the loser gets
+          // ENOENT and loops back to mkdir. The thief then re-checks the
+          // stolen dir's mtime — if it turned out to be fresh (the owner
+          // reclaimed between our stat and our rename), we put it back.
+          const stolen = lockDir + ".stale." + process.pid + "." + crypto.randomBytes(4).toString("hex");
+          try {
+            fs.renameSync(lockDir, stolen);
+            const stolenStat = fs.statSync(stolen);
+            if (Date.now() - stolenStat.mtimeMs > LOCK_STALE_MS) {
+              fs.rmdirSync(stolen);
+            } else {
+              // Stole a live lock — restore it and keep waiting. If the
+              // restore fails (owner released meanwhile) the dir is gone
+              // and the next mkdir attempt simply succeeds.
+              try { fs.renameSync(stolen, lockDir); } catch { /* released */ }
+            }
+          } catch { /* another waiter won the steal — loop and retry mkdir */ }
           continue;
         }
       } catch { /* lock vanished between EEXIST and stat */ }
       // Yield the CPU between retries instead of spinning. `Atomics.wait`
-      // on a tiny SharedArrayBuffer parks the thread without burning a core
-      // — the previous spin loop could pin a CPU at 100% for up to 2 s
-      // (80 retries x 25 ms) during contention from multiple pi sessions
-      // appending metrics simultaneously.
+      // on a tiny SharedArrayBuffer parks the thread without burning a core.
+      // Node and Bun both allow this on the main thread (only browsers
+      // forbid it), so the catch branch fires only in exotic sandboxes
+      // where SharedArrayBuffer itself is unavailable.
+      // ponytail: the spin fallback burns a core for up to 2s under
+      // contention; acceptable because it's unreachable on our supported
+      // runtimes — revisit if a SAB-less host becomes a target.
       try {
         const sab = new SharedArrayBuffer(4);
         const view = new Int32Array(sab);
-        // Wait until either the timeout elapses or the value at index 0
-        // changes (we never notify, so this always times out). The return
-        // value is "timed-out" in the normal contention path.
+        // We never notify, so this always times out after LOCK_RETRY_MS.
         Atomics.wait(view, 0, 0, LOCK_RETRY_MS);
       } catch {
-        // SharedArrayBuffer is unavailable in some sandboxed environments;
-        // fall back to the original spin so the lock still works.
         const until = Date.now() + LOCK_RETRY_MS;
         while (Date.now() < until) { /* spin */ }
       }

--- a/src/infra/llm-client.ts
+++ b/src/infra/llm-client.ts
@@ -8,24 +8,6 @@
  *    metrics test path to the peer dependency, which made `bun test` fail
  *    when the peer was not installed.
  *
- *  pi-ai 0.80 removed the standalone `complete()`/`stream()` from the package
- *  root and moved them to the `/compat` subpath. We import from `/compat`
- *  deliberately, NOT from `createModels()` + provider factories:
- *
- *    - This is a Pi *extension*. The host (pi-coding-agent) owns model/auth
- *      management via `ctx.modelRegistry` (a `ModelRegistry`), which resolves
- *      auth but exposes no `.complete()`. The host itself imports its types
- *      from `@earendil-works/pi-ai/compat`.
- *    - `createModels()` would build a *second* registry that bypasses the
- *      host's `ctx.modelRegistry` and its auth — wrong for an extension.
- *    - pi-ai's "avoid /compat" advice targets standalone bundled apps, not
- *      host-managed extensions.
- *
- *  The whole pi-coding-agent ecosystem (host + extensions) sits on `/compat`
- *  until the host finishes its ModelManager migration. The compat surface is
- *  pinned to this one file: when the host eventually offers completion on the
- *  context, change only the import + the call on line ~42 below.
- *
  *  - Test fakes need to assert which `phase` was used, control failures, and
  *    return synthetic usage tokens for calibration tests.
  *
@@ -37,12 +19,36 @@
  *
  * The default implementation (`defaultLlmClient`) calls `complete()` from
  * pi-ai. `setLlmClient` is exposed for tests and for callers that wish to
- * inject a wrapping/fallback client at extension boot.
+ * inject a wrapping/fallback client at extension boot. See `resolveComplete`
+ * below for how `complete` is obtained under the host's compat aliasing.
  */
 
 import type { Model, Api, AssistantMessage, Context, ProviderStreamOptions } from "@earendil-works/pi-ai";
-import { complete } from "@earendil-works/pi-ai/compat";
 import { withRetry } from "./llm-retry.ts";
+
+// pi-ai 0.80 removed the standalone `complete()`/`stream()` from the package
+// root types and moved them to the `/compat` subpath. The pi host
+// (pi-coding-agent's extension loader) aliases the `@earendil-works/pi-ai` ROOT
+// import to the compat entrypoint at runtime, so importing the root is the
+// supported, normal way for an extension to get the old global API. A bare
+// `import { complete } from "@earendil-works/pi-ai"` fails typecheck (the root
+// types no longer declare it) and importing the `/compat` subpath directly is
+// not aliased by older host builds and breaks at load. We resolve `complete`
+// lazily instead: try the root first (host-aliased to compat), fall back to the
+// `/compat` subpath. Resolution runs on first use, never at module load, so a
+// missing export can't break the whole extension or the test fakes (which never
+// call through to the real client).
+let _complete: ((model: Model<Api>, body: Context, opts: ProviderStreamOptions) => Promise<AssistantMessage>) | null = null;
+function resolveComplete() {
+  if (_complete) return _complete;
+  // Both specifiers resolve to the compat entrypoint under the host loader; in
+  // raw test/node resolution only `/compat` exports `complete` in 0.80+.
+  const root = require("@earendil-works/pi-ai") as typeof import("@earendil-works/pi-ai/compat");
+  const fn = root.complete ?? require("@earendil-works/pi-ai/compat").complete;
+  if (!fn) throw new Error("smart-compact: could not resolve pi-ai complete()");
+  _complete = fn;
+  return fn;
+}
 
 export interface LlmClient {
   complete(model: Model<Api>, body: Context, opts: ProviderStreamOptions): Promise<AssistantMessage>;
@@ -50,7 +56,7 @@ export interface LlmClient {
 
 /** Raw client — direct pass-through to pi-ai. Tests can install this to skip retries. */
 export const rawLlmClient: LlmClient = {
-  complete: (model, body, opts) => complete(model, body, opts),
+  complete: (model, body, opts) => resolveComplete()(model, body, opts),
 };
 
 /**

--- a/src/infra/llm-client.ts
+++ b/src/infra/llm-client.ts
@@ -27,25 +27,25 @@ import type { Model, Api, AssistantMessage, Context, ProviderStreamOptions } fro
 import { withRetry } from "./llm-retry.ts";
 
 // pi-ai 0.80 removed the standalone `complete()`/`stream()` from the package
-// root types and moved them to the `/compat` subpath. The pi host
-// (pi-coding-agent's extension loader) aliases the `@earendil-works/pi-ai` ROOT
-// import to the compat entrypoint at runtime, so importing the root is the
-// supported, normal way for an extension to get the old global API. A bare
-// `import { complete } from "@earendil-works/pi-ai"` fails typecheck (the root
-// types no longer declare it) and importing the `/compat` subpath directly is
-// not aliased by older host builds and breaks at load. We resolve `complete`
-// lazily instead: try the root first (host-aliased to compat), fall back to the
-// `/compat` subpath. Resolution runs on first use, never at module load, so a
-// missing export can't break the whole extension or the test fakes (which never
-// call through to the real client).
+// root and moved them to the `/compat` subpath. The bare `complete` is resolved
+// with a dynamic import rather than a static one:
+//
+//  - A STATIC `import { complete }` breaks either context: the root specifier
+//    has no `complete` export in raw node/test resolution, and importing the
+//    `/compat` subpath statically is not aliased by some host builds and fails
+//    at module load.
+//  - A dynamic `import("@earendil-works/pi-ai/compat")` works in BOTH: the pi
+//    host's extension loader (getAliases + VIRTUAL_MODULES) aliases the
+//    `/compat` subpath to the compat entrypoint, and raw resolution finds
+//    `/compat` directly. It runs on first use (never at module load), so a
+//    resolution hiccup can never break extension loading, and test fakes that
+//    inject their own client via setLlmClient never trigger it.
 let _complete: ((model: Model<Api>, body: Context, opts: ProviderStreamOptions) => Promise<AssistantMessage>) | null = null;
-function resolveComplete() {
+async function resolveComplete() {
   if (_complete) return _complete;
-  // Both specifiers resolve to the compat entrypoint under the host loader; in
-  // raw test/node resolution only `/compat` exports `complete` in 0.80+.
-  const root = require("@earendil-works/pi-ai") as typeof import("@earendil-works/pi-ai/compat");
-  const fn = root.complete ?? require("@earendil-works/pi-ai/compat").complete;
-  if (!fn) throw new Error("smart-compact: could not resolve pi-ai complete()");
+  const mod = await import("@earendil-works/pi-ai/compat");
+  const fn = mod.complete;
+  if (typeof fn !== "function") throw new Error("smart-compact: pi-ai /compat did not export complete()");
   _complete = fn;
   return fn;
 }
@@ -56,7 +56,7 @@ export interface LlmClient {
 
 /** Raw client — direct pass-through to pi-ai. Tests can install this to skip retries. */
 export const rawLlmClient: LlmClient = {
-  complete: (model, body, opts) => resolveComplete()(model, body, opts),
+  complete: async (model, body, opts) => (await resolveComplete())(model, body, opts),
 };
 
 /**

--- a/src/infra/llm-client.ts
+++ b/src/infra/llm-client.ts
@@ -8,6 +8,24 @@
  *    metrics test path to the peer dependency, which made `bun test` fail
  *    when the peer was not installed.
  *
+ *  pi-ai 0.80 removed the standalone `complete()`/`stream()` from the package
+ *  root and moved them to the `/compat` subpath. We import from `/compat`
+ *  deliberately, NOT from `createModels()` + provider factories:
+ *
+ *    - This is a Pi *extension*. The host (pi-coding-agent) owns model/auth
+ *      management via `ctx.modelRegistry` (a `ModelRegistry`), which resolves
+ *      auth but exposes no `.complete()`. The host itself imports its types
+ *      from `@earendil-works/pi-ai/compat`.
+ *    - `createModels()` would build a *second* registry that bypasses the
+ *      host's `ctx.modelRegistry` and its auth — wrong for an extension.
+ *    - pi-ai's "avoid /compat" advice targets standalone bundled apps, not
+ *      host-managed extensions.
+ *
+ *  The whole pi-coding-agent ecosystem (host + extensions) sits on `/compat`
+ *  until the host finishes its ModelManager migration. The compat surface is
+ *  pinned to this one file: when the host eventually offers completion on the
+ *  context, change only the import + the call on line ~42 below.
+ *
  *  - Test fakes need to assert which `phase` was used, control failures, and
  *    return synthetic usage tokens for calibration tests.
  *
@@ -23,7 +41,7 @@
  */
 
 import type { Model, Api, AssistantMessage, Context, ProviderStreamOptions } from "@earendil-works/pi-ai";
-import { complete } from "@earendil-works/pi-ai";
+import { complete } from "@earendil-works/pi-ai/compat";
 import { withRetry } from "./llm-retry.ts";
 
 export interface LlmClient {

--- a/src/infra/services.ts
+++ b/src/infra/services.ts
@@ -154,7 +154,10 @@ export function makeCompactSessionId(): string {
 export function createServices(overrides: Partial<SmartCompactServices> = {}): SmartCompactServices {
   return {
     clock: overrides.clock ?? systemClock,
-    llm: overrides.llm ?? getLlmClient(),
+    // Lazy delegate, not `getLlmClient()` captured eagerly: the llm-client
+    // seam promises call-time resolution, so a `setLlmClient` installed
+    // after this bag was created must still be honoured.
+    llm: overrides.llm ?? { complete: (...args) => getLlmClient().complete(...args) },
     toolSupport: overrides.toolSupport ?? new ToolSupportCache(),
     metrics: overrides.metrics ?? new MetricsSink(),
     extractionCacheStats: overrides.extractionCacheStats ?? new ExtractionCacheStats(),

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -91,13 +91,16 @@ export function verifySummary(summary: string, extraction: StructuredExtraction)
   // contract is the same: only return tokens that look like real file
   // references (no SemVer literals, no bare names without an extension).
   const summaryFileRefs = extractFileRefs(summary);
-  const knownFiles = new Set([
+  // Plain array (not Set): membership is suffix-based, so every lookup scans
+  // all entries anyway — the previous `[...set].some(...)` re-materialized
+  // the array on every ref, O(refs × files) allocations for zero benefit.
+  const knownFiles = [
     ...extraction.modifiedFiles.map(f => f.path.toLowerCase()),
     ...extraction.readFiles.map(f => f.toLowerCase()),
-  ]);
+  ];
   for (const ref of summaryFileRefs) {
     const refLower = ref.toLowerCase();
-    const isKnown = [...knownFiles].some(kf => (kf.endsWith("/" + refLower) || kf === refLower || (kf.endsWith(refLower) && refLower.length > 3)));
+    const isKnown = knownFiles.some(kf => (kf.endsWith("/" + refLower) || kf === refLower || (kf.endsWith(refLower) && refLower.length > 3)));
     if (!isKnown) {
       gaps.push("Potentially fabricated file: " + ref);
       score -= 4;

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,17 @@ export interface PendingCompaction {
   details: SmartCompactDetails;
   compactionState?: CompactionState;
   /**
+   * Project id + extraction snapshot for durable-state persistence at
+   * consume time. The auto-trigger and tool paths never reach
+   * `applyCompaction` (they return early), so the only moment we *know*
+   * the payload is being applied is when `session_before_compact`
+   * consumes it. Carrying these fields lets `persistConsumedState` write
+   * the project fingerprint + compaction state exactly once, on every
+   * path, at that moment.
+   */
+  projectId?: string;
+  extraction?: StructuredExtraction;
+  /**
    * Originating pi session id. Used by `session_before_compact` to refuse a
    * pending payload that was prepared by a different session (e.g. when two
    * pi sessions share the same Node process via sub-agents). Without this

--- a/src/ui/overlays.ts
+++ b/src/ui/overlays.ts
@@ -172,7 +172,7 @@ export async function showResultScreen(
   ctx: ExtensionContext,
   details: SmartCompactDetails,
   extraction: StructuredExtraction,
-  services?: SmartCompactServices,
+  services: SmartCompactServices,
 ): Promise<void> {
   await ctx.ui.custom<void>((tui, theme, _kb, done) => {
     const c = new Container();

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -4,8 +4,8 @@
  * Filesystem writes go through `src/infra/fs.ts` (atomic temp+rename for
  * snapshots, advisory lock for the metrics append log) so that two pi
  * sessions racing to compact the same project cannot corrupt each other's
- * state. All LLM I/O routes through `getLlmClient()` so tests can swap a fake
- * provider in without resolving the real peer dependency.
+ * state. All LLM I/O routes through the services bag's `llm` client so tests
+ * can swap a fake provider in without resolving the real peer dependency.
  */
 
 import fs from "node:fs";
@@ -15,7 +15,6 @@ import type { LLMCallMetric, StructuredExtraction, CachedExtraction, CacheAwareO
 import { estimateTokens, calibrateFromResponse, getProviderCaps } from "./tokens.ts";
 import * as log from "./logger.ts";
 import type { Model, Api, AssistantMessage, Context } from "@earendil-works/pi-ai";
-import { getLlmClient } from "../infra/llm-client.ts";
 import {
   extractionCacheFile, metricsLogFile, damageReportsFile,
   cacheDir as cacheDirPath, metricsDashboardFile,
@@ -23,13 +22,12 @@ import {
 import { appendLineLocked, ensureDir, readJsonSync, writeJsonSync, atomicWriteFileSync } from "../infra/fs.ts";
 import { ONE_HOUR_MS, SEVEN_DAYS_MS, EXTRACTION_CACHE_PREFIX } from "../constants.ts";
 import { buildEntryIdFingerprint } from "./id-fingerprint.ts";
-import { getDefaultServices, makeCompactSessionId, type SmartCompactServices } from "../infra/services.ts";
+import { getDefaultServices, type SmartCompactServices } from "../infra/services.ts";
 
 // ── Cache Options ──
 
-// Prompt-cache namespace id comes from `makeCompactSessionId` (services.ts),
-// shared with the per-run services container so the fallback path can't drift
-// in format from the live one.
+// Prompt-cache namespace id comes from the services bag's `compactSessionId`
+// (set once per run by `createServices`).
 /** Internal compaction phases that should never use prompt caching — one-shot, not worth write cost. */
 const INTERNAL_PHASES: ReadonlySet<LLMCallMetric["phase"]> = new Set([
   "explore", "explore-loop", "explore-retry", "explore-direct",
@@ -38,9 +36,9 @@ const INTERNAL_PHASES: ReadonlySet<LLMCallMetric["phase"]> = new Set([
 
 export function cacheOpts(
   opts: CacheAwareOptions,
-  provider?: string,
-  phase?: LLMCallMetric["phase"],
-  services?: SmartCompactServices,
+  provider: string | undefined,
+  phase: LLMCallMetric["phase"] | undefined,
+  services: SmartCompactServices,
 ): CacheAwareOptions & { sessionId?: string } {
   // Internal compaction LLM calls are one-shot: cache write cost (1.25x–2x) is never amortized.
   if (phase && INTERNAL_PHASES.has(phase)) {
@@ -52,24 +50,19 @@ export function cacheOpts(
   if (retention === "none") {
     return { ...opts, cacheRetention: "none" as const };
   }
-  return { ...opts, sessionId: services?.compactSessionId ?? makeCompactSessionId(), cacheRetention: retention };
+  return { ...opts, sessionId: services.compactSessionId, cacheRetention: retention };
 }
 
 // ── Metrics ──
 //
-// Metrics now live on the per-run services container. These functions remain
-// for backwards compatibility (overlays.ts, app/steps/metrics.ts call them by
-// name); they delegate to the active services bag, which is rotated on each
-// `resetMetrics` invocation by the orchestrator. The default container is also
-// what tests grab via `setDefaultServices` to inject a deterministic clock.
+// Metrics live on the per-run services container, injected explicitly by
+// every caller (orchestrator threads `rc.services`; overlays receive it as a
+// parameter). No hidden `getDefaultServices()` fallback on this surface: a
+// missing bag is a compile error, not a silent cross-session leak. The one
+// sanctioned fallback lives at the top of `trackedComplete` — the deep
+// phases seam — and is resolved exactly once there.
 
-export function resetMetrics(services = getDefaultServices()): void {
-  services.metrics.clear();
-  services.extractionCacheStats.clear();
-  services.tokenCalibration.clear();
-}
-export function recordMetric(m: LLMCallMetric, services = getDefaultServices()): void { services.metrics.record(m); }
-export function getMetrics(services = getDefaultServices()): LLMCallMetric[] { return services.metrics.snapshot(); }
+export function recordMetric(m: LLMCallMetric, services: SmartCompactServices): void { services.metrics.record(m); }
 
 export function effectivePromptInputTokens(inputTokens: number, cacheHitTokens: number): number {
   // Provider usage semantics differ: some providers report `input` as total
@@ -80,7 +73,7 @@ export function effectivePromptInputTokens(inputTokens: number, cacheHitTokens: 
   return cacheHitTokens > inputTokens ? inputTokens + cacheHitTokens : inputTokens;
 }
 
-export function getMetricsSummary(services = getDefaultServices()): { totalCalls: number; totalInput: number; totalOutput: number; totalCacheHit: number; avgLatency: number; cacheHitRate: number } {
+export function getMetricsSummary(services: SmartCompactServices): { totalCalls: number; totalInput: number; totalOutput: number; totalCacheHit: number; avgLatency: number; cacheHitRate: number } {
   const sum = services.metrics.summary();
   // The services container computes a structurally identical summary but
   // uses a slightly different cache-hit denominator. Keep the previously
@@ -102,10 +95,14 @@ export async function trackedComplete(
   opts: CacheAwareOptions,
   services?: SmartCompactServices,
 ): Promise<AssistantMessage> {
+  // Single sanctioned fallback point: direct callers (legacy tests, REPL)
+  // may omit services; everything downstream of here receives the resolved
+  // bag explicitly.
+  const svc = services ?? getDefaultServices();
   const start = Date.now();
   try {
-    const resolvedOpts = cacheOpts(opts, model.provider, phase, services);
-    const resp = await (services?.llm ?? getLlmClient()).complete(model, reqBody, resolvedOpts as import("@earendil-works/pi-ai").ProviderStreamOptions);
+    const resolvedOpts = cacheOpts(opts, model.provider, phase, svc);
+    const resp = await svc.llm.complete(model, reqBody, resolvedOpts as import("@earendil-works/pi-ai").ProviderStreamOptions);
     const latency = Date.now() - start;
     const usage = resp.usage;
     const inputT = usage?.input ?? 0;
@@ -114,11 +111,11 @@ export async function trackedComplete(
     recordMetric({
       phase, model: model.id, provider: model.provider, inputTokens: inputT, outputTokens: outputT,
       cacheHitTokens: cacheT, latencyMs: latency, success: true,
-    }, services);
+    }, svc);
     try {
       if (inputT > 0 && "messages" in reqBody) {
         const rawText = JSON.stringify((reqBody as unknown as Record<string, unknown>).messages);
-        const calibration = services?.tokenCalibration;
+        const calibration = svc.tokenCalibration;
         calibrateFromResponse(
           estimateTokens(rawText, model.provider, model.id, calibration),
           inputT,
@@ -133,7 +130,7 @@ export async function trackedComplete(
     recordMetric({
       phase, model: model.id, provider: model.provider, inputTokens: 0, outputTokens: 0,
       cacheHitTokens: 0, latencyMs: Date.now() - start, success: false,
-    }, services);
+    }, svc);
     throw err;
   }
 }
@@ -144,19 +141,14 @@ function getCachePath(sessionId: string): string {
   return extractionCacheFile(sessionId);
 }
 
-// Extraction cache stats delegate to the active services container. Resetting
-// the container (via resetMetrics) zeros these counters too, which matches
-// the previous module-level behaviour without leaking state across sessions.
-export function resetExtractionCacheStats(services = getDefaultServices()): void {
-  services.extractionCacheStats.clear();
-}
-
-export function getExtractionCacheStats(services = getDefaultServices()): { hits: number; misses: number; hitRate: number } {
+// Extraction cache stats delegate to the caller's services container —
+// explicit injection, same contract as the metrics surface above.
+export function getExtractionCacheStats(services: SmartCompactServices): { hits: number; misses: number; hitRate: number } {
   return services.extractionCacheStats.snapshot();
 }
 
-export function recordExtractionCacheHit(services = getDefaultServices()): void { services.extractionCacheStats.recordHit(); }
-export function recordExtractionCacheMiss(services = getDefaultServices()): void { services.extractionCacheStats.recordMiss(); }
+export function recordExtractionCacheHit(services: SmartCompactServices): void { services.extractionCacheStats.recordHit(); }
+export function recordExtractionCacheMiss(services: SmartCompactServices): void { services.extractionCacheStats.recordMiss(); }
 
 /**
  * Save extraction cache with entry-id fingerprints for branch-aware
@@ -298,8 +290,8 @@ export function mergeExtractions(base: StructuredExtraction, delta: StructuredEx
 /** Extended metrics entry including pipeline context for regression detection. */
 export function appendMetricsLog(
   sessionId: string,
-  extra?: Partial<Omit<CompactMetricsEntry, "ts" | "sessionId" | "totalCalls" | "totalInput" | "totalOutput" | "totalCacheHit" | "avgLatency" | "cacheHitRate">>,
-  services?: SmartCompactServices,
+  extra: Partial<Omit<CompactMetricsEntry, "ts" | "sessionId" | "totalCalls" | "totalInput" | "totalOutput" | "totalCacheHit" | "avgLatency" | "cacheHitRate">> | undefined,
+  services: SmartCompactServices,
 ): void {
   try {
     const summary = getMetricsSummary(services);

--- a/src/utils/extraction.ts
+++ b/src/utils/extraction.ts
@@ -336,8 +336,14 @@ export function buildTimeline(msgs: LlmMessage[], errors: StructuredExtraction["
     }
     if (errorIndices.has(i)) timeline.push({ index: i, event: "error", summary: errors.find(e => e.index === i)?.message.slice(0, TRUNC.TIMELINE_ERROR) ?? "error" });
   }
+  // Keep the *most recent* N user requests (slice(-N), not slice(0, N)) —
+  // for compaction the latest requests are the valuable ones. Re-sort by
+  // index so errors interleave chronologically instead of clumping at the end.
   return timeline.length > 30
-    ? [...timeline.filter(t => t.event === "user_request").slice(0, TRUNC.TIMELINE_DISPLAY), ...timeline.filter(t => t.event === "error")]
+    ? [
+      ...timeline.filter(t => t.event === "user_request").slice(-TRUNC.TIMELINE_DISPLAY),
+      ...timeline.filter(t => t.event === "error"),
+    ].sort((a, b) => a.index - b.index)
     : timeline;
 }
 
@@ -413,11 +419,16 @@ export function extractOpenLoops(msgs: LlmMessage[], extraction: StructuredExtra
   }
 
   // ── 3. Blocked items → blocked loops ──
-  const BLOCKED_RE = /blocked|waiting for|depend|ba[ğg]li|bekliyor|engell/i;
+  // `\bdepends?\s+on\b` instead of bare `depend`: "dependency/dependencies"
+  // appears in routine package talk and was flagging ordinary messages as
+  // high-priority blocked loops. Same min-length/command guard as the
+  // follow-up scan above — slash commands and tiny fragments are never loops.
+  const BLOCKED_RE = /\bblocked\b|waiting for|\bdepends?\s+on\b|ba[ğg]l[iı]|bekliyor|engell/i;
   for (let idx = 0; idx < msgs.length; idx++) {
     const msg = msgs[idx];
     if (msg.role !== "user") continue;
     const txt = extractText(msg.content);
+    if (txt.length < 10 || txt.startsWith("/")) continue;
     if (BLOCKED_RE.test(txt)) {
       const isDup = loops.some(l => Math.abs((l.sourceIndex ?? 0) - idx) < 5);
       if (!isDup) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -181,15 +181,21 @@ function prunePass(dir: string): void {
 
 /**
  * Queue an asynchronous prune. Returns immediately; the actual scan runs on
- * the next microtask. Multiple queued calls for the same directory collapse
- * to a single pass.
+ * a later event-loop turn. Multiple queued calls for the same directory
+ * collapse to a single pass.
+ *
+ * `setTimeout(0)`, not `queueMicrotask`: microtasks run before control
+ * returns to the event loop, so the readdir+stat scan would still block the
+ * same turn that triggered the backup — the exact hot-path stall this
+ * deferral exists to avoid. A macrotask lets the compaction pipeline finish
+ * first.
  */
 function schedulePruneBackups(dir: string): void {
   if (_pruneInFlight.has(dir)) return;
   _pruneInFlight.add(dir);
-  queueMicrotask(() => {
+  setTimeout(() => {
     try { prunePass(dir); } finally { _pruneInFlight.delete(dir); }
-  });
+  }, 0);
 }
 
 export function backupConversation(convText: string, sessionId: string): string | null {

--- a/src/utils/session-log.ts
+++ b/src/utils/session-log.ts
@@ -18,6 +18,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { extractText, TRUNCATE_RE } from "./extraction.ts";
 import type { LlmMessage, SessionMessageEntry } from "../types.ts";
 import * as log from "./logger.ts";
@@ -58,6 +59,12 @@ function* streamJsonlLines(fp: string, chunkSize = 64 * 1024): Generator<string>
   try {
     fd = fs.openSync(fp, "r");
     const buf = Buffer.allocUnsafe(chunkSize);
+    // StringDecoder buffers a multi-byte UTF-8 sequence split across chunk
+    // boundaries instead of emitting U+FFFD. A bare `toString("utf-8")` on a
+    // chunk that ends mid-character corrupts that character, which silently
+    // breaks JSON.parse for the line it lands in — non-ASCII content
+    // (Turkish text is common here) made that a real failure mode.
+    const decoder = new StringDecoder("utf8");
     let leftover = "";
     let totalRead = 0;
     for (;;) {
@@ -71,7 +78,7 @@ function* streamJsonlLines(fp: string, chunkSize = 64 * 1024): Generator<string>
       // Concatenating the leftover prefix to the new chunk is cheap because
       // the leftover is at most one line long; we never accumulate the full
       // file in memory.
-      const data = leftover + buf.subarray(0, bytes).toString("utf-8");
+      const data = leftover + decoder.write(buf.subarray(0, bytes));
       const lines = data.split("\n");
       // The last entry may be a partial line; keep it for the next iteration.
       leftover = lines.pop() ?? "";
@@ -79,6 +86,7 @@ function* streamJsonlLines(fp: string, chunkSize = 64 * 1024): Generator<string>
         if (line.length > 0) yield line;
       }
     }
+    leftover += decoder.end();
     if (leftover.length > 0) yield leftover;
   } finally {
     if (fd != null) {

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -193,8 +193,11 @@ export function estimateTokens(text: string, provider?: string, model?: string, 
     }
     if (structural / sample.length > JSON_DENSITY_THRESHOLD) jsonPenalty = JSON_PENALTY;
   }
-  // Turkish/CE characters tokenize differently (multi-byte in some tokenizers)
-  const langPenalty = /[çğıöşüÇĞİÖŞÜ]/.test(text) ? 0.9 : 1.0;
+  // Turkish/CE characters tokenize differently (multi-byte in some tokenizers).
+  // Scan the same capped sample as the JSON-density check — an uncapped regex
+  // over a multi-MB conversation serialization walks the whole string.
+  const langSample = text.length > JSON_DENSITY_SCAN_CAP ? text.slice(0, JSON_DENSITY_SCAN_CAP) : text;
+  const langPenalty = /[çğıöşüÇĞİÖŞÜ]/.test(langSample) ? 0.9 : 1.0;
   const factor = calibration.get(provider, model);
   return Math.ceil((text.length / baseRatio) * jsonPenalty * langPenalty * factor);
 }

--- a/test/backup-prune.test.ts
+++ b/test/backup-prune.test.ts
@@ -7,8 +7,8 @@
  *      block on directory scan / unlink. The previous implementation could
  *      stall for 20-50ms when the backup directory held >100 files.
  *
- *   2. Eventual: after enough microtask ticks the prune happens and files
- *      over the count cap (or age cap) are removed.
+ *   2. Eventual: after the deferred macrotask runs the prune happens and
+ *      files over the count cap (or age cap) are removed.
  *
  * The tests use a per-test HOME swap so they don't touch the user's real
  * backups directory.
@@ -39,9 +39,11 @@ afterEach(() => {
   try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
 });
 
-function flushMicrotasks(): Promise<void> {
-  // Two microtask hops cover the queued prune + its inner readdir loop.
-  return new Promise(resolve => queueMicrotask(() => queueMicrotask(() => resolve())));
+function flushDeferred(): Promise<void> {
+  // The prune is scheduled with setTimeout(0) (a macrotask — microtasks
+  // would still block the triggering turn); one longer timeout hop
+  // deterministically runs after it.
+  return new Promise(resolve => setTimeout(resolve, 10));
 }
 
 describe("backupConversation hot path", () => {
@@ -63,7 +65,7 @@ describe("backupConversation hot path", () => {
 });
 
 describe("deferred prune", () => {
-  it("trims files past the count cap after microtasks flush", async () => {
+  it("trims files past the count cap after the deferred prune runs", async () => {
     fs.mkdirSync(backupDir, { recursive: true });
     // Pre-populate with BACKUP_MAX_FILES + 5 backups so the trim has work to do.
     const total = BACKUP_MAX_FILES + 5;
@@ -75,10 +77,10 @@ describe("deferred prune", () => {
       const t = (now - (total - i) * 1000) / 1000;
       fs.utimesSync(fp, t, t);
     }
-    // Trigger a real backup → schedules a prune microtask.
+    // Trigger a real backup → schedules the deferred prune.
     backupConversation("trigger prune", "trigger");
-    await flushMicrotasks();
-    // After the microtask runs we should be at the cap (or close to it).
+    await flushDeferred();
+    // After the deferred prune runs we should be at the cap (or close to it).
     const remaining = fs.readdirSync(backupDir).filter(n => n.endsWith(".md")).length;
     expect(remaining).toBeLessThanOrEqual(BACKUP_MAX_FILES + 1); // +1 for the trigger backup
   });

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -4,12 +4,14 @@ import path from "node:path";
 import os from "node:os";
 
 let cache: typeof import("../src/utils/cache.ts");
+let services: typeof import("../src/infra/services.ts");
 let home: string;
 
 async function loadWithHome() {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "psc-metrics-"));
   process.env.HOME = home;
   cache = await import("../src/utils/cache.ts?home=" + encodeURIComponent(home) + "-" + Date.now());
+  services = await import("../src/infra/services.ts");
   return home;
 }
 
@@ -19,8 +21,9 @@ describe("metrics reporting", () => {
   });
 
   it("writes and summarizes profile/provider comparisons", () => {
-    cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", model: "openai/gpt", method: "single-pass", status: "success", durationMs: 1000, tokensSaved: 5000, verificationScore: 95 });
-    cache.appendMetricsLog("s2", { profile: "aggressive", provider: "anthropic", model: "anthropic/claude", method: "eesv", status: "timeout", durationMs: 2000, tokensSaved: 9000, verificationScore: 90 });
+    const svc = services.createServices();
+    cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", model: "openai/gpt", method: "single-pass", status: "success", durationMs: 1000, tokensSaved: 5000, verificationScore: 95 }, svc);
+    cache.appendMetricsLog("s2", { profile: "aggressive", provider: "anthropic", model: "anthropic/claude", method: "eesv", status: "timeout", durationMs: 2000, tokensSaved: 9000, verificationScore: 90 }, svc);
     const report = cache.buildMetricsReport(cache.readMetricsLog());
     expect(report).toContain("Profile comparison");
     expect(report).toContain("balanced: n=1");
@@ -28,7 +31,7 @@ describe("metrics reporting", () => {
   });
 
   it("writes a local html dashboard", () => {
-    cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", status: "success", durationMs: 1000 });
+    cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", status: "success", durationMs: 1000 }, services.createServices());
     const fp = cache.writeMetricsDashboard(cache.readMetricsLog());
     expect(fp).toBeTruthy();
     expect(fs.existsSync(fp!)).toBe(true);
@@ -36,7 +39,7 @@ describe("metrics reporting", () => {
   });
 
   it("caps provider cache hit rate when cacheRead exceeds uncached input", () => {
-    cache.resetMetrics();
+    const svc = services.createServices();
     cache.recordMetric({
       phase: "batch",
       model: "claude",
@@ -46,24 +49,25 @@ describe("metrics reporting", () => {
       cacheHitTokens: 120248,
       latencyMs: 10,
       success: true,
-    });
-    const summary = cache.getMetricsSummary();
+    }, svc);
+    const summary = cache.getMetricsSummary(svc);
     expect(summary.cacheHitRate).toBeGreaterThan(0.99);
     expect(summary.cacheHitRate).toBeLessThanOrEqual(1);
     expect(cache.effectivePromptInputTokens(summary.totalInput, summary.totalCacheHit)).toBe(120269);
   });
 
   it("skips corrupt jsonl rows instead of dropping all metrics", () => {
-    cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", status: "success" });
+    const svc = services.createServices();
+    cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", status: "success" }, svc);
     const logPath = path.join(home, ".pi", "agent", ".cache", "compact-metrics.jsonl");
     fs.appendFileSync(logPath, "{not-json}\n");
-    cache.appendMetricsLog("s2", { profile: "aggressive", provider: "anthropic", status: "error" });
+    cache.appendMetricsLog("s2", { profile: "aggressive", provider: "anthropic", status: "error" }, svc);
     const entries = cache.readMetricsLog();
     expect(entries.map(e => e.sessionId)).toEqual(["s1", "s2"]);
   });
 
   it("escapes dashboard table values", () => {
-    cache.appendMetricsLog("s1", { profile: "<script>alert(1)</script>", provider: "openai", status: "success" });
+    cache.appendMetricsLog("s1", { profile: "<script>alert(1)</script>", provider: "openai", status: "success" }, services.createServices());
     const fp = cache.writeMetricsDashboard(cache.readMetricsLog());
     const html = fs.readFileSync(fp!, "utf8");
     expect(html).not.toContain("<script>alert(1)</script>");

--- a/test/persist-consumed.test.ts
+++ b/test/persist-consumed.test.ts
@@ -1,0 +1,66 @@
+/**
+ * C1 regression: durable state (project fingerprint + compaction state) must
+ * be persisted when a pending payload is CONSUMED — the auto-trigger and tool
+ * paths never reach applyCompaction, so consume is the only apply point they
+ * share. Before this fix the fingerprint/state chain silently never ran on
+ * the most common (auto) path.
+ */
+import { describe, it, expect, beforeAll } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let home: string;
+beforeAll(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "psc-consumed-"));
+  process.env.HOME = home;
+});
+
+function minimalExtraction() {
+  return {
+    modifiedFiles: [{ path: "src/a.ts", toolCalls: 1, lastModifiedIndex: 0 }],
+    readFiles: ["src/b.ts"], deletedFiles: [],
+    errors: [], decisions: [], constraints: [], topics: [], timeline: [],
+    mediaAttachments: [], mainGoal: "test goal", lastUserMessages: [], lastErrors: [],
+    messageCount: 3,
+  };
+}
+
+describe("persistConsumedState", () => {
+  it("writes fingerprint + compaction state for a payload carrying projectId", async () => {
+    const { persistConsumedState } = await import("../src/app/steps/persist.ts");
+    const { loadProjectFingerprint } = await import("../src/utils/fingerprint.ts");
+    const { loadCompactionState } = await import("../src/utils/state.ts");
+    const { VERSION } = await import("../src/constants.ts");
+
+    const projectId = "test-project-consumed";
+    persistConsumedState({
+      summary: "## Goal\nx", firstKeptEntryId: "e1", tokensBefore: 100,
+      details: {} as never, sessionId: "s1",
+      projectId,
+      extraction: minimalExtraction() as never,
+      compactionState: {
+        goal: "test goal", decisions: [], constraints: [],
+        modifiedFiles: ["src/a.ts"], readFiles: [], deletedFiles: [],
+        unresolvedErrors: [], resolvedErrors: [], openLoops: [], topics: [],
+        nextActions: [], criticalContext: [], sessionType: "implementation",
+        compactionVersion: VERSION, updatedAt: Date.now(),
+      } as never,
+    });
+
+    const fp = loadProjectFingerprint(projectId);
+    expect(fp).not.toBeNull();
+    expect(fp!.sessionCount).toBe(1);
+    const state = loadCompactionState(projectId);
+    expect(state).not.toBeNull();
+    expect(state!.goal).toBe("test goal");
+  });
+
+  it("is a no-op without projectId (legacy payloads) and never throws", async () => {
+    const { persistConsumedState } = await import("../src/app/steps/persist.ts");
+    expect(() => persistConsumedState({
+      summary: "x", firstKeptEntryId: "e", tokensBefore: 0,
+      details: {} as never, sessionId: "s",
+    })).not.toThrow();
+  });
+});

--- a/test/persist-lifecycle.test.ts
+++ b/test/persist-lifecycle.test.ts
@@ -12,8 +12,17 @@
  * These tests exercise the orchestration without needing a real Pi context —
  * we drive `applyCompaction` with a minimal fake RunContext.
  */
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeAll } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { applyCompaction } from "../src/app/steps/persist.ts";
+
+// applyCompaction records outcome metrics (JSONL append under HOME); isolate
+// the writes so the suite never touches the developer's real metrics log.
+beforeAll(() => {
+  process.env.HOME = fs.mkdtempSync(path.join(os.tmpdir(), "psc-persist-"));
+});
 import type { RunContext } from "../src/app/run-context.ts";
 import { createPendingSlot } from "../src/app/pending-slot.ts";
 import type { PendingCompaction } from "../src/types.ts";
@@ -55,10 +64,32 @@ function makeRC(behaviour: "complete" | "error"): RunContext {
     notify: () => { /* no-op */ },
     phaseTimings: [],
     phaseStart: 0,
-    pipelineStart: 0,
+    pipelineStart: Date.now(),
     extraction: undefined,
     compactionState: undefined,
+    // applyCompaction now records the run outcome from the native compact's
+    // callbacks (success on onComplete, error on onError), so the fake RC
+    // needs the metric fields those paths read.
+    sessionId: "test-session",
+    profile: "balanced",
+    tier: "full",
+    contextPercent: 80,
+    toolPercent: 0,
+    totalTokens: 1000,
+    tokensSaved: 500,
+    chunkCount: 1,
+    verificationScore: 100,
+    verificationGaps: [],
+    method: "eesv",
+    modelLabel: "test/model",
+    summaryModel: { provider: "test", id: "model" } as any,
+    cancellation: { timedOut: false } as any,
+    services: undefined as any,
   };
+  // recordSuccessMetrics/recordFailureMetrics read rc.services; give the
+  // fake RC a real bag (lazily imported to keep the test header clean).
+  const { createServices } = require("../src/infra/services.ts");
+  (rc as any).services = createServices();
   (rc as unknown as { _calls: string[] })._calls = calls;
   return rc as RunContext;
 }

--- a/test/resolve-models.test.ts
+++ b/test/resolve-models.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "bun:test";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Model, Api } from "@earendil-works/pi-ai";
+import type { CompactConfig } from "../src/types.ts";
+import { DEFAULT_CONFIG } from "../src/constants.ts";
+import { resolveModels } from "../src/index.ts";
+
+// Minimal mock: resolveModels only touches modelRegistry.find,
+// modelRegistry.getAvailable and ctx.model, so we cast a stub.
+function mkCtx(opts: { models: Model<Api>[]; session?: Model<Api> }): ExtensionContext {
+  const models = opts.models;
+  return {
+    model: opts.session,
+    modelRegistry: {
+      getAvailable: () => models,
+      find: (provider: string, id: string) =>
+        models.find(m => m.provider === provider && m.id === id),
+    },
+  } as unknown as ExtensionContext;
+}
+
+function mkModel(provider: string, id: string): Model<Api> {
+  return { provider, id, contextWindow: 200000 } as unknown as Model<Api>;
+}
+
+function cfg(over: Partial<CompactConfig> = {}): CompactConfig {
+  return { ...DEFAULT_CONFIG, ...over } as CompactConfig;
+}
+
+const OPENAI = mkModel("openai", "gpt-5");
+const ANTHROPIC = mkModel("anthropic", "claude-sonnet");
+
+describe("resolveModels precedence", () => {
+  it("explicit selection (TUI) wins over config.summaryModel", () => {
+    const ctx = mkCtx({ models: [OPENAI, ANTHROPIC], session: OPENAI });
+    const config = cfg({ summaryModel: "anthropic/claude-sonnet" });
+    // User picked OPENAI in the TUI -> explicit=true
+    const { sumModel } = resolveModels(ctx, OPENAI, config, true);
+    expect(sumModel).toBe(OPENAI);
+  });
+
+  it("non-explicit falls back to config.summaryModel (auto-trigger path)", () => {
+    const ctx = mkCtx({ models: [OPENAI, ANTHROPIC], session: OPENAI });
+    const config = cfg({ summaryModel: "anthropic/claude-sonnet" });
+    const { sumModel } = resolveModels(ctx, OPENAI, config, false);
+    expect(sumModel).toBe(ANTHROPIC);
+  });
+
+  it("default (no arg) behaves like non-explicit", () => {
+    const ctx = mkCtx({ models: [OPENAI, ANTHROPIC], session: OPENAI });
+    const config = cfg({ summaryModel: "anthropic/claude-sonnet" });
+    const { sumModel } = resolveModels(ctx, OPENAI, config);
+    expect(sumModel).toBe(ANTHROPIC);
+  });
+
+  it("without config.summaryModel, primary is used regardless of explicit", () => {
+    const ctx = mkCtx({ models: [OPENAI, ANTHROPIC], session: OPENAI });
+    const config = cfg({ summaryModel: null });
+    expect(resolveModels(ctx, ANTHROPIC, config, true).sumModel).toBe(ANTHROPIC);
+    expect(resolveModels(ctx, ANTHROPIC, config, false).sumModel).toBe(ANTHROPIC);
+  });
+
+  it("config.segmentationModel still overrides segModel (TUI exposes only summary)", () => {
+    const ctx = mkCtx({ models: [OPENAI, ANTHROPIC], session: OPENAI });
+    const config = cfg({ segmentationModel: "anthropic/claude-sonnet" });
+    const { segModel, sumModel } = resolveModels(ctx, OPENAI, config, true);
+    expect(sumModel).toBe(OPENAI); // explicit won
+    expect(segModel).toBe(ANTHROPIC); // segmentation config still applied
+  });
+});

--- a/test/services.test.ts
+++ b/test/services.test.ts
@@ -117,7 +117,8 @@ describe("run-scoped services", () => {
 
     expect(getMetricsSummary(a).totalInput).toBe(10);
     expect(getMetricsSummary(b).totalInput).toBe(20);
-    expect(getMetricsSummary().totalCalls).toBe(0);
+    // The default container must stay untouched — explicit bags only.
+    expect(getMetricsSummary(getDefaultServices()).totalCalls).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Full codebase audit follow-up. 508 tests pass, typecheck clean.

### Critical
- **persistConsumedState**: durable state (project fingerprint + compaction state) now persists at the `session_before_compact` consume point — the auto-trigger and tool paths never reach `applyCompaction`, so the fingerprint/delta/damage-baseline chain silently never ran on the most common path
- **StringDecoder in streamJsonlLines**: multi-byte UTF-8 chars split across 64KB chunk boundaries no longer corrupt to U+FFFD (silently broke JSON.parse for that line)

### Major
- `acquireLockSync`: atomic rename-steal replaces racy rmdir stale-reclaim (two waiters could co-hold the lock)
- unresolvable explicit model arg now errors loudly instead of silent fallback to ctx.model

### Minor
- `BLOCKED_RE` narrowed (\\bdepends? on\\b) + min-length/command guard
- timeline keeps most *recent* user requests, chronological order restored
- manual-run success/error metric recorded from native compact callbacks (was pre-apply)
- tool `dry_run` reports success instead of failure message
- `createServices` resolves LLM client lazily (honours late `setLlmClient`)

### Refactor
- metrics surface migrated to explicit services DI; module-level shims deleted; single sanctioned fallback at `trackedComplete`
- backup prune deferred via `setTimeout(0)` (queueMicrotask ran in the same turn)
- dropped write-only `prunedToolCallIndex`; capped Turkish-char scan to 8KB; removed per-ref Set spread in verifySummary

### New tests
- `test/persist-consumed.test.ts` (C1 regression)
- `test/persist-lifecycle.test.ts` + `test/backup-prune.test.ts` updated for new behaviour