### PR TITLE
feat: add per-stage compaction reasoning levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Independent `summaryThinkingLevel` and `segmentationThinkingLevel` settings control per-phase reasoning while preserving provider defaults when unset.
+
 ## [7.21.0] - 2026-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Add `smartCompact` to `~/.pi/agent/settings.json`:
     "profile": "balanced",
     "summaryModel": null,
     "segmentationModel": null,
+    "summaryThinkingLevel": null,
+    "segmentationThinkingLevel": null,
     "autoTrigger": true,
     "minContextPercent": 60,
     "backupEnabled": true,
@@ -226,6 +228,8 @@ Add `smartCompact` to `~/.pi/agent/settings.json`:
 | `profile` | `light \| balanced \| aggressive` | `balanced` | Default policy profile |
 | `summaryModel` | `string \| null` | `null` | Uses the active session model when null |
 | `segmentationModel` | `string \| null` | `null` | Optional cheaper model for Explore |
+| `summaryThinkingLevel` | `minimal \| low \| medium \| high \| xhigh \| max \| null` | `null` | Reasoning level for synthesis and repair; provider default when null |
+| `segmentationThinkingLevel` | `minimal \| low \| medium \| high \| xhigh \| max \| null` | `null` | Reasoning level for exploration; provider default when null |
 | `autoTrigger` | `boolean` | `true` | Participate in Pi's native compact hook |
 | `autoTriggerTimeoutMs` | `number` | `120000` | Hard timeout for automatic runs |
 | `minContextPercent` | `number` | `60` | Actual context usage gate |

--- a/src/app/steps/prepare.ts
+++ b/src/app/steps/prepare.ts
@@ -39,6 +39,10 @@ export async function prepareRun(rc: RcBase): Promise<PreparedRc | null> {
     }
   }
   const providerCaps = getProviderCaps(rc.summaryModel.provider);
+  rc.services.thinkingLevels = {
+    summaryThinkingLevel: config.summaryThinkingLevel,
+    segmentationThinkingLevel: config.segmentationThinkingLevel,
+  };
   rc.services.scrubber = new SecretScrubber(config.scrubSecrets, config.scrubPii);
   if (config.maxLatencyMs > 0) {
     rc.timeoutMs = rc.timeoutMs > 0 ? Math.min(rc.timeoutMs, config.maxLatencyMs) : config.maxLatencyMs;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -52,6 +52,8 @@ export const DEFAULT_CONFIG = {
   profiles: PROFILES,
   summaryModel: null as string | null,
   segmentationModel: null as string | null,
+  summaryThinkingLevel: null,
+  segmentationThinkingLevel: null,
   autoTrigger: true,
   autoTriggerTimeoutMs: 120000,
   backupEnabled: true,

--- a/src/infra/llm-client.ts
+++ b/src/infra/llm-client.ts
@@ -3,10 +3,10 @@
  *
  * Why we have a seam at all:
  *
- *  - `complete` from `@earendil-works/pi-ai` is the *only* runtime entry point
- *    into a model. Importing it directly from utility modules tied even the
- *    metrics test path to the peer dependency, which made `bun test` fail
- *    when the peer was not installed.
+ *  - pi-ai's completers are the only runtime entry points into a model.
+ *    Importing them directly from utility modules tied even the metrics test
+ *    path to the peer dependency, which made `bun test` fail when the peer
+ *    was not installed.
  *
  *  - Test fakes need to assert which `phase` was used, control failures, and
  *    return synthetic usage tokens for calibration tests.
@@ -17,18 +17,17 @@
  * The interface is intentionally narrow: a single `complete()` method matching
  * the pi-ai shape, plus the same options object existing callers already pass.
  *
- * The default implementation (`defaultLlmClient`) calls `complete()` from
- * pi-ai. `setLlmClient` is exposed for tests and for callers that wish to
- * inject a wrapping/fallback client at extension boot. See `resolveComplete`
- * below for how `complete` is obtained under the host's compat aliasing.
+ * The default implementation keeps `complete()` for existing calls and uses
+ * `completeSimple()` when generic reasoning is explicitly configured.
+ * `setLlmClient` is exposed for tests and wrapping/fallback clients. Both
+ * completers are resolved below through the host's compat alias.
  */
 
-import type { Model, Api, AssistantMessage, Context, ProviderStreamOptions } from "@earendil-works/pi-ai";
+import type { Model, Api, AssistantMessage, Context, ProviderStreamOptions, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { withRetry } from "./llm-retry.ts";
 
-// pi-ai 0.80 removed the standalone `complete()`/`stream()` from the package
-// root and moved them to the `/compat` subpath. The bare `complete` is resolved
-// with a dynamic import rather than a static one:
+// pi-ai 0.80 moved the completers to the `/compat` subpath. They are resolved
+// with dynamic imports rather than static ones:
 //
 //  - A STATIC `import { complete }` breaks either context: the root specifier
 //    has no `complete` export in raw node/test resolution, and importing the
@@ -40,8 +39,13 @@ import { withRetry } from "./llm-retry.ts";
 //    `/compat` directly. It runs on first use (never at module load), so a
 //    resolution hiccup can never break extension loading, and test fakes that
 //    inject their own client via setLlmClient never trigger it.
-let _complete: ((model: Model<Api>, body: Context, opts: ProviderStreamOptions) => Promise<AssistantMessage>) | null = null;
-async function resolveComplete() {
+type CompleteFn<TOptions> = (model: Model<Api>, body: Context, opts: TOptions) => Promise<AssistantMessage>;
+export type LlmCompleteOptions = SimpleStreamOptions;
+
+let _complete: CompleteFn<ProviderStreamOptions> | null = null;
+let _completeSimple: CompleteFn<SimpleStreamOptions> | null = null;
+
+async function resolveComplete(): Promise<CompleteFn<ProviderStreamOptions>> {
   if (_complete) return _complete;
   const mod = await import("@earendil-works/pi-ai/compat");
   const fn = mod.complete;
@@ -50,13 +54,24 @@ async function resolveComplete() {
   return fn;
 }
 
-export interface LlmClient {
-  complete(model: Model<Api>, body: Context, opts: ProviderStreamOptions): Promise<AssistantMessage>;
+async function resolveCompleteSimple(): Promise<CompleteFn<SimpleStreamOptions>> {
+  if (_completeSimple) return _completeSimple;
+  const mod = await import("@earendil-works/pi-ai/compat");
+  const fn = mod.completeSimple;
+  if (typeof fn !== "function") throw new Error("smart-compact: pi-ai /compat did not export completeSimple()");
+  _completeSimple = fn;
+  return fn;
 }
 
-/** Raw client — direct pass-through to pi-ai. Tests can install this to skip retries. */
+export interface LlmClient {
+  complete(model: Model<Api>, body: Context, opts: LlmCompleteOptions): Promise<AssistantMessage>;
+}
+
+/** Raw client — map generic reasoning only when explicitly configured. */
 export const rawLlmClient: LlmClient = {
-  complete: async (model, body, opts) => (await resolveComplete())(model, body, opts),
+  complete: async (model, body, opts) => opts.reasoning === undefined
+    ? (await resolveComplete())(model, body, opts as ProviderStreamOptions)
+    : (await resolveCompleteSimple())(model, body, opts),
 };
 
 /**

--- a/src/infra/llm-retry.ts
+++ b/src/infra/llm-retry.ts
@@ -27,8 +27,8 @@
  * the common shapes; anything unrecognized retries once at most.
  */
 
-import type { Model, Api, AssistantMessage, Context, ProviderStreamOptions } from "@earendil-works/pi-ai";
-import type { LlmClient } from "./llm-client.ts";
+import type { Model, Api, AssistantMessage, Context } from "@earendil-works/pi-ai";
+import type { LlmClient, LlmCompleteOptions } from "./llm-client.ts";
 import * as log from "../utils/logger.ts";
 
 export interface RetryPolicy {
@@ -122,7 +122,7 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
  */
 export function withRetry(inner: LlmClient, policy: RetryPolicy = DEFAULT_RETRY_POLICY): LlmClient {
   return {
-    async complete(model: Model<Api>, body: Context, opts: ProviderStreamOptions): Promise<AssistantMessage> {
+    async complete(model: Model<Api>, body: Context, opts: LlmCompleteOptions): Promise<AssistantMessage> {
       let lastErr: unknown;
       for (let attempt = 1; attempt <= policy.maxAttempts; attempt++) {
         try {

--- a/src/infra/services.ts
+++ b/src/infra/services.ts
@@ -30,7 +30,7 @@ import { systemClock } from "./clock.ts";
 import type { LlmClient } from "./llm-client.ts";
 import { getLlmClient } from "./llm-client.ts";
 import crypto from "node:crypto";
-import type { LLMCallMetric } from "../types.ts";
+import type { CompactConfig, LLMCallMetric } from "../types.ts";
 import { METRICS_BUFFER_MAX, ONE_HOUR_MS } from "../constants.ts";
 import { TokenCalibrationStore } from "../utils/tokens.ts";
 import { SecretScrubber } from "../domain/scrub.ts";
@@ -183,6 +183,8 @@ export interface SmartCompactServices {
   tokenCalibration: TokenCalibrationStore;
   budget: BudgetGuard;
   scrubber: SecretScrubber;
+  /** Config snapshot used to select generic reasoning levels for each phase. */
+  thinkingLevels: Pick<CompactConfig, "summaryThinkingLevel" | "segmentationThinkingLevel">;
   /** Per-run prompt-cache namespace for providers that support prompt caching. */
   compactSessionId: string;
 }
@@ -204,6 +206,7 @@ export function createServices(overrides: Partial<SmartCompactServices> = {}): S
     tokenCalibration: overrides.tokenCalibration ?? new TokenCalibrationStore(),
     budget: overrides.budget ?? new BudgetGuard(),
     scrubber: overrides.scrubber ?? new SecretScrubber(),
+    thinkingLevels: overrides.thinkingLevels ?? { summaryThinkingLevel: null, segmentationThinkingLevel: null },
     compactSessionId: overrides.compactSessionId ?? makeCompactSessionId(),
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
  * Core type definitions for the Smart Compact extension.
  */
 
-import type { Model, Api } from "@earendil-works/pi-ai";
+import type { Model, Api, ThinkingLevel } from "@earendil-works/pi-ai";
 import type { SectionKind } from "./domain/summary-schema.ts";
 
 /** Session type classification */
@@ -24,6 +24,8 @@ export interface CompactConfig {
   profiles: Record<CompressionProfile, ProfileConfig>;
   summaryModel: string | null;
   segmentationModel: string | null;
+  summaryThinkingLevel: ThinkingLevel | null;
+  segmentationThinkingLevel: ThinkingLevel | null;
   autoTrigger: boolean;
   autoTriggerTimeoutMs: number;
   backupEnabled: boolean;
@@ -307,6 +309,7 @@ export interface CacheAwareOptions {
   headers?: Record<string, string>;
   maxTokens?: number;
   signal?: AbortSignal;
+  reasoning?: ThinkingLevel;
   cacheRetention?: "none" | "short" | "long";
   sessionId?: string;
 }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -31,6 +31,9 @@ const INTERNAL_PHASES: ReadonlySet<LLMCallMetric["phase"]> = new Set([
   "explore", "explore-loop", "explore-retry", "explore-direct",
   "single-pass", "batch", "assemble", "patch",
 ]);
+const SEGMENTATION_PHASES: ReadonlySet<LLMCallMetric["phase"]> = new Set([
+  "probe", "explore", "explore-loop", "explore-retry", "explore-direct",
+]);
 
 export function cacheOpts(
   opts: CacheAwareOptions,
@@ -101,8 +104,14 @@ export async function trackedComplete(
   const safeRequest = svc.scrubber.scrubValue(reqBody).value;
   const start = Date.now();
   try {
-    const resolvedOpts = cacheOpts(opts, model.provider, phase, svc);
-    const resp = await svc.llm.complete(model, safeRequest, resolvedOpts as import("@earendil-works/pi-ai").ProviderStreamOptions);
+    const configuredReasoning = SEGMENTATION_PHASES.has(phase)
+      ? svc.thinkingLevels.segmentationThinkingLevel
+      : svc.thinkingLevels.summaryThinkingLevel;
+    const callOpts = opts.reasoning !== undefined || configuredReasoning === null
+      ? opts
+      : { ...opts, reasoning: configuredReasoning };
+    const resolvedOpts = cacheOpts(callOpts, model.provider, phase, svc);
+    const resp = await svc.llm.complete(model, safeRequest, resolvedOpts);
     const latency = Date.now() - start;
     const usage = resp.usage;
     const inputT = usage?.input ?? 0;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -14,6 +14,7 @@ import { flattenToolCallBlock } from "./extraction.ts";
 import { extractToolPath } from "../domain/tool-semantics.ts";
 
 const VALID_PROFILES = ["light", "balanced", "aggressive"] as const;
+const VALID_THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const PROFILE_NUMERIC_KEYS = ["summaryBudgetTokens", "keepRecentTokens", "minChunkTokens", "maxChunkTokens", "singlePassMaxTokens", "batchMaxTokens"] as const;
 
 /**
@@ -49,6 +50,13 @@ export function validateSmartCompactConfig(sc: Record<string, unknown>): void {
   if ("segmentationModel" in sc && sc.segmentationModel !== null && typeof sc.segmentationModel !== "string") {
     log.warn("smart-compact config: segmentationModel must be string|null, got " + typeof sc.segmentationModel);
     delete sc.segmentationModel;
+  }
+  for (const key of ["summaryThinkingLevel", "segmentationThinkingLevel"] as const) {
+    const value = sc[key];
+    if (key in sc && value !== null && !(typeof value === "string" && (VALID_THINKING_LEVELS as readonly string[]).includes(value))) {
+      log.warn("smart-compact config: " + key + " must be minimal|low|medium|high|xhigh|max|null.");
+      delete sc[key];
+    }
   }
   if ("profiles" in sc) {
     if (typeof sc.profiles !== "object" || sc.profiles === null || Array.isArray(sc.profiles)) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -16,6 +16,18 @@ describe("validateSmartCompactConfig", () => {
     expect(sc.profile).toBe("light");
   });
 
+  it("validates per-phase thinking levels", () => {
+    const sc: Record<string, unknown> = {
+      summaryThinkingLevel: "max",
+      segmentationThinkingLevel: "extreme",
+    };
+    validateSmartCompactConfig(sc);
+    expect(sc.summaryThinkingLevel).toBe("max");
+    expect(sc.segmentationThinkingLevel).toBeUndefined();
+    expect(DEFAULT_CONFIG.summaryThinkingLevel).toBeNull();
+    expect(DEFAULT_CONFIG.segmentationThinkingLevel).toBeNull();
+  });
+
   it("deletes invalid autoTrigger (string)", () => {
     const sc = { autoTrigger: "true" };
     validateSmartCompactConfig(sc);

--- a/test/llm-client.test.ts
+++ b/test/llm-client.test.ts
@@ -6,7 +6,8 @@
  * `complete` from pi-ai. Also verifies `resetLlmClient` restores the default.
  */
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { setLlmClient, resetLlmClient, defaultLlmClient, getLlmClient } from "../src/infra/llm-client.ts";
+import { setLlmClient, resetLlmClient, defaultLlmClient, getLlmClient, rawLlmClient } from "../src/infra/llm-client.ts";
+import { createServices } from "../src/infra/services.ts";
 import { trackedComplete } from "../src/utils/cache.ts";
 import type { Model, Api } from "@earendil-works/pi-ai";
 
@@ -31,6 +32,46 @@ describe("llm-client seam", () => {
     const resp = await trackedComplete("batch", model, { systemPrompt: "x", messages: [] } as any, { apiKey: "k" } as any);
     expect(captured.model?.id).toBe("test-model");
     expect(resp.usage?.input).toBe(10);
+  });
+
+  it("uses the run config snapshot by phase and preserves explicit overrides", async () => {
+    const captured: unknown[] = [];
+    const services = createServices({
+      thinkingLevels: { segmentationThinkingLevel: "low", summaryThinkingLevel: "high" },
+      llm: {
+        complete: async (_model, _body, opts) => {
+          captured.push(opts.reasoning);
+          return { content: [], usage: { input: 0, output: 0, cacheRead: 0 } } as any;
+        },
+      },
+    });
+    const body = { systemPrompt: "x", messages: [] } as any;
+
+    await trackedComplete("explore", model, body, { apiKey: "k" }, services);
+    await trackedComplete("batch", model, body, { apiKey: "k" }, services);
+    await trackedComplete("patch", model, body, { apiKey: "k", reasoning: "minimal" }, services);
+
+    expect(captured).toEqual(["low", "high", "minimal"]);
+  });
+
+  it("maps generic reasoning through completeSimple before building the provider payload", async () => {
+    const { getModel } = await import("@earendil-works/pi-ai/compat");
+    const openaiModel = getModel("openai", "gpt-5.4");
+    expect(openaiModel).toBeDefined();
+    let payload: any;
+
+    await rawLlmClient.complete(openaiModel!, {
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }], timestamp: Date.now() }],
+    }, {
+      apiKey: "test",
+      reasoning: "low",
+      onPayload: (value) => {
+        payload = value;
+        throw new Error("payload captured");
+      },
+    });
+
+    expect(payload?.reasoning?.effort).toBe("low");
   });
 
   it("resetLlmClient restores the default", () => {


### PR DESCRIPTION
## Summary

Adds independently configurable reasoning levels for Smart Compact's two model roles:

- `summaryThinkingLevel` for synthesis, assembly, and repair
- `segmentationThinkingLevel` for exploration and segmentation

Both default to `null`, preserving the provider's existing default behavior. Explicit call-level reasoning still takes precedence.

## Motivation

Smart Compact supports separate summary and segmentation models, but its direct `complete()` calls do not inherit Pi's session thinking level. Users currently cannot choose lighter reasoning for segmentation and stronger reasoning for final synthesis.

## Implementation

- Adds typed, validated per-stage configuration keys
- Maps exploration phases to `segmentationThinkingLevel`
- Maps synthesis, assembly, and patch phases to `summaryThinkingLevel`
- Passes the selected level through Pi's existing `reasoning` provider option
- Documents the new settings and adds changelog coverage

## Validation

- `bun run typecheck`
- `bun test` — 522 tests passed
- `bun run build`
- `bun run compat:pi` — passed against Pi 0.80.7
