### PR TITLE
release: v7.21.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Test
         run: bun test
 
+      - name: EESV adversarial gate
+        run: bun run gate
+
       - name: Build
         run: bun run build
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -158,6 +158,16 @@ open-loop coverage.
 **Repair order is intentional:** (1) accept if good enough → (2) deterministic
 patch first (free, idempotent) → (3) LLM patch only if still insufficient.
 
+## EESV hardening and control surfaces
+
+- **Canonical summary IR** accepts recognized H1/H2/H3 headings, preserves Progress subsections, and merges duplicate canonical kinds before state mutation.
+- **Typed verification gaps** drive mandatory deterministic repair; collision-aware path needles prevent basename cross-satisfaction. Provenance is persisted and shown before optional approval.
+- **Fine tool semantics** separate read/search/list/mutate/delete/execute operations. Pruning deduplicates only identical idempotent access signatures.
+- **Unified token planning** uses one run-scoped provider/model-calibrated estimator and counts structured tool-call arguments in window and batch decisions.
+- **Security boundaries** scrub high-confidence secrets before provider calls and durable cache/backup/state writes; PII scrubbing is opt-in.
+- **Policy controls** include focus weighting, exact call/latency budgets, fail-closed manual approval, online damage monitoring, and persisted open-loop overrides.
+- **Release gate** (`bun run gate`) covers adversarial parser, verification, tool, cache, budget, scrub and damage fixtures.
+
 ## State, caching & persistence
 
 Post-verification, `app/steps/state.ts` + `src/utils/state.ts` enrich the
@@ -289,7 +299,9 @@ Pure semantics — no I/O, no async, no globals.
 | File | Responsibility |
 | --- | --- |
 | `domain/summary-schema.ts` | canonical section kinds + heading classification |
-| `domain/summary-parse.ts` | parse/render summary into structured sections; placement (`before`/`after`) |
+| `domain/summary-parse.ts` | parse/render canonical H1/H2/H3 sections; merge duplicates; placement (`before`/`after`) |
+| `domain/tool-semantics.ts` | fine tool operation taxonomy with broad compatibility wrapper |
+| `domain/scrub.ts` | pure secret/PII redaction primitives and run-scoped scrubber |
 
 ### Algorithm layer (`src/phases/`)
 
@@ -297,7 +309,7 @@ Pure semantics — no I/O, no async, no globals.
 | --- | --- |
 | `phases/explore.ts` | targeted exploration with tool-call probing |
 | `phases/synthesize.ts` | chunking, single-pass compact, batch summarization, assembly |
-| `phases/verify.ts` | scoring, gap detection, summary patching |
+| `phases/verify.ts` | typed gap detection, collision-safe coverage, deterministic/LLM repair |
 
 ### Infrastructure layer (`src/infra/`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [7.21.0] - 2026-07-15
+
+### Fixed
+- Canonical summary parsing now recognizes canonical H3 headings, merges duplicate sections, and preserves H3-only summaries during state injection.
+- File verification uses collision-aware path needles; one monorepo basename can no longer satisfy multiple modified files.
+- Every deterministic verification gap is repaired regardless of scalar score; typed gaps and repair provenance replace string-prefix policy.
+- Recent-tail and batch planning count structured tool-call arguments with run-scoped provider/model calibration.
+- Access pruning deduplicates only identical tool name + argument signatures; read/search/list evidence no longer collapses by path alone.
+- MCP snake-case edit aliases are classified as mutations without treating ambiguous `path + text` payloads universally as writes.
+- Incremental extraction reconciles cached unresolved errors against successful retries in the new suffix.
+- LLM call counts now come from the run-scoped metrics sink, including probes, retries, failures and patches.
+
+### Added
+- High-confidence secret scrubbing at provider, extraction-cache, backup, state and pending-summary boundaries; optional PII scrubbing.
+- Optional fail-closed manual Apply/Cancel approval gate with verification provenance.
+- Exact max-call and max-latency budgets with deterministic degradation, plus `--focus` budget weighting.
+- Online `session_compact` → `message_end` damage monitoring and opt-in adaptive preservation policy.
+- `/smart-compact loops` manager for resolve/reopen, priority and pin/unpin overrides with stable summary identity across runs.
+- Deterministic adversarial EESV release gate (`bun run gate`) covering parser, verification, tools, cache, budgets, scrubbing and damage.
+
+### Changed
+- Public README redesigned for npm, GitHub and Pi package surfaces with install-first quick start, progressive EESV documentation, complete configuration, safety/privacy guidance and current recovery/observability flows.
+- Extraction and exploration share one deduplicated fact context; runtime call accounting now comes from the metrics sink instead of inferred round counts.
+- CI and the release checklist now run the adversarial EESV gate.
+
 ## [7.20.0] - 2026-07-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,37 +1,20 @@
 <div align="center">
 
-<img src="./docs/assets/banner.svg" alt="pi-smart-compact" width="860" />
+<a href="https://github.com/alpertarhan/pi-smart-compact">
+  <img src="https://raw.githubusercontent.com/alpertarhan/pi-smart-compact/main/docs/assets/banner.svg" alt="pi-smart-compact" width="860" />
+</a>
 
 [![CI](https://github.com/alpertarhan/pi-smart-compact/actions/workflows/ci.yml/badge.svg)](https://github.com/alpertarhan/pi-smart-compact/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/pi-smart-compact?color=60a5fa)](https://www.npmjs.com/package/pi-smart-compact)
-[![license](https://img.shields.io/npm/l/pi-smart-compact?color=22c55e)](./LICENSE)
-[![Pi extension](https://img.shields.io/badge/Pi-extension-fbbf24)](https://github.com/earendil-works/pi)
+[![license](https://img.shields.io/npm/l/pi-smart-compact?color=22c55e)](https://github.com/alpertarhan/pi-smart-compact/blob/main/LICENSE)
+[![Pi package](https://img.shields.io/badge/Pi-package-fbbf24)](https://github.com/earendil-works/pi)
 
-**Verification-oriented smart compaction for the [Pi Coding Agent](https://github.com/earendil-works/pi-coding-agent).**
+### Verification-oriented context compaction for the Pi Coding Agent
+
+Preserve the agent's **working state**—goals, files, decisions, errors,
+constraints, and open loops—not just a vague recap of the conversation.
 
 </div>
-
-Default compaction trims your conversation blind. `pi-smart-compact` keeps what
-the agent actually needs to continue — the **goal, changed files, unresolved
-errors, decisions, constraints, and open loops** — through a verified
-**Extract → Explore → Synthesize → Verify** pipeline.
-
-> Facts first, synthesis second, verification last.
-
----
-
-## Why
-
-Default compaction produces a vague recap and quietly drops the operational
-context that matters most during coding. The result is the classic
-*"didn't we already fix this?"* loop.
-
-| Default compaction | `pi-smart-compact` |
-| --- | --- |
-| Trims by token count | Extracts facts deterministically (zero LLM) |
-| Generic prose recap | Structured working-state summary |
-| Loses files / errors / decisions | Preserves them, then **verifies** they survived |
-| No regression signal | Damage detection + metrics dashboard |
 
 ## Install
 
@@ -39,7 +22,7 @@ context that matters most during coding. The result is the classic
 pi install npm:pi-smart-compact
 ```
 
-From GitHub:
+Or install directly from GitHub:
 
 ```bash
 pi install git:github.com/alpertarhan/pi-smart-compact
@@ -48,237 +31,330 @@ pi install git:github.com/alpertarhan/pi-smart-compact
 ## Quick start
 
 ```bash
-/smart-compact                              # interactive — pick model + profile
-/smart-compact anthropic/claude-sonnet-4 balanced
-/smart-compact "focus on auth + unresolved follow-ups"
-/smart-compact metrics                      # profile / provider comparison
-/smart-compact dashboard                    # interactive TUI dashboard
-/smart-compact restore                      # list + view + restore backups
+/smart-compact                                         # interactive model + profile picker
+/smart-compact balanced                                # direct profile
+/smart-compact anthropic/claude-sonnet-4 balanced     # direct model + profile
+/smart-compact balanced --focus=auth                   # preserve extra auth detail
+/smart-compact metrics                                 # text metrics report
+/smart-compact dashboard                               # interactive metrics dashboard
+/smart-compact restore                                 # browse and restore backups
+/smart-compact loops                                   # manage persisted open loops
 ```
 
-Or let the agent call it as a tool on long sessions:
+The extension also participates in Pi's native compaction flow automatically
+when actual context usage crosses the configured threshold (60% by default),
+and exposes a `smart_compact` tool for long-running agents.
 
-```jsonc
-{
-  "name": "smart_compact",
-  "parameters": { "profile": "balanced", "dashboard": false }
-}
-```
+> The tool path stages a safe pending summary. It never compacts the active
+> conversation in the middle of an agent turn.
 
-Auto-compaction also runs before Pi's native compact once context pressure
-crosses your threshold (default 60% **actual** context usage).
+## Why smart compaction?
 
-## How it works
-
-```mermaid
-flowchart LR
-    A["Extract<br/>deterministic facts<br/><i>0 LLM calls</i>"] --> B["Explore<br/>optional deep<br/>analysis"]
-    B --> C["Synthesize<br/>single-pass or<br/>chunked summary"]
-    C --> D["Verify<br/>score gaps,<br/>repair"]
-    D --> E["Return verified<br/>summary to Pi"]
-```
-
-| Stage | What it does |
+| Native-style recap | `pi-smart-compact` |
 | --- | --- |
-| **Extract** | Deterministically pulls files, errors, decisions, constraints, topics, and open loops — no LLM, the ground truth. |
-| **Explore** | Optionally inspects the conversation more deeply when the session is complex. |
-| **Synthesize** | Single-pass for short sessions, Kamradt-style chunked + assembled for long ones. |
-| **Verify** | Scores the result against extracted facts and patches missing critical details. |
+| Summarizes prose | Preserves operational coding state |
+| Trusts one LLM response | Extracts deterministic ground truth first |
+| File/error omissions can be silent | Verifies coverage and repairs known gaps |
+| One strategy for every session | Chooses single-pass or hierarchical synthesis |
+| No quality feedback | Tracks provenance, damage signals, and metrics |
 
-**What it preserves:** user goal · constraints & preferences · modified / read /
-deleted files · unresolved & resolved errors · key decisions · open follow-up
-work · critical next-turn context · the delta since the previous compaction.
+The design principle is simple:
 
-## Integration surfaces
+> **Facts first. Synthesis second. Verification before apply.**
 
-| Surface | When | Detail |
-| --- | --- | --- |
-| `/smart-compact` | Manual | Interactive picker or direct args; bypasses the adaptive gate. |
-| `session_before_compact` | Auto | Runs before Pi's native compaction when context pressure is high. |
-| `smart_compact` tool | Agent | Prepares a pending summary; Pi applies it on the next natural compact. |
+## EESV pipeline
 
-A short-lived pending summary is staged in memory (5-minute TTL) and handed to
-Pi when compaction is applied.
-
-## Example output
-
-A generated summary follows a stable, structured contract:
-
-```markdown
-## Goal
-Add retry/backoff to the LLM client so transient 429/5xx don't abort compaction.
-
-## Constraints & Preferences
-- [requirement] never compact mid-turn from the tool path
-
-## Progress
-### Done
-- [x] Added `withRetry` wrapper in src/infra/llm-retry.ts
-### In Progress
-- [ ] Wire retry client into the services container
-### Blocked
-- None
-
-## Key Decisions
-- **Honor Retry-After verbatim**: providers that set it know their limits best.
-
-## Files Modified
-- src/infra/llm-retry.ts
-- src/infra/llm-client.ts
-
-## Files Read
-- src/app/run-smart-compact.ts
-
-## Open Loops
-- [high] Retried but unresolved: AbortSignal ignored by some providers
-
-## Changes Since Last Compaction
-- New files touched: src/infra/llm-retry.ts
-- New loops: AbortSignal ignored by some providers
-
-## Next Steps
-1. Add an outer hard-timeout as a second line of defense
-
-## Critical Context
-- 408/425/429/5xx are retriable; 4xx (other) fails fast
-
-## Topics Covered
-- LLM retry wrapper (high)
+```text
+Pi conversation
+      │
+      ▼
+┌───────────┐   ┌───────────┐   ┌────────────┐   ┌───────────┐
+│  Extract  │ → │  Explore  │ → │ Synthesize │ → │  Verify   │
+│ 0 LLM     │   │ adaptive  │   │ 1-pass or  │   │ + repair  │
+│ calls     │   │           │   │ hierarchical│   │           │
+└───────────┘   └───────────┘   └────────────┘   └───────────┘
+                                                           │
+                                                           ▼
+                                               staged/applied by Pi
 ```
 
-A machine-readable `CompactionState` is built alongside it for reuse across
-later compactions (delta tracking, damage detection).
+| Stage | Responsibility |
+| --- | --- |
+| **Extract** | Deterministically catalogs files, errors, decisions, constraints, topics, media metadata, and open loops. This is the verification ground truth. |
+| **Explore** | Uses a cheaper segmentation model when a complex session needs deeper topic boundaries or error-chain inspection. Simple sessions skip it. |
+| **Synthesize** | Uses one pass for short sessions and bounded chunk/assembly fallbacks for long sessions. Focus and call/latency budgets are enforced here. |
+| **Verify** | Checks canonical sections and extracted facts, applies every safe deterministic repair, and escalates only unresolved low-scoring gaps to an LLM patch. |
+
+### What survives compaction
+
+- The current goal and user constraints
+- Modified, read, and deleted files
+- Unresolved **and** resolved error history
+- Explicit and implicit decisions
+- Open follow-ups, blockers, priorities, and pinned loops
+- Next actions and critical continuation context
+- Changes since the previous compaction
+
+Summaries use a canonical H1/H2/H3-aware structure, collision-safe file
+matching, typed verification gaps, and persisted repair provenance.
+
+## Usage surfaces
+
+| Surface | Behavior |
+| --- | --- |
+| `/smart-compact` | Explicit manual run. Supports picker UI, direct args, dry-run, focus, and budgets. |
+| `session_before_compact` | Auto path. Runs before Pi's native compaction and returns a verification-scored result when context pressure is high. |
+| `smart_compact` tool | Agent path. Produces a pending summary for Pi's next natural compact; does not compact mid-turn. |
+| `/smart-compact loops` | Project-level open-loop manager: resolve/reopen, priority, pin/unpin. |
+
+### Focus and budgets
+
+```bash
+/smart-compact balanced --focus=authentication
+/smart-compact aggressive --max-calls=6 --max-latency=30000
+/smart-compact balanced --focus=src/auth.ts --max-calls=8
+```
+
+- `--focus` assigns more synthesis/exploration budget to a topic or path. It
+  does **not** attempt unsupported non-contiguous compaction.
+- `--max-calls` accepts `1–100`.
+- `--max-latency` accepts `5000–600000` milliseconds.
+- Call-budget exhaustion degrades to deterministic summaries. The latency
+  budget is a hard cancellation deadline.
+
+The tool exposes equivalent `focus`, `max_calls`, and `max_latency_ms`
+parameters.
+
+## Profiles
+
+| Profile | Summary budget | Recent context kept | Best for |
+| --- | ---: | ---: | --- |
+| `light` | 10,000 tokens | 30,000 tokens | Maximum continuity and detail |
+| `balanced` | 6,000 tokens | 20,000 tokens | General use; default |
+| `aggressive` | 3,000 tokens | 10,000 tokens | Tight context budgets |
+
+Profiles are a starting policy. Provider/model calibration, conversation shape,
+focus hints, damage feedback, and explicit budgets refine the actual run.
+
+## Safety and privacy
+
+### Deterministic safeguards
+
+- Tool-call-aware recent-tail budgeting
+- Exact access-call pruning—different reads, searches, offsets, and patterns do not collapse
+- Tool-call/tool-result pair integrity at the compaction boundary
+- Collision-safe modified-file verification for monorepos
+- Mandatory deterministic repair for patchable verification gaps
+- Cross-session guard and five-minute TTL for pending summaries
+- Session-log recovery for older, truncated tool results
+- Retention-pruned backups before compaction
+
+### Secrets and PII
+
+High-confidence secret scrubbing is enabled by default at every relevant trust
+boundary:
+
+```text
+provider request · extraction cache · backup · state · pending summary
+```
+
+It covers common API keys, cloud/GitHub/Slack tokens, JWTs, bearer tokens,
+private keys, and credential assignments. Optional email/phone/payment-card
+scrubbing is available through `scrubPii`.
+
+Secret scrubbing is defense in depth, **not a replacement for proper secret
+handling or a dedicated DLP system**. See the
+[security policy](https://github.com/alpertarhan/pi-smart-compact/blob/main/SECURITY.md).
+
+### Approval and feedback
+
+- `requireApproval: true` adds a fail-closed manual **Apply / Cancel** decision
+  after the provenance review screen. Auto and tool paths retain their native
+  staged lifecycle.
+- Online damage monitoring observes the first post-compaction messages and
+  records re-read files or repeated context. Remediation hints feed those files
+  into the next compaction.
+- `adaptiveDamageFeedback` can opt a project into larger preservation budgets
+  after repeated high-damage reports.
+
+## Open-loop control
+
+```bash
+/smart-compact loops
+```
+
+The manager operates on the project's persisted `CompactionState`:
+
+- resolve or reopen a loop
+- change priority
+- pin or unpin it across later compactions
+
+Overrides use normalized summary identity instead of positional IDs, so a loop
+cannot accidentally inherit another loop's state on a later run.
 
 ## Configuration
 
-Add to `~/.pi/agent/settings.json`:
+Add `smartCompact` to `~/.pi/agent/settings.json`:
 
 ```json
 {
   "smartCompact": {
     "profile": "balanced",
-    "summaryModel": "anthropic/claude-sonnet-4",
+    "summaryModel": null,
+    "segmentationModel": null,
     "autoTrigger": true,
     "minContextPercent": 60,
-    "backupEnabled": true
+    "backupEnabled": true,
+    "scrubSecrets": true,
+    "scrubPii": false,
+    "requireApproval": false,
+    "maxLlmCalls": 0,
+    "maxLatencyMs": 0,
+    "focusWeighting": true,
+    "onlineDamageMonitor": true,
+    "adaptiveDamageFeedback": false,
+    "pinPaths": []
   }
 }
 ```
 
-| Key | Type | Default |
-| --- | --- | --- |
-| `profile` | `light \| balanced \| aggressive` | `balanced` |
-| `summaryModel` | `string \| null` | `null` (uses session model) |
-| `segmentationModel` | `string \| null` | `null` |
-| `autoTrigger` | `boolean` | `true` |
-| `autoTriggerTimeoutMs` | `number` | `120000` |
-| `minContextPercent` | `number` | `60` |
-| `backupEnabled` | `boolean` | `true` |
-| `backupDir` | `string` | `~/.pi/agent/compact-backups` |
-| `profiles` | per-profile overrides | built-ins |
-| `pinPaths` | `string[]` | `[]` (paths always preserved) |
+<details>
+<summary><strong>All configuration keys</strong></summary>
 
-### Profiles
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `profile` | `light \| balanced \| aggressive` | `balanced` | Default policy profile |
+| `summaryModel` | `string \| null` | `null` | Uses the active session model when null |
+| `segmentationModel` | `string \| null` | `null` | Optional cheaper model for Explore |
+| `autoTrigger` | `boolean` | `true` | Participate in Pi's native compact hook |
+| `autoTriggerTimeoutMs` | `number` | `120000` | Hard timeout for automatic runs |
+| `minContextPercent` | `number` | `60` | Actual context usage gate |
+| `backupEnabled` | `boolean` | `true` | Write a pre-compaction backup |
+| `backupDir` | `string` | `~/.pi/agent/compact-backups` | Empty config value uses this path |
+| `profiles` | object | built-ins | Per-profile numeric overrides |
+| `pinPaths` | `string[]` | `[]` | Always preserve matching paths |
+| `requireApproval` | `boolean` | `false` | Manual UI only; cancel/error fails closed |
+| `scrubSecrets` | `boolean` | `true` | High-confidence credential redaction |
+| `scrubPii` | `boolean` | `false` | Email/phone/card-shaped redaction |
+| `maxLlmCalls` | integer `0–100` | `0` | `0` means unlimited |
+| `maxLatencyMs` | `0` or `5000–600000` | `0` | `0` means unlimited |
+| `focusWeighting` | `boolean` | `true` | Weight focused topics/paths higher |
+| `onlineDamageMonitor` | `boolean` | `true` | Observe post-compaction regression signals |
+| `adaptiveDamageFeedback` | `boolean` | `false` | Increase preservation after repeated damage |
 
-| Profile | Summary budget | Keep recent | Use when |
-| --- | ---: | ---: | --- |
-| `light` | 10000 | 30000 | preserve more detail |
-| `balanced` | 6000 | 20000 | default, general use |
-| `aggressive` | 3000 | 10000 | tighter summaries |
+The legacy `semanticCompact` root key is still accepted for compatibility.
 
-The legacy config key `semanticCompact` is still accepted.
+</details>
 
-## Safeguards
+## Example summary
 
-**Correctness**
+<details>
+<summary><strong>Show canonical output</strong></summary>
 
-- Deterministic extraction before any synthesis
-- Verification scoring with deterministic patching **before** LLM patching
-- Hallucinated file-reference detection (SemVer-aware)
-- Open-loop injection + cross-compaction delta tracking
-- Pinned-path preservation (`pinPaths`) — a deterministic, LLM-free guarantee
-- Damage auto-remediation — re-read files feed forward and get re-preserved next compaction
+```markdown
+## Goal
+Add retry/backoff to the LLM client without breaking cancellation.
 
-**Safety**
+## Constraints & Preferences
+- [requirement] Never compact mid-turn from the tool path.
 
-- Conversation backups before compaction (retention-pruned), browsable + restorable via `/smart-compact restore`
-- `toolCall` / `toolResult` pair integrity at the compaction boundary
-- Cross-session leak guard on the pending summary
-- Session-log recovery that bypasses truncation of older tool results
+## Progress
+### Done
+- [x] Added `withRetry` in `src/infra/llm-retry.ts`.
+### In Progress
+- [ ] Wire the retry client into run-scoped services.
+### Blocked
+- None.
 
-**Observability**
+## Key Decisions
+- **Honor Retry-After verbatim**: provider limits are authoritative.
 
-- Metrics logging with profile / provider comparison
-- Post-compaction damage (regression) detection
-- Interactive TUI + HTML dashboards
+## Files Modified
+- src/infra/llm-retry.ts
+- src/infra/llm-client.ts
 
-## Usage notes
+## Open Loops
+- [high] Preserve AbortSignal behavior across providers.
 
-- Auto / tool compaction is skipped while context is small (below 60% actual usage).
-- Manual `/smart-compact` bypasses that gate — you asked for it.
-- `pi-toolkit`'s `tool=XX%` means tool-output ratio, **not** context fullness;
-  smart-compact uses actual `context=XX%`.
-- The tool path does **not** compact mid-turn (it stages a pending summary).
-- Exploration is adaptive and may be skipped for simple sessions.
+## Changes Since Last Compaction
+- New files touched: src/infra/llm-retry.ts
 
-## Companions & compatibility
+## Next Steps
+1. Add an outer timeout as a second line of defense.
 
-Pi core libraries are host-provided wildcard peers and are excluded from the
-published bundle. This keeps the extension independent from Pi's release cadence:
-the lockfile provides a reproducible development baseline, while daily CI runs
-the full suite against the latest Pi packages without changing the manifest.
+## Critical Context
+- Retry 408/425/429/5xx; fail fast on other 4xx responses.
+```
 
-`pi-smart-compact` is designed to coexist with — and recommended alongside —
-[`pi-toolkit`](https://github.com/ersintarhan/pi-toolkit). pi-toolkit handles
-everyday context hygiene (anchors, pivots, status lines, old tool-output
-trimming); smart-compact handles high-pressure verified compaction. The
-integration protects recent pi-toolkit anchors and recovers original tool
-outputs from the session log.
+</details>
 
-Because smart-compact sits close to Pi's compaction path, take extra care with
-extensions that also rewrite compaction hooks, branch history, entry IDs, tool
-output, or the compaction boundary. If you run another automatic compaction /
-context-rewriting extension, prefer a single `session_before_compact` owner
-unless hook order is explicitly coordinated.
+## Observability and recovery
 
-## Runtime artifacts
+```bash
+/smart-compact metrics       # text report
+/smart-compact dashboard     # interactive TUI; can write a local HTML report
+/smart-compact restore       # browse, inspect, and restore backups
+```
 
-The extension writes under `~/.pi/agent/`:
+Metrics include method, profile, provider, phase timing, token/call estimates,
+verification quality, cache behavior, redactions, adaptation, fallbacks, and
+cancelled runs.
+
+<details>
+<summary><strong>Runtime artifacts</strong></summary>
+
+All files live under `~/.pi/agent/`.
 
 | Path | Purpose |
 | --- | --- |
-| `settings.json` | configuration (read) |
-| `compact-backups/` | conversation backups (retention-pruned) |
-| `.cache/compact-extraction-<session>.json` | incremental extraction cache |
-| `.cache/compact-metrics.jsonl` | metrics log (tail-retained, 5 MiB cap) |
-| `.cache/smart-compact-report.html` | HTML dashboard |
-| `.cache/smart-compact/projects/<projectId>.json` | project fingerprint |
-| `.cache/smart-compact/states/<projectId>.json` | reusable compaction state |
-| `.cache/smart-compact/damage-reports.jsonl` | regression signals (tail-retained, 5 MiB cap) |
-| `.cache/smart-compact/remediation-<projectId>.json` | files to re-preserve after damage |
+| `settings.json` | Configuration (read only) |
+| `compact-backups/` | Retention-pruned conversation backups |
+| `.cache/compact-extraction-<session>.json` | Incremental extraction cache |
+| `.cache/compact-metrics.jsonl` | Tail-retained metrics log; 5 MiB cap |
+| `.cache/smart-compact-report.html` | Local HTML dashboard |
+| `.cache/smart-compact/projects/<projectId>.json` | Project fingerprint |
+| `.cache/smart-compact/states/<projectId>.json` | Compaction state and loop overrides |
+| `.cache/smart-compact/damage-reports.jsonl` | Damage reports; 5 MiB cap |
+| `.cache/smart-compact/remediation-<projectId>.json` | Files to preserve after damage |
+
+</details>
+
+## Compatibility
+
+Pi core packages are host-provided wildcard peers and are excluded from the
+published bundle. The lockfile gives contributors a reproducible baseline,
+while CI validates the latest Pi release daily without changing the manifest.
+An exact version can be checked with `bun run compat:pi <version>`.
+
+`pi-smart-compact` is designed to coexist with
+[`pi-toolkit`](https://github.com/ersintarhan/pi-toolkit): toolkit handles daily
+context hygiene; smart-compact handles high-pressure verified compaction. If
+another extension also owns `session_before_compact` or rewrites branch history,
+coordinate hook order or prefer a single automatic compaction owner.
 
 ## Development
 
 ```bash
 bun install
-bun run typecheck   # tsc --noEmit
-bun test            # full test suite
-bun run bench       # repeatable hot-path benchmark
-bun run compat:pi   # latest Pi, without changing package.json or bun.lock
-bun run compat:pi 0.80.6  # optional exact Pi version
-bun run build       # dist/ output for publishing
+bun run typecheck
+bun test
+bun run gate          # deterministic adversarial EESV release gate
+bun run bench
+bun run build
+bun run compat:pi     # isolated latest-Pi compatibility check
 ```
 
-Pull requests run the same verification in GitHub Actions before merge.
+Pull requests run typecheck, the complete test suite, the adversarial gate, and
+the build in GitHub Actions.
 
-## Documentation
+## Project documentation
 
-- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — system design, execution model, layer responsibilities
-- [`CHANGELOG.md`](./CHANGELOG.md) — release history
-- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — contributor workflow and expectations
-- [`SECURITY.md`](./SECURITY.md) — vulnerability reporting and data-handling notes
-- [`SUPPORT.md`](./SUPPORT.md) — where to ask for help
-- [`docs/RELEASE.md`](./docs/RELEASE.md) — release checklist
+- [Architecture](https://github.com/alpertarhan/pi-smart-compact/blob/main/ARCHITECTURE.md)
+- [Changelog](https://github.com/alpertarhan/pi-smart-compact/blob/main/CHANGELOG.md)
+- [Contributing](https://github.com/alpertarhan/pi-smart-compact/blob/main/CONTRIBUTING.md)
+- [Security](https://github.com/alpertarhan/pi-smart-compact/blob/main/SECURITY.md)
+- [Support](https://github.com/alpertarhan/pi-smart-compact/blob/main/SUPPORT.md)
+- [Release checklist](https://github.com/alpertarhan/pi-smart-compact/blob/main/docs/RELEASE.md)
 
 ## License
 

--- a/bench/hot-paths.bench.ts
+++ b/bench/hot-paths.bench.ts
@@ -2,6 +2,8 @@ import { performance } from "node:perf_hooks";
 import { PROFILES } from "../src/constants.ts";
 import { buildToolCallIndex, extractStructured } from "../src/utils/extraction.ts";
 import { pruneRedundant } from "../src/utils/pruning.ts";
+import { parseSummary } from "../src/domain/summary-parse.ts";
+import { buildUniquePathNeedles } from "../src/utils/file-needles.ts";
 import type { LlmMessage } from "../src/types.ts";
 
 const fullConversation: LlmMessage[] = Array.from({ length: 2_500 }, (_, i): LlmMessage[] => [
@@ -12,6 +14,8 @@ const fullConversation: LlmMessage[] = Array.from({ length: 2_500 }, (_, i): Llm
   { role: "toolResult", toolCallId: "read-" + i, content: [{ type: "text", text: "export const value = " + i + ";" }] },
 ]).flat();
 const incrementalDelta = fullConversation.slice(-100);
+const oneMegabyteSummary = "## Goal\n" + "x".repeat(1_000_000);
+const collidingPaths = Array.from({ length: 500 }, (_, i) => "packages/p" + i + "/src/index.ts");
 let sink = 0;
 
 interface Benchmark {
@@ -42,6 +46,16 @@ const benchmarks: Benchmark[] = [
     name: "prune 5k messages",
     iterations: 5,
     run: () => { sink += pruneRedundant(fullConversation).messages.length; },
+  },
+  {
+    name: "parse 1MB canonical summary",
+    iterations: 5,
+    run: () => { sink += parseSummary(oneMegabyteSummary).sections[0]?.body.length ?? 0; },
+  },
+  {
+    name: "unique needles across 500 paths",
+    iterations: 20,
+    run: () => { sink += buildUniquePathNeedles(collidingPaths[250], collidingPaths).length; },
   },
 ];
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -16,6 +16,7 @@ Use this checklist before publishing `pi-smart-compact`.
 ```bash
 bun run typecheck
 bun test
+bun run gate
 bun run build
 bun run compat:pi
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "7.20.0",
+  "version": "7.21.0",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",
@@ -48,6 +48,7 @@
     "build": "rm -rf dist && mkdir dist && bun build ./src/index.ts --outdir ./dist --target bun --external '@earendil-works/*' --external 'typebox' && bun x tsc --emitDeclarationOnly --outDir dist",
     "test": "bun test",
     "bench": "bun bench/hot-paths.bench.ts",
+    "gate": "bun run scripts/eval-gate.ts",
     "compat:pi": "bun run scripts/check-pi-compat.ts",
     "typecheck": "bun x tsc --noEmit",
     "prepublishOnly": "bun run typecheck && bun test && bun run build"

--- a/scripts/eval-gate.ts
+++ b/scripts/eval-gate.ts
@@ -1,0 +1,18 @@
+const suites = [
+  "test/eval.test.ts",
+  "test/eval-adversarial.test.ts",
+  "test/summary-parse.test.ts",
+  "test/verify.test.ts",
+  "test/tool-semantics.test.ts",
+  "test/window-boundary.test.ts",
+];
+
+const child = Bun.spawn(["bun", "test", ...suites], {
+  cwd: import.meta.dir + "/..",
+  stdin: "inherit",
+  stdout: "inherit",
+  stderr: "inherit",
+});
+const exitCode = await child.exited;
+if (exitCode !== 0) process.exit(exitCode);
+console.log("EESV adversarial release gate passed (" + suites.length + " suites)");

--- a/src/app/run-context.ts
+++ b/src/app/run-context.ts
@@ -44,6 +44,7 @@ import type {
 import type { PendingSlot } from "./pending-slot.ts";
 import type { PruningResult } from "../utils/pruning.ts";
 import type { CompactionTier } from "../utils/helpers.ts";
+import type { TokenEstimator } from "../utils/tokens.ts";
 import type { SmartCompactServices } from "../infra/services.ts";
 
 // ── Shared infra types (unchanged) ───────────────────────────────────────────
@@ -101,6 +102,8 @@ export interface RcBase {
   isRunning: Cell<boolean>;
   flags: RunFlags;
   userNote?: string;
+  focus?: string;
+  maxLlmCalls?: number;
   timeoutMs: number;
   phaseTimings: PipelinePhaseTiming[];
   pipelineStart: number;
@@ -122,6 +125,8 @@ export interface PreparedExt {
   config: CompactConfig;
   profileCfg: ProfileConfig;
   providerCaps: ProviderCapabilities;
+  estimator: TokenEstimator;
+  adapted: boolean;
   summaryAuth: ResolvedAuth;
   segAuth: ResolvedAuth;
 }
@@ -214,6 +219,7 @@ export interface VerifiedExt extends SynthesizedExt {
   readonly _verified: true;
   verificationScore: number;
   verificationGaps: string[];
+  verificationProvenance: import("../types.ts").VerificationProvenance;
   verified: boolean;
 }
 export type VerifiedRc = RcBase & VerifiedExt;

--- a/src/app/run-smart-compact.ts
+++ b/src/app/run-smart-compact.ts
@@ -77,6 +77,8 @@ export interface SmartCompactOptions {
   isRunning: Cell<boolean>;
   autoTriggered?: boolean;
   userNote?: string;
+  focus?: string;
+  maxLlmCalls?: number;
   skipCompact?: boolean;
   /** Explicit user command may bypass adaptive context-pressure tier gate. */
   force?: boolean;
@@ -120,6 +122,8 @@ function makeBase(opts: SmartCompactOptions): RcBase {
       force: !!opts.force,
     },
     userNote: opts.userNote,
+    focus: opts.focus,
+    maxLlmCalls: opts.maxLlmCalls,
     timeoutMs: opts.timeoutMs ?? 0,
     phaseTimings: [],
     pipelineStart,
@@ -267,19 +271,34 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
     if (!willApply) recordSuccessMetrics(stated, "success");
 
     if (!stated.flags.autoTriggered) {
+      const approvalRequired = willApply && stated.config.requireApproval && stated.ctx.hasUI;
+      let decision: "apply" | "cancel" | "closed" = approvalRequired ? "cancel" : "closed";
       try {
-        let resultTimer: ReturnType<typeof setTimeout> | undefined;
-        const timeoutPromise = new Promise<void>(resolve => { resultTimer = setTimeout(resolve, 5000); });
-        try {
-          await Promise.race([showResultScreen(stated.ctx, stated.details, stated.extraction, stated.services), timeoutPromise]);
-        } finally {
-          // Clear the fallback timer whether the screen or the timeout won
-          // the race — otherwise it lingers up to 5s after we've moved on.
-          if (resultTimer) clearTimeout(resultTimer);
+        if (approvalRequired) {
+          // Approval is fail-closed and never races an auto-apply timer.
+          decision = await showResultScreen(stated.ctx, stated.details, stated.extraction, stated.services, { approval: true });
+        } else {
+          let resultTimer: ReturnType<typeof setTimeout> | undefined;
+          const timeoutPromise = new Promise<"closed">(resolve => { resultTimer = setTimeout(() => resolve("closed"), 5000); });
+          try {
+            decision = await Promise.race([
+              showResultScreen(stated.ctx, stated.details, stated.extraction, stated.services),
+              timeoutPromise,
+            ]);
+          } finally {
+            if (resultTimer) clearTimeout(resultTimer);
+          }
         }
       } catch (err) {
         log.warn("Result screen error", err);
-        stated.notify("Result screen skipped", "info");
+        stated.notify(approvalRequired ? "Approval UI failed — compaction cancelled" : "Result screen skipped", approvalRequired ? "warning" : "info");
+        decision = approvalRequired ? "cancel" : "closed";
+      }
+      if (approvalRequired && decision !== "apply") {
+        stated.pendingRef.clear();
+        recordSuccessMetrics(stated, "cancelled");
+        stated.notify("Compaction cancelled — current conversation unchanged", "info");
+        return;
       }
     }
 

--- a/src/app/steps/extract.ts
+++ b/src/app/steps/extract.ts
@@ -30,7 +30,6 @@ import {
 import { deriveProjectId, findGitRoot, loadProjectFingerprint, buildProjectContext } from "../../utils/fingerprint.ts";
 import { getPreviousCompactionContext } from "../../utils/helpers.ts";
 import { isPrefixOf, legacyPrefixMatch } from "../../utils/id-fingerprint.ts";
-import { estimateTokens } from "../../utils/tokens.ts";
 import { serializeConversation } from "@earendil-works/pi-coding-agent";
 import { asSerializableMessages } from "../../infra/ai-messages.ts";
 import { backupConversation } from "../../utils/helpers.ts";
@@ -62,9 +61,9 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
 
   const extractionStart = pruneEnd;
   const convText = serializeConversation(asSerializableMessages(rc.llmMessages));
-  const convTokens = estimateTokens(convText);
+  const convTokens = rc.estimator.text(convText);
 
-  const backupPath = backupConversation(convText, rc.sessionId);
+  const backupPath = backupConversation(rc.services.scrubber.scrubText(convText).value, rc.sessionId);
   const prevContext = getPreviousCompactionContext(rc.branch);
 
   const cachedExt = loadCachedExtraction(rc.sessionId);
@@ -116,7 +115,7 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
     // expects offsets relative to newMsgs[0].
     const deltaTcIdx = buildToolCallIndex(newMsgs);
     const delta = extractStructured(newMsgs, rc.profileCfg, deltaTcIdx);
-    extraction = mergeExtractions(cachedExt.extraction, delta, cachedExt.messageCount);
+    extraction = mergeExtractions(cachedExt.extraction, delta, cachedExt.messageCount, newMsgs, deltaTcIdx);
     rc.notify(
       "Phase 1 Incremental: " + cachedExt.messageCount + " cached + " + newMsgs.length + " new pruned messages",
       "info",
@@ -140,6 +139,10 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
     rc.vlog("Full extraction — " + rc.llmMessages.length + " messages, tier=" + rc.tier);
     recordExtractionCacheMiss(rc.services);
   }
+
+  // Extraction caches are durable artifacts too: redact sensitive text before
+  // it crosses the disk/prompt/state boundary. Paths and indexes are preserved.
+  extraction = rc.services.scrubber.scrubValue(extraction).value;
 
   // messageCount is the pruned domain; entryIds is unpruned; keptEntryIds is
   // the pruning-prefix used for safe incremental extraction next time.

--- a/src/app/steps/metrics.ts
+++ b/src/app/steps/metrics.ts
@@ -25,7 +25,7 @@ function runType(rc: RcBase): "manual" | "auto" | "tool" {
   return rc.flags.skipCompact ? "tool" : rc.flags.autoTriggered ? "auto" : "manual";
 }
 
-export function recordSuccessMetrics(rc: StatedRc, status: "success" | "dry-run"): void {
+export function recordSuccessMetrics(rc: StatedRc, status: "success" | "dry-run" | "cancelled"): void {
   const ecs = getExtractionCacheStats(rc.services);
   appendMetricsLog(rc.sessionId, {
     profile: rc.profile, tier: rc.tier,
@@ -48,6 +48,9 @@ export function recordSuccessMetrics(rc: StatedRc, status: "success" | "dry-run"
     extractionCacheMisses: ecs.misses,
     extractionCacheHitRate: ecs.hitRate,
     extractionCacheMissReason: rc.extractionCacheMissReason,
+    fallbackReason: rc.services.budget.reason() ? "budget-" + rc.services.budget.reason() : undefined,
+    redactions: rc.services.scrubber.count(),
+    adapted: rc.adapted,
   }, rc.services);
 
   const ms = getMetricsSummary(rc.services);

--- a/src/app/steps/persist.ts
+++ b/src/app/steps/persist.ts
@@ -78,7 +78,7 @@ export function runDamageDetection(rc: RunContext): void {
     if (damage.damageScore > 0) {
       rc.notify("Previous compaction damage: " + damage.summary, "warning");
     }
-    logDamageReport(rc.sessionId, damage, safeDetails);
+    logDamageReport(rc.sessionId, damage, safeDetails, rc.projectId);
     // Feed re-read files forward as remediation hints so the next compaction
     // preserves them instead of losing them again.
     if (damage.reReadFiles.length > 0) {

--- a/src/app/steps/prepare.ts
+++ b/src/app/steps/prepare.ts
@@ -11,14 +11,40 @@
 import type { RcBase, PreparedRc } from "../run-context.ts";
 import { advance } from "../run-context.ts";
 import { PROFILES } from "../../constants.ts";
-import { getProviderCaps } from "../../utils/tokens.ts";
+import { getProviderCaps, makeTokenEstimator } from "../../utils/tokens.ts";
 import { loadConfig } from "../../utils/helpers.ts";
 import * as log from "../../utils/logger.ts";
+import { SecretScrubber } from "../../domain/scrub.ts";
+import { BudgetGuard } from "../../infra/services.ts";
+import { deriveProjectIdFromCwd } from "../../utils/fingerprint.ts";
+import { readRecentDamageScores } from "../../utils/damage.ts";
 
 export async function prepareRun(rc: RcBase): Promise<PreparedRc | null> {
   const config = loadConfig();
-  const profileCfg = { ...PROFILES[rc.profile], ...(config.profiles?.[rc.profile] ?? {}) };
+  let profileCfg = { ...PROFILES[rc.profile], ...(config.profiles?.[rc.profile] ?? {}) };
+  let adapted = false;
+  if (config.adaptiveDamageFeedback) {
+    const scores = readRecentDamageScores(deriveProjectIdFromCwd(rc.ctx.cwd), 5);
+    const recent = scores.slice(-3).sort((a, b) => a - b);
+    const median = recent.length ? recent[Math.floor(recent.length / 2)] : 0;
+    if (median >= 25) {
+      const multiplier = median >= 50 ? 1.5 : 1.25;
+      profileCfg = {
+        ...profileCfg,
+        keepRecentTokens: Math.round(profileCfg.keepRecentTokens * multiplier),
+        summaryBudgetTokens: Math.round(profileCfg.summaryBudgetTokens * (median >= 50 ? 1.3 : 1.2)),
+      };
+      adapted = true;
+      rc.notify("Adaptive damage policy: median " + median + "/100 — preserving more recent context", "warning");
+    }
+  }
   const providerCaps = getProviderCaps(rc.summaryModel.provider);
+  rc.services.scrubber = new SecretScrubber(config.scrubSecrets, config.scrubPii);
+  if (config.maxLatencyMs > 0) {
+    rc.timeoutMs = rc.timeoutMs > 0 ? Math.min(rc.timeoutMs, config.maxLatencyMs) : config.maxLatencyMs;
+  }
+  rc.services.budget = new BudgetGuard(rc.maxLlmCalls ?? config.maxLlmCalls, rc.timeoutMs, rc.services.clock);
+  const estimator = makeTokenEstimator(rc.summaryModel.provider, rc.summaryModel.id, rc.services.tokenCalibration);
 
   const auth = await rc.ctx.modelRegistry.getApiKeyAndHeaders(rc.summaryModel);
   // Avoid a second auth call when segModel === summaryModel; some providers
@@ -37,7 +63,7 @@ export async function prepareRun(rc: RcBase): Promise<PreparedRc | null> {
       rc.cancellation.timedOut = true;
       rc.cancellation.controller.abort();
       rc.notify(
-        "Smart compact auto-trigger exceeded " + rc.timeoutMs + "ms; Pi will use native compact for this run",
+        "Smart compact exceeded " + rc.timeoutMs + "ms; Pi will use native compact for this run",
         "warning",
       );
     }, rc.timeoutMs);
@@ -52,12 +78,16 @@ export async function prepareRun(rc: RcBase): Promise<PreparedRc | null> {
     config: typeof config;
     profileCfg: typeof profileCfg;
     providerCaps: typeof providerCaps;
+    estimator: typeof estimator;
+    adapted: boolean;
     summaryAuth: { apiKey: string; headers?: Record<string, string> };
     segAuth: { apiKey: string; headers?: Record<string, string> };
   };
   out.config = config;
   out.profileCfg = profileCfg;
   out.providerCaps = providerCaps;
+  out.estimator = estimator;
+  out.adapted = adapted;
   out.summaryAuth = { apiKey: auth.apiKey, headers: auth.headers };
   out.segAuth = { apiKey: segAuth.apiKey!, headers: segAuth.headers };
   return advance<RcBase, PreparedRc>(out, "_prepared");

--- a/src/app/steps/state.ts
+++ b/src/app/steps/state.ts
@@ -14,18 +14,27 @@ import { advance } from "../run-context.ts";
 import {
   buildCompactionState, injectOpenLoopsSection, extractNextActions,
   extractCriticalContext, loadCompactionState, computeDelta, injectDeltaSection,
-  hasDeltaChanges, ensurePinnedPaths,
+  hasDeltaChanges, ensurePinnedPaths, applyLoopOverrides,
 } from "../../utils/state.ts";
 import { extractOpenLoops } from "../../utils/extraction.ts";
 import { readRemediationHints } from "../../utils/damage.ts";
-import { estimateTokens } from "../../utils/tokens.ts";
 import type { SmartCompactDetails, OpenLoop, CompactionState } from "../../types.ts";
 
 export function buildState(rc: VerifiedRc): StatedRc {
   const extraction = rc.extraction;
   let summary = rc.finalSummary;
 
-  const openLoops = extractOpenLoops(rc.llmMessages, extraction);
+  const prevState = loadCompactionState(rc.projectId);
+  const loopOverrides = prevState?.loopOverrides ?? [];
+  const extractedLoops = extractOpenLoops(rc.llmMessages, extraction);
+  const currentKeys = new Set(extractedLoops.map(loop => loop.summary.toLowerCase().replace(/\s+/g, " ").trim()));
+  const pinnedPrevious = (prevState?.openLoops ?? []).filter(loop => {
+    const key = loop.summary.toLowerCase().replace(/\s+/g, " ").trim();
+    const override = loopOverrides.find(item => item.summaryKey === key);
+    return override?.pinned && !currentKeys.has(key);
+  });
+  const managedLoops = applyLoopOverrides([...extractedLoops, ...pinnedPrevious], loopOverrides);
+  const openLoops = managedLoops.filter(loop => loop.status !== "resolved");
   if (openLoops.length > 0) {
     rc.notify(
       "Open Loops: " + openLoops.length + " detected (" +
@@ -53,14 +62,13 @@ export function buildState(rc: VerifiedRc): StatedRc {
 
   const nextActions = extractNextActions(summary);
   const criticalContextItems = extractCriticalContext(summary);
-  const compactionState = buildCompactionState(
-    extraction, openLoops, rc.explorationReport, nextActions, criticalContextItems,
+  let compactionState = buildCompactionState(
+    extraction, managedLoops, rc.explorationReport, nextActions, criticalContextItems, loopOverrides,
   );
 
   // Cross-compaction delta: when previous state exists, surface what changed
   // since last time so the agent sees a focused diff rather than the entire
   // recomputed state.
-  const prevState = loadCompactionState(rc.projectId);
   if (prevState) {
     const delta = computeDelta(prevState, compactionState);
     if (hasDeltaChanges(delta)) {
@@ -73,9 +81,14 @@ export function buildState(rc: VerifiedRc): StatedRc {
     }
   }
 
+  // Defense in depth: LLM requests and extraction caches are already scrubbed,
+  // but deterministic state/delta injection is another write boundary.
+  summary = rc.services.scrubber.scrubText(summary).value;
+  compactionState = rc.services.scrubber.scrubValue(compactionState).value;
+
   const detModified = extraction.modifiedFiles.map(f => f.path);
   const detRead = extraction.readFiles;
-  const estimatedAfter = estimateTokens(summary) + rc.accTokens;
+  const estimatedAfter = rc.estimator.text(summary) + rc.accTokens;
   const tokensSaved = Math.max(0, rc.totalTokens - estimatedAfter);
 
   const details: SmartCompactDetails = {
@@ -89,7 +102,9 @@ export function buildState(rc: VerifiedRc): StatedRc {
     explorationRounds: rc.explorationRounds, explorationBoundaries: rc.explorationReport?.boundaries.length ?? 0,
     model: rc.modelLabel, qualityScore: rc.verificationScore,
     tokensBefore: rc.totalTokens,
+    provenance: rc.verificationProvenance,
     compactionState, openLoops,
+    redactions: rc.services.scrubber.count(),
   };
 
   const out = rc as VerifiedRc & {

--- a/src/app/steps/synthesize.ts
+++ b/src/app/steps/synthesize.ts
@@ -43,7 +43,6 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
 
   let finalSummary: string;
   let method: "eesv" | "single-pass" | "heuristic";
-  let llmCalls = 0;
   let summaries: ChunkSummary[] = [];
   let explorationReport: import("../../types.ts").ExplorationReport | null = null;
   let explorationRounds = 0;
@@ -61,12 +60,13 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
       const r = await singlePassCompact(
         convText, extraction, null, rc.prevContext + rc.projectCtx,
         rc.summaryModel, rc.summaryAuth, pc.summaryBudgetTokens, rc.cancellation.signal, rc.services,
+        rc.config.focusWeighting ? rc.focus : undefined,
       );
-      finalSummary = r.summary; method = "single-pass"; llmCalls = r.llmCalls;
+      finalSummary = r.summary; method = "single-pass";
     } catch (err) {
       rc.notify("Single-pass failed: " + (err instanceof Error ? err.message : String(err)), "warning");
       finalSummary = assembleFallback([], extraction);
-      method = "heuristic"; llmCalls = 0;
+      method = "heuristic";
     }
   } else {
     const needsExploration = !shouldSkipExplore && shouldExplore(extraction);
@@ -81,7 +81,9 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
       try {
         const expResult = await exploreConversation(
           rc.llmMessages, extraction, rc.segModel, rc.segAuth,
-          rc.prevContext || undefined, rc.userNote, rc.cancellation.signal,
+          rc.prevContext || undefined,
+          [rc.userNote, rc.config.focusWeighting && rc.focus ? "Focus extra preservation on: " + rc.focus : undefined].filter(Boolean).join("\n") || undefined,
+          rc.cancellation.signal,
           MAX_EXPLORATION_ROUNDS, rc.notify, rc.services,
         );
         explorationReport = expResult.report;
@@ -140,7 +142,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
       }));
     }
 
-    const chunks = chunkLlmMessages(rc.llmMessages, boundaries, pc);
+    const chunks = chunkLlmMessages(rc.llmMessages, boundaries, pc, rc.estimator, rc.config.focusWeighting ? rc.focus : undefined);
     chunkCount = chunks.length;
     rc.notify("Chunked: " + chunkCount + " chunks", "info");
     rc.vlog("Chunk topics: " + chunks.map(c => c.topic + "[" + c.startIndex + "-" + c.endIndex + "]").join(", "));
@@ -174,6 +176,13 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
       const errors: (Error | null)[] = new Array(totalBatches).fill(null);
       let completed = 0;
       for (let wave = 0; wave < totalBatches; wave += concurrency) {
+        if (rc.services.budget.reason()) {
+          for (let index = wave; index < totalBatches; index++) {
+            results[index] = batches[index].map(chunk => failedChunkSummary(chunk));
+          }
+          rc.notify("Synthesis budget exhausted — remaining batches use deterministic fallback", "warning");
+          break;
+        }
         const waveBatches = batches.slice(wave, Math.min(wave + concurrency, totalBatches));
         const wavePromises = waveBatches.map(async (batch, i) => {
           const idx = wave + i;
@@ -205,19 +214,18 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
         model: rc.modelLabel, profile: rc.profile, extraction, totalBatches: batches.length,
       });
     }
-    let assemblyCalls = 1;
     try {
       const r = await assembleLLM(
         summaries, extraction, explorationReport, rc.summaryModel, rc.summaryAuth,
         pc.summaryBudgetTokens, rc.prevContext, rc.cancellation.signal, rc.services,
+        rc.config.focusWeighting ? rc.focus : undefined,
       );
       if (r?.startsWith("##")) finalSummary = r; else throw new Error("bad");
     } catch (err) {
       log.warn("Assembly failed", err);
-      finalSummary = assembleFallback(summaries, extraction); assemblyCalls = 0;
+      finalSummary = assembleFallback(summaries, extraction);
     }
     method = "eesv";
-    llmCalls = explorationRounds + batches.length + assemblyCalls;
   }
 
   const out = rc as ExtractedRc & {
@@ -234,7 +242,10 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
   out.finalSummary = finalSummary;
   out.method = method;
   out.methodForMetrics = method;
-  out.llmCalls = llmCalls;
+  // The run-scoped metrics sink is the single source of truth for network
+  // calls, including probes, direct/retry fallbacks, failed batches and patch
+  // calls that manual round arithmetic cannot represent accurately.
+  out.llmCalls = rc.services.metrics.summary().totalCalls;
   out.summaries = summaries;
   out.explorationReport = explorationReport;
   out.explorationRounds = explorationRounds;

--- a/src/app/steps/verify.ts
+++ b/src/app/steps/verify.ts
@@ -1,23 +1,17 @@
 /**
- * Step 7: verify and optionally patch the summary.
+ * Step 7: verify and repair the synthesized summary.
  *
- * Stage: `SynthesizedRc` → `VerifiedRc`.
- *
- * Two-stage patch policy:
- *
- *   1. Run deterministic verification. If the score is comfortably high we
- *      accept the summary as-is — no LLM patch cost, no extra latency.
- *   2. If the score is < 85, apply the deterministic patcher first. It is
- *      free, idempotent, and almost always recovers missing sections / file
- *      lists that the LLM elided.
- *   3. Re-verify. Only if the deterministic patch couldn't bring us above 75
- *      do we burn an LLM call on `patchSummary`. This keeps cost predictable
- *      while still preserving the safety net for catastrophic LLM output.
+ * Every safe deterministic repair is applied regardless of scalar score. The
+ * score controls only whether unresolved findings justify an additional LLM
+ * call; it never suppresses known, zero-cost repairs.
  */
 
 import type { SynthesizedRc, VerifiedRc } from "../run-context.ts";
 import { advance } from "../run-context.ts";
-import { verifySummary, patchDeterministic, patchSummary } from "../../phases/verify.ts";
+import {
+  verifySummary, patchDeterministic, patchSummary,
+  formatVerificationGap, isDeterministicallyPatchable,
+} from "../../phases/verify.ts";
 import { showProgressOverlay } from "../../ui/overlays.ts";
 import * as log from "../../utils/logger.ts";
 
@@ -34,45 +28,49 @@ export async function verifyAndPatch(rc: SynthesizedRc): Promise<VerifiedRc> {
   }
 
   let verification = verifySummary(summary, extraction);
+  const initialScore = verification.score;
+  const deterministicPatched = verification.gaps.filter(isDeterministicallyPatchable);
+  let llmPatched = false;
   rc.vlog("Verification score=" + verification.score + " ok=" + verification.ok + " gaps=" + verification.gaps.length);
 
-  if (!verification.ok) {
-    if (verification.score < 85) {
-      rc.notify(
-        "Phase 4 Verify: " + verification.gaps.length + " gap(s), score=" + verification.score +
-          ", applying deterministic patch",
-        "warning",
-      );
-      summary = patchDeterministic(summary, verification.gaps, extraction);
-      let recheck = verifySummary(summary, extraction);
-      if (!recheck.ok && recheck.score < 75) {
-        rc.notify(
-          "Phase 4 Verify: deterministic patch insufficient (score=" + recheck.score + "), trying LLM patch",
-          "warning",
-        );
-        try {
-          summary = await patchSummary(summary, recheck.gaps, rc.summaryModel, rc.summaryAuth, rc.cancellation.signal, rc.services);
-          rc.llmCalls += 1;
-        } catch (err) { log.warn("LLM patch failed", err); }
-        recheck = verifySummary(summary, extraction);
-      }
-      verification = recheck;
-    } else {
-      rc.notify(
-        "Phase 4 Verify: " + verification.gaps.length + " gap(s), score=" + verification.score +
-          " ≥ 85 — skipping patch",
-        "info",
-      );
+  if (deterministicPatched.length > 0) {
+    rc.notify(
+      "Phase 4 Verify: " + deterministicPatched.length + " deterministic gap(s), score=" + verification.score + ", applying repair",
+      "warning",
+    );
+    summary = patchDeterministic(summary, verification.gaps, extraction);
+    verification = verifySummary(summary, extraction);
+  }
+
+  if (!verification.ok && verification.score < 75) {
+    rc.notify("Phase 4 Verify: deterministic repair insufficient (score=" + verification.score + "), requesting LLM patch", "warning");
+    const beforePatch = summary;
+    try {
+      summary = await patchSummary(summary, verification.gaps, rc.summaryModel, rc.summaryAuth, rc.cancellation.signal, rc.services);
+    } catch (error) { log.warn("LLM patch failed", error); }
+    if (summary !== beforePatch) {
+      llmPatched = true;
+      verification = verifySummary(summary, extraction);
     }
   }
 
   const out = rc as SynthesizedRc & {
     _verified: true;
-    verificationScore: number; verificationGaps: string[]; verified: boolean;
+    verificationScore: number;
+    verificationGaps: string[];
+    verified: boolean;
+    verificationProvenance: import("../../types.ts").VerificationProvenance;
   };
   out.finalSummary = summary;
   out.verified = verification.ok;
-  out.verificationGaps = verification.gaps;
+  out.verificationGaps = verification.gaps.map(formatVerificationGap);
   out.verificationScore = verification.score;
+  out.verificationProvenance = {
+    initialScore,
+    deterministicPatched,
+    llmPatched,
+    finalScore: verification.score,
+    remainingGaps: verification.gaps,
+  };
   return advance<SynthesizedRc, VerifiedRc>(out, "_verified");
 }

--- a/src/app/steps/window.ts
+++ b/src/app/steps/window.ts
@@ -16,10 +16,8 @@
 
 import type { PreparedRc, WindowedRc } from "../run-context.ts";
 import { advance } from "../run-context.ts";
-import type { SessionMessageEntry } from "../../types.ts";
-import { estimateTokens } from "../../utils/tokens.ts";
+import type { LlmMessage, SessionMessageEntry } from "../../types.ts";
 import { smartKeepBoundary, guardToolCallBoundary } from "../../utils/helpers.ts";
-import { extractText } from "../../utils/extraction.ts";
 import { resolveSessionId } from "../../infra/session-identity.ts";
 
 export function resolveCompactionWindow(rc: PreparedRc): WindowedRc | null {
@@ -35,13 +33,10 @@ export function resolveCompactionWindow(rc: PreparedRc): WindowedRc | null {
   let accTokens = 0;
   let keepFrom = msgs.length;
   for (let i = msgs.length - 1; i >= 0; i--) {
-    const msg = msgs[i].message as Record<string, unknown>;
-    // extractText already handles string | block[] | undefined and shares the
-    // same approximation as the rest of the pipeline. The earlier code used
-    // JSON.stringify on the raw content which over-counts tokens (it includes
-    // type markers, escapes, and tool args verbatim).
-    const contentText = extractText(msg?.content);
-    accTokens += estimateTokens(contentText);
+    // The model receives structured tool-call arguments as context, so the
+    // recent-tail budget must count them too. The run-scoped estimator applies
+    // the same provider/model calibration used by synthesis planning.
+    accTokens += rc.estimator.message(msgs[i].message as LlmMessage);
     if (accTokens >= rc.profileCfg.keepRecentTokens) { keepFrom = i; break; }
   }
   keepFrom = smartKeepBoundary(msgs, keepFrom, branch);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "7.20.0";
+export const VERSION = "7.21.0";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =
@@ -57,6 +57,14 @@ export const DEFAULT_CONFIG = {
   backupEnabled: true,
   backupDir: "",
   minContextPercent: 60, // Don't compact below this context threshold (tool=97% ≠ context full)
+  requireApproval: false,
+  scrubSecrets: true,
+  scrubPii: false,
+  maxLlmCalls: 0,
+  maxLatencyMs: 0,
+  focusWeighting: true,
+  adaptiveDamageFeedback: false,
+  onlineDamageMonitor: true,
   pinPaths: [] as string[],
 };
 

--- a/src/domain/scrub.ts
+++ b/src/domain/scrub.ts
@@ -1,0 +1,110 @@
+export interface RedactionFinding {
+  kind: string;
+  count: number;
+}
+
+export interface ScrubResult<T = string> {
+  value: T;
+  findings: RedactionFinding[];
+}
+
+interface Pattern {
+  kind: string;
+  regex: RegExp;
+  replacement?: (...groups: string[]) => string;
+}
+
+const SECRET_PATTERNS: Pattern[] = [
+  { kind: "private-key", regex: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g },
+  { kind: "aws-access-key", regex: /\bAKIA[0-9A-Z]{16}\b/g },
+  { kind: "github-token", regex: /\bgh[pousr]_[A-Za-z0-9]{30,}\b/g },
+  { kind: "api-key", regex: /\bsk-(?:ant-)?[A-Za-z0-9_-]{20,}\b/g },
+  { kind: "slack-token", regex: /\bxox[baprs]-[A-Za-z0-9-]{20,}\b/g },
+  { kind: "jwt", regex: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g },
+  { kind: "bearer-token", regex: /\bBearer\s+[A-Za-z0-9._~+\/-]{24,}/gi, replacement: () => "Bearer [REDACTED:bearer-token]" },
+  {
+    kind: "credential",
+    regex: /\b(api[_-]?key|access[_-]?token|auth[_-]?token|token|password|passwd|secret)\s*([:=])\s*["']?([A-Za-z0-9._~+\/-]{16,})["']?/gi,
+    replacement: (name, separator) => name + separator + "[REDACTED:credential]",
+  },
+];
+
+const PII_PATTERNS: Pattern[] = [
+  { kind: "email", regex: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi },
+  { kind: "payment-card", regex: /\b(?:\d[ -]*?){13,19}\b/g },
+  { kind: "phone", regex: /(?<![\w.])(?:\+?\d[\d ()-]{8,}\d)(?![\w.])/g },
+];
+
+function redact(text: string, patterns: Pattern[]): ScrubResult<string> {
+  const counts = new Map<string, number>();
+  let value = text;
+  for (const pattern of patterns) {
+    value = value.replace(pattern.regex, (...args: unknown[]) => {
+      counts.set(pattern.kind, (counts.get(pattern.kind) ?? 0) + 1);
+      if (pattern.replacement) {
+        const groups = args.slice(1, -2).map(String);
+        return pattern.replacement(...groups);
+      }
+      return "[REDACTED:" + pattern.kind + "]";
+    });
+  }
+  return { value, findings: [...counts].map(([kind, count]) => ({ kind, count })) };
+}
+
+function mergeFindings(target: Map<string, number>, findings: RedactionFinding[]): void {
+  for (const finding of findings) target.set(finding.kind, (target.get(finding.kind) ?? 0) + finding.count);
+}
+
+/** Run-scoped scrubber used at LLM, cache, backup and persistence boundaries. */
+export class SecretScrubber {
+  private total = 0;
+
+  constructor(private readonly secretsEnabled = true, private readonly piiEnabled = false) {}
+
+  scrubText(text: string): ScrubResult<string> {
+    let value = text;
+    const findings = new Map<string, number>();
+    if (this.secretsEnabled) {
+      const result = redact(value, SECRET_PATTERNS);
+      value = result.value;
+      mergeFindings(findings, result.findings);
+    }
+    if (this.piiEnabled) {
+      const result = redact(value, PII_PATTERNS);
+      value = result.value;
+      mergeFindings(findings, result.findings);
+    }
+    const merged = [...findings].map(([kind, count]) => ({ kind, count }));
+    this.total += merged.reduce((sum, finding) => sum + finding.count, 0);
+    return { value, findings: merged };
+  }
+
+  scrubValue<T>(input: T): ScrubResult<T> {
+    const findings = new Map<string, number>();
+    const seen = new WeakMap<object, unknown>();
+    const visit = (value: unknown): unknown => {
+      if (typeof value === "string") {
+        const result = this.scrubText(value);
+        mergeFindings(findings, result.findings);
+        return result.value;
+      }
+      if (value == null || typeof value !== "object") return value;
+      const cached = seen.get(value);
+      if (cached !== undefined) return cached;
+      if (Array.isArray(value)) {
+        const output: unknown[] = [];
+        seen.set(value, output);
+        for (const item of value) output.push(visit(item));
+        return output;
+      }
+      const output: Record<string, unknown> = {};
+      seen.set(value, output);
+      for (const [key, item] of Object.entries(value as Record<string, unknown>)) output[key] = visit(item);
+      return output;
+    };
+    const value = visit(input) as T;
+    return { value, findings: [...findings].map(([kind, count]) => ({ kind, count })) };
+  }
+
+  count(): number { return this.total; }
+}

--- a/src/domain/summary-parse.ts
+++ b/src/domain/summary-parse.ts
@@ -8,34 +8,30 @@
  * `Files Modified` matched but `Files modified` had to be lowercased first,
  * etc.
  *
- * This module performs one structural parse up front: every `^#{1,3} ` line
- * becomes a section, and the text between headings becomes its body. After
+ * This module performs one structural parse up front: H1/H2 headings and
+ * recognized canonical H3 headings start sections. Unknown H3 headings remain
+ * in their parent body so Progress subsections retain their structure. After
  * that, the rest of the code can ask `findSection(summary, "goal")` and let
  * the classifier handle aliases.
  *
- * The parser is intentionally tolerant — it accepts H1/H2/H3 and trims
- * surrounding whitespace — because we expect occasional formatting drift from
- * smaller LLMs.
+ * Duplicate recognized kinds are merged at their first position with exact
+ * duplicate body lines removed. Unknown sections remain independent.
  */
 
 import { CanonicalSummary, Section, SectionKind, classifyHeading, canonicalHeading } from "./summary-schema.ts";
 
-/**
- * When true, `renderSummary` rewrites every recognized section's heading to
- * its canonical form (`## Goal`, `## Next Steps`, ...). This is used by patch
- * paths that want to guarantee verification can find the section regardless
- * of what the LLM emitted. Default behaviour preserves the original heading
- * so user-visible markdown stays close to the model's output.
- */
+/** H1/H2 always start sections; H3 starts one only when its kind is recognized. */
+const HEADING_RE = /^(#{1,3})\s+(.+?)\s*$/;
 
-/**
- * Only H1/H2 lines start a new section. Earlier versions accepted H3 as well,
- * which caused the `## Progress\n### Done\n...\n### In Progress\n...` block
- * to be flattened into 3 separate sections — leaving `Progress` with an empty
- * body and pushing `Done` / `In Progress` to top level. Now H3 stays inside
- * the body of its parent section, which is what every prompt template assumes.
- */
-const HEADING_RE = /^(#{1,2})\s+(.+?)\s*$/;
+function mergeBodies(first: string, second: string): string {
+  const seen = new Set<string>();
+  return [first, second]
+    .filter(Boolean)
+    .flatMap(body => body.split("\n"))
+    .filter(line => seen.has(line) ? false : (seen.add(line), true))
+    .join("\n")
+    .trim();
+}
 
 export function parseSummary(markdown: string): CanonicalSummary {
   const sections: Section[] = [];
@@ -47,23 +43,25 @@ export function parseSummary(markdown: string): CanonicalSummary {
 
   const flush = () => {
     if (!started) return;
-    sections.push({
-      kind: currentKind,
-      heading: currentHeading.trim(),
-      body: bodyLines.join("\n").trim(),
-    });
+    const body = bodyLines.join("\n").trim();
+    const existing = currentKind === "unknown" ? undefined : sections.find(s => s.kind === currentKind);
+    if (existing) existing.body = mergeBodies(existing.body, body);
+    else sections.push({ kind: currentKind, heading: currentHeading.trim(), body });
   };
 
   for (const line of lines) {
     const m = line.match(HEADING_RE);
     if (m) {
-      flush();
-      // Drop the leading hashes so callers see the human label only.
-      currentHeading = "## " + m[2].trim();
-      currentKind = classifyHeading(m[2]);
-      bodyLines = [];
-      started = true;
-      continue;
+      const kind = classifyHeading(m[2]);
+      if (m[1].length <= 2 || kind !== "unknown") {
+        flush();
+        // Normalize heading depth while preserving the model's label.
+        currentHeading = "## " + m[2].trim();
+        currentKind = kind;
+        bodyLines = [];
+        started = true;
+        continue;
+      }
     }
     if (started) bodyLines.push(line);
   }

--- a/src/domain/summary-schema.ts
+++ b/src/domain/summary-schema.ts
@@ -51,7 +51,7 @@ export type SectionKind =
 
 export interface Section {
   kind: SectionKind;
-  /** Original heading as parsed from the markdown (preserves the user-facing label). */
+  /** Parsed heading with normalized H2 depth; the user-facing label is preserved. */
   heading: string;
   /** Body of the section, leading/trailing whitespace trimmed. */
   body: string;

--- a/src/domain/tool-semantics.ts
+++ b/src/domain/tool-semantics.ts
@@ -1,32 +1,11 @@
 /**
- * Name-agnostic tool classification by argument shape.
+ * Tool classification by argument shape, with normalized names used only to
+ * safely break ties that arguments cannot resolve (read/search/list/delete and
+ * ambiguous `text` payloads). The broad `classifyTool(args)` API remains
+ * name-agnostic for compatibility.
  *
- * Extraction used to classify tools by NAME — `hasToolHint(name, ["write",
- * "edit", ...])` and `tc.name === "bash"`. That is a proxy: a tool is a write
- * tool because its ARGUMENTS carry a content payload, not because its name
- * happens to contain "write". Name matching is also churn-fragile —
- * `read` → `hypa_read` → whatever-next silently drops off the list, and every
- * new tool demands a code change.
- *
- * We classify by what the tool CARRIES, which is invariant under renaming:
- *
- *   mutates   — a path-like arg AND a content payload (write/edit/append/...)
- *   executes  — a command/shell arg (bash/hypa_shell/...)
- *   accesses  — a path-like arg with no payload (read/grep/find/ls)
- *   other     — none of the above (ask_user, process, ...)
- *
- * The argument-name conventions (path/content/command) are far more stable
- * across tools and providers than tool names, so this auto-adapts to tools
- * this code has never seen (hypa_*, MCP tools, custom extensions) without a
- * single name in a list.
- *
- * Ceiling (documented, not hidden): a DELETE cannot be told from a READ by
- * arguments alone — both carry only a path. Callers that need deletion must
- * resolve it from the result text. Bash-style tools that take a free-text
- * `command` are opaque to file-path tracking by construction.
- *
- * Pure: no I/O, no async, no globals — lives in the domain layer alongside
- * `summary-schema.ts`.
+ * Bash-style tools that take a free-text `command` remain opaque to file-path
+ * tracking by construction. Pure: no I/O, no async, no globals.
  */
 
 type Args = Record<string, unknown>;
@@ -35,7 +14,10 @@ type Args = Record<string, unknown>;
  * Argument keys that carry a file path. `path` is near-universal; the others
  * cover common casing/word variants seen across Pi tools and MCP servers.
  */
-const PATH_KEYS = ["path", "file_path", "filePath", "filename", "file"] as const;
+const PATH_KEYS = [
+  "path", "file_path", "filePath", "filename", "file",
+  "target_file", "file_uri", "absolute_path",
+] as const;
 
 /**
  * Argument keys that carry the bytes being written. Deliberately the strict,
@@ -44,7 +26,10 @@ const PATH_KEYS = ["path", "file_path", "filePath", "filename", "file"] as const
  * false-positive (pollute the modified list with a read). Vague keys like
  * `data`/`text` that can also mean options/labels are intentionally excluded.
  */
-const PAYLOAD_KEYS = ["content", "newText", "oldText", "edits", "patch", "replacement"] as const;
+const PAYLOAD_KEYS = [
+  "content", "newText", "oldText", "new_str", "old_str",
+  "new_string", "old_string", "edits", "patch", "replacement",
+] as const;
 
 /** Argument keys that carry a shell command to execute. */
 const COMMAND_KEYS = ["command", "cmd", "script"] as const;
@@ -70,22 +55,52 @@ export function extractToolPath(args: unknown): string | undefined {
 }
 
 export type ToolClass = "mutates" | "accesses" | "executes" | "other";
+export type ToolOperation = "read" | "search" | "list" | "mutate" | "delete" | "execute" | "unknown";
+
+/** Normalize provider wrappers and spelling differences without merging namespaces. */
+export function normalizeToolName(name: unknown): string {
+  if (typeof name !== "string") return "";
+  return name
+    .replace(/^functions[.:/_-]+/i, "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function nameHas(name: string, hints: readonly string[]): boolean {
+  const words = name.split("_");
+  return hints.some(hint => words.includes(hint));
+}
 
 /**
- * Classify a tool by its argument shape, independent of its name.
- *
- * Order matters: a path + payload wins as `mutates` even if a command key is
- * also present (a write tool that logs a command is still a write). A bare
- * command with no path is `executes`. A bare path is `accesses`.
+ * Fine-grained EESV operation taxonomy. Argument shape is authoritative;
+ * normalized names only disambiguate otherwise-safe path/text and access calls.
+ */
+export function classifyToolOperation(args: unknown, toolName?: string): ToolOperation {
+  const a = args && typeof args === "object" ? args as Args : {};
+  const name = normalizeToolName(toolName);
+  const hasPath = extractToolPath(a) !== undefined;
+
+  if (hasPath && hasPresent(a, PAYLOAD_KEYS)) return "mutate";
+  if (hasPresent(a, COMMAND_KEYS)) return "execute";
+  if (hasPath && hasPresent(a, ["text"]) && nameHas(name, ["write", "edit", "patch", "replace", "append", "create", "update", "insert"])) return "mutate";
+  if (hasPath && nameHas(name, ["delete", "remove", "unlink"])) return "delete";
+  if (hasPresent(a, ["pattern", "query", "glob"]) || nameHas(name, ["grep", "search", "find", "glob", "rg"])) return "search";
+  if (nameHas(name, ["list", "ls", "tree"])) return "list";
+  if (hasPath || nameHas(name, ["read"])) return "read";
+  return "unknown";
+}
+
+/**
+ * Broad compatibility classifier retained for existing name-agnostic callers.
  */
 export function classifyTool(args: unknown): ToolClass {
   if (!args || typeof args !== "object") return "other";
   const a = args as Args;
   const hasPath = extractToolPath(a) !== undefined;
-  const hasPayload = hasPresent(a, PAYLOAD_KEYS);
-  const hasCommand = hasPresent(a, COMMAND_KEYS);
-  if (hasPath && hasPayload) return "mutates";
-  if (hasCommand) return "executes";
+  if (hasPath && hasPresent(a, PAYLOAD_KEYS)) return "mutates";
+  if (hasPresent(a, COMMAND_KEYS)) return "executes";
   if (hasPath) return "accesses";
   return "other";
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * Architecture: Extract -> Explore -> Synthesize -> Verify
  */
 
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { convertToLlm, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type { CompressionProfile, PendingCompaction, Cell } from "./types.ts";
 import { VERSION, MIN_TOKEN_THRESHOLD, CONFIG_KEY, CONFIG_KEY_ALT, FIVE_MINUTES_MS } from "./constants.ts";
@@ -13,11 +13,14 @@ import { getProviderCaps } from "./utils/tokens.ts";
 import { readMetricsLog } from "./utils/cache.ts";
 import { buildMetricsReport, writeMetricsDashboard } from "./ui/metrics-report.ts";
 import { runSmartCompact } from "./app/run-smart-compact.ts";
-import { showCompactUI, showMetricsDashboardUI, showRestorePicker, showBackupViewer, showRestoreAction } from "./ui/overlays.ts";
+import { showCompactUI, showMetricsDashboardUI, showRestorePicker, showBackupViewer, showRestoreAction, showOpenLoopsUI } from "./ui/overlays.ts";
 import { resolveSessionId, isUnresolvedSessionId } from "./infra/session-identity.ts";
 import { createPendingSlot, type PendingSlot, type ConsumeResult } from "./app/pending-slot.ts";
 import { persistConsumedState } from "./app/steps/persist.ts";
+import { OnlineDamageMonitor, logDamageReport, writeRemediationHints } from "./utils/damage.ts";
 import * as log from "./utils/logger.ts";
+import { deriveProjectIdFromCwd } from "./utils/fingerprint.ts";
+import { applyLoopOverrides, loadCompactionState, saveCompactionState } from "./utils/state.ts";
 
 /**
  * Translate a `ConsumeResult` into the side-effects the host expects:
@@ -96,11 +99,17 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
   // entirely inside the slot factory — see src/app/pending-slot.ts.
   const pendingRef: PendingSlot = createPendingSlot({ ttlMs: PENDING_TTL_MS });
   const isRunning: Cell<boolean> = { value: false };
+  const damageMonitor = new OnlineDamageMonitor();
+  const monitorCandidates = new Map<string, { projectId: string; details: import("./types.ts").SmartCompactDetails }>();
+  const rememberForOnlineDamage = (pending: PendingCompaction): void => {
+    if (!loadConfig().onlineDamageMonitor || !pending.projectId) return;
+    monitorCandidates.set(pending.sessionId, { projectId: pending.projectId, details: pending.details });
+  };
 
   pi.registerCommand("smart-compact", {
-    description: "EESV smart compaction v" + VERSION + ". Usage: /smart-compact [model] [light|balanced|aggressive] [verbose|debug|dry-run|restore|metrics|dashboard] [note]",
+    description: "EESV smart compaction v" + VERSION + ". Usage: /smart-compact [model] [profile] [flags] [--focus=topic] [--max-calls=N] [--max-latency=ms] [note]",
     getArgumentCompletions: (prefix: string) => {
-      const m = ["verbose", "debug", "dry-run", "metrics", "dashboard", "restore", "light", "balanced", "aggressive"].filter(o => o.startsWith(prefix)).map(o => ({ value: o, label: o }));
+      const m = ["verbose", "debug", "dry-run", "metrics", "dashboard", "restore", "loops", "light", "balanced", "aggressive", "--focus=", "--max-calls=", "--max-latency="].filter(o => o.startsWith(prefix)).map(o => ({ value: o, label: o }));
       return m.length ? m : null;
     },
     handler: async (args, ctx) => {
@@ -110,6 +119,20 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         const flags = tokens.map(t => t.toLowerCase());
         const verbose = flags.includes("verbose") || flags.includes("debug");
         const dryRun = flags.includes("dry-run");
+        const optionValue = (name: string): string | undefined => tokens.find(token => token.startsWith("--" + name + "="))?.slice(name.length + 3);
+        const focus = optionValue("focus")?.trim() || undefined;
+        const maxCallsRaw = optionValue("max-calls");
+        const maxLatencyRaw = optionValue("max-latency");
+        const maxLlmCalls = maxCallsRaw == null ? undefined : Number(maxCallsRaw);
+        const maxLatencyMs = maxLatencyRaw == null ? undefined : Number(maxLatencyRaw);
+        if (maxLlmCalls !== undefined && (!Number.isInteger(maxLlmCalls) || maxLlmCalls < 1 || maxLlmCalls > 100)) {
+          ctx.ui.notify("--max-calls must be an integer from 1 to 100", "error");
+          return;
+        }
+        if (maxLatencyMs !== undefined && (!Number.isFinite(maxLatencyMs) || maxLatencyMs < 5000 || maxLatencyMs > 600000)) {
+          ctx.ui.notify("--max-latency must be 5000–600000 ms", "error");
+          return;
+        }
         if (flags.includes("metrics") || flags.includes("dashboard")) {
           if (flags.includes("dashboard")) {
             const entries = readMetricsLog(200);
@@ -177,6 +200,23 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
           }
           return;
         }
+        if (flags.includes("loops")) {
+          const projectId = deriveProjectIdFromCwd(ctx.cwd);
+          const state = loadCompactionState(projectId);
+          if (!state || state.openLoops.length === 0) {
+            ctx.ui.notify("No persisted open loops for this project", "info");
+            return;
+          }
+          const overrides = await showOpenLoopsUI(ctx, state.openLoops, state.loopOverrides ?? []);
+          if (!overrides) { ctx.ui.notify("Open-loop manager closed without changes", "info"); return; }
+          state.loopOverrides = overrides;
+          state.openLoops = applyLoopOverrides(state.openLoops, overrides);
+          state.updatedAt = Date.now();
+          saveCompactionState(projectId, state);
+          ctx.ui.notify("Open-loop overrides saved", "info");
+          return;
+        }
+
         // A token is a model arg when it resolves in the registry, or when
         // its provider prefix is a known provider (i.e. a typo'd model id we
         // must reject loudly rather than let fall through as note text).
@@ -217,7 +257,11 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         const { segModel, sumModel } = resolveModels(ctx, explicitModel ?? ctx.model, loadConfig(), Boolean(modelArg));
         if (!sumModel) { ctx.ui.notify("Could not resolve model", "error"); return; }
         const note = extractUserNote(args);
-        await runSmartCompact({ ctx, summaryModel: sumModel, segModel: segModel ?? sumModel, profile, verbose, dryRun, pendingRef, isRunning, userNote: note, force: true });
+        await runSmartCompact({
+          ctx, summaryModel: sumModel, segModel: segModel ?? sumModel, profile, verbose, dryRun,
+          pendingRef, isRunning, userNote: note, focus, maxLlmCalls,
+          timeoutMs: maxLatencyMs, force: true,
+        });
       } catch (error) {
         const msg = error instanceof Error ? error.message + "\n" + error.stack : String(error);
         ctx.ui.notify("smart-compact error: " + msg, "error");
@@ -228,6 +272,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
   pi.on("session_before_compact", async (_event, ctx) => {
     const consumed = unwrapConsumed(pendingRef.consume(ctx), ctx);
     if (consumed) {
+      rememberForOnlineDamage(consumed);
       return { compaction: { summary: consumed.summary, firstKeptEntryId: consumed.firstKeptEntryId, tokensBefore: consumed.tokensBefore, details: consumed.details } };
     }
     const config = loadConfig();
@@ -292,10 +337,44 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         // behavior — we don't need to re-check the timeout flag here.
         const fresh = unwrapConsumed(pendingRef.consume(ctx), ctx);
         if (fresh) {
+          rememberForOnlineDamage(fresh);
           return { compaction: { summary: fresh.summary, firstKeptEntryId: fresh.firstKeptEntryId, tokensBefore: fresh.tokensBefore, details: fresh.details } };
         }
       }
     } catch (e) { log.warn("session_before_compact error", e); }
+  });
+
+  pi.on("session_compact", async (_event, ctx) => {
+    const sessionId = resolveSessionId(ctx);
+    const candidate = monitorCandidates.get(sessionId);
+    if (!candidate) return;
+    monitorCandidates.delete(sessionId);
+    damageMonitor.activate(sessionId, candidate.projectId, candidate.details);
+  });
+
+  pi.on("message_end", async (event, ctx) => {
+    try {
+      const sessionId = resolveSessionId(ctx);
+      const converted = convertToLlm([event.message as never])[0] as import("./types.ts").LlmMessage | undefined;
+      if (!converted) return;
+      const observation = damageMonitor.observe(sessionId, converted);
+      if (!observation) return;
+      logDamageReport(sessionId, observation.report, observation.details, observation.projectId);
+      if (observation.report.reReadFiles.length > 0) {
+        writeRemediationHints(observation.projectId, observation.report.reReadFiles);
+      }
+      if (observation.report.damageScore > 0) {
+        ctx.ui.notify("Post-compaction damage detected: " + observation.report.summary, "warning");
+      }
+    } catch (error) {
+      log.warn("online damage monitor message_end failed", error);
+    }
+  });
+
+  pi.on("session_shutdown", async (_event, ctx) => {
+    const sessionId = resolveSessionId(ctx);
+    damageMonitor.clear(sessionId);
+    monitorCandidates.delete(sessionId);
   });
 
   pi.registerTool({
@@ -315,12 +394,18 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         dry_run: { type: "boolean", description: "Run the pipeline but skip applying the compaction." },
         report: { type: "boolean", description: "Return recent performance metrics instead of compacting." },
         dashboard: { type: "boolean", description: "Write a local HTML metrics dashboard and return its path." },
+        focus: { type: "string", description: "Topic or path that should receive extra preservation budget." },
+        max_calls: { type: "number", description: "Maximum LLM calls for this run (1-100)." },
+        max_latency_ms: { type: "number", description: "Hard pipeline latency budget in milliseconds (5000-600000)." },
       },
     },
     async execute(_id, params, signal, _onUp, ctx) {
       const profile = (params.profile === "light" || params.profile === "balanced" || params.profile === "aggressive") ? params.profile : undefined;
       const verbose = !!params.verbose;
       const dryRun = !!params.dry_run;
+      const focus = typeof params.focus === "string" ? params.focus.trim() || undefined : undefined;
+      const maxLlmCalls = typeof params.max_calls === "number" && Number.isInteger(params.max_calls) && params.max_calls >= 1 && params.max_calls <= 100 ? params.max_calls : undefined;
+      const maxLatencyMs = typeof params.max_latency_ms === "number" && params.max_latency_ms >= 5000 && params.max_latency_ms <= 600000 ? params.max_latency_ms : undefined;
       if (params.report || params.dashboard) {
         const report = buildMetricsReport();
         const fp = params.dashboard ? writeMetricsDashboard() : null;
@@ -355,7 +440,11 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         // (b) tool_result referencing a tool_call in a message that no longer exists.
         // Instead, store the summary in pendingRef and let the session_before_compact
         // hook apply it on the next natural compact (or auto-trigger).
-        await runSmartCompact({ ctx, summaryModel: sumModel, segModel: segModel ?? sumModel, profile: resolvedProfile, verbose, dryRun, pendingRef, isRunning, autoTriggered: true, skipCompact: true, abortSignal: signal });
+        await runSmartCompact({
+          ctx, summaryModel: sumModel, segModel: segModel ?? sumModel, profile: resolvedProfile,
+          verbose, dryRun, pendingRef, isRunning, autoTriggered: true, skipCompact: true,
+          abortSignal: signal, focus, maxLlmCalls, timeoutMs: maxLatencyMs,
+        });
         const toolSecs = ((Date.now() - toolStart) / 1000).toFixed(1);
         const staged = pendingRef.peek();
         if (staged) {

--- a/src/infra/fs.ts
+++ b/src/infra/fs.ts
@@ -177,6 +177,29 @@ export function appendLineLocked(target: string, line: string): void {
   }
 }
 
+/** Read the newest valid JSONL records without loading an entire bounded log. */
+export function readJsonlTail<T>(target: string, limit: number, maxBytes = 512 * 1024): T[] {
+  if (limit <= 0 || !fs.existsSync(target)) return [];
+  const stat = fs.statSync(target);
+  const length = Math.min(stat.size, maxBytes);
+  const buffer = Buffer.alloc(length);
+  const fd = fs.openSync(target, "r");
+  try { fs.readSync(fd, buffer, 0, length, stat.size - length); }
+  finally { fs.closeSync(fd); }
+  let text = buffer.toString("utf8");
+  if (stat.size > length) {
+    const newline = text.indexOf("\n");
+    text = newline >= 0 ? text.slice(newline + 1) : "";
+  }
+  const values: T[] = [];
+  for (const line of text.split("\n")) {
+    if (!line) continue;
+    try { values.push(JSON.parse(line) as T); }
+    catch { /* corrupt/incomplete lines are ignored at this recovery boundary */ }
+  }
+  return values.slice(-limit);
+}
+
 /** Keep only complete trailing lines that fit within `maxBytes`. */
 export function trimFileTailLocked(target: string, maxBytes: number): void {
   const release = acquireLockSync(target);

--- a/src/infra/services.ts
+++ b/src/infra/services.ts
@@ -33,6 +33,7 @@ import crypto from "node:crypto";
 import type { LLMCallMetric } from "../types.ts";
 import { METRICS_BUFFER_MAX, ONE_HOUR_MS } from "../constants.ts";
 import { TokenCalibrationStore } from "../utils/tokens.ts";
+import { SecretScrubber } from "../domain/scrub.ts";
 
 /**
  * In-memory cache for "does this provider support tools?".
@@ -120,6 +121,43 @@ export class MetricsSink {
  * Tracks hits vs misses on `loadCachedExtraction`. Surfaced into the metrics
  * dashboard so we can tune the prefix-match tolerance over time.
  */
+export class BudgetExceededError extends Error {
+  constructor(readonly reason: "calls" | "latency") {
+    super("Smart Compact " + reason + " budget exhausted");
+    this.name = "BudgetExceededError";
+  }
+}
+
+/** Atomic per-run reservation guard; safe for concurrent batch wave launches. */
+export class BudgetGuard {
+  private calls = 0;
+  private startedAt: number;
+  private lastReason: "calls" | "latency" | null = null;
+
+  constructor(
+    private readonly maxCalls = 0,
+    private readonly maxLatencyMs = 0,
+    private readonly clock: Clock = systemClock,
+  ) {
+    this.startedAt = clock.now();
+  }
+
+  reserveCall(): void {
+    if (this.maxLatencyMs > 0 && this.clock.now() - this.startedAt >= this.maxLatencyMs) {
+      this.lastReason = "latency";
+      throw new BudgetExceededError("latency");
+    }
+    if (this.maxCalls > 0 && this.calls >= this.maxCalls) {
+      this.lastReason = "calls";
+      throw new BudgetExceededError("calls");
+    }
+    this.calls++;
+  }
+
+  callCount(): number { return this.calls; }
+  reason(): "calls" | "latency" | null { return this.lastReason; }
+}
+
 export class ExtractionCacheStats {
   private hits = 0;
   private misses = 0;
@@ -143,6 +181,8 @@ export interface SmartCompactServices {
   metrics: MetricsSink;
   extractionCacheStats: ExtractionCacheStats;
   tokenCalibration: TokenCalibrationStore;
+  budget: BudgetGuard;
+  scrubber: SecretScrubber;
   /** Per-run prompt-cache namespace for providers that support prompt caching. */
   compactSessionId: string;
 }
@@ -162,6 +202,8 @@ export function createServices(overrides: Partial<SmartCompactServices> = {}): S
     metrics: overrides.metrics ?? new MetricsSink(),
     extractionCacheStats: overrides.extractionCacheStats ?? new ExtractionCacheStats(),
     tokenCalibration: overrides.tokenCalibration ?? new TokenCalibrationStore(),
+    budget: overrides.budget ?? new BudgetGuard(),
+    scrubber: overrides.scrubber ?? new SecretScrubber(),
     compactSessionId: overrides.compactSessionId ?? makeCompactSessionId(),
   };
 }

--- a/src/phases/explore.ts
+++ b/src/phases/explore.ts
@@ -14,6 +14,7 @@ import { getProviderCaps } from "../utils/tokens.ts";
 import * as log from "../utils/logger.ts";
 import type { SmartCompactServices } from "../infra/services.ts";
 import { getDefaultServices } from "../infra/services.ts";
+import { buildExtractionContext } from "../utils/helpers.ts";
 
 // Tool support is cached on the per-run services container. The previous
 // module-level `_toolSupportCache` leaked TTL'd state across pi sessions and
@@ -297,15 +298,11 @@ export async function exploreConversation(
   const svc = services ?? getDefaultServices();
 
   const extractionContext = [
-    "## Deterministic Extraction (verified facts)",
+    buildExtractionContext(extraction),
     "Message count: " + extraction.messageCount,
     "Main goal: " + (extraction.mainGoal ?? "unknown"),
-    "Files modified (" + extraction.modifiedFiles.length + "): " + (extraction.modifiedFiles.map(f => f.path).join(", ") || "none"),
-    "Files read (" + extraction.readFiles.length + "): " + (extraction.readFiles.join(", ") || "none"),
-    "Errors (" + extraction.errors.length + "): " + (extraction.errors.map(e => "[" + e.tool + "] " + e.message.slice(0, TRUNC.SNIPPET) + (e.resolved ? " (resolved)" : e.retryAttempted ? " (retry attempted)" : "")).join("; ") || "none"),
-    "Decisions (" + extraction.decisions.length + "): " + (extraction.decisions.map(d => d.type + ": " + d.summary.slice(0, TRUNC.SNIPPET)).join("; ") || "none"),
-    "Constraints (" + extraction.constraints.length + "): " + (extraction.constraints.map(cc => "[" + cc.category + "] " + cc.text.slice(0, TRUNC.SNIPPET)).join("; ") || "none"),
-    "Heuristic topics (" + extraction.topics.length + "): " + (extraction.topics.map(t => "[" + t.startIndex + "-" + t.endIndex + "] " + t.type).join("; ") || "none"),
+    "Files read: " + (extraction.readFiles.join(", ") || "none"),
+    "Heuristic topics: " + (extraction.topics.map(t => "[" + t.startIndex + "-" + t.endIndex + "] " + t.type).join("; ") || "none"),
     extraction.lastUserMessages.length ? "Last user messages: " + extraction.lastUserMessages.map(m => m.slice(0, TRUNC.TOPIC_LABEL)).join(" | ") : "",
     extraction.lastErrors.length ? "Last errors: " + extraction.lastErrors.map(e => e.slice(0, TRUNC.TOPIC_LABEL)).join(" | ") : "",
   ].filter(Boolean).join("\n");

--- a/src/phases/synthesize.ts
+++ b/src/phases/synthesize.ts
@@ -8,24 +8,45 @@ import type {
   ExplorationReport, ProfileConfig,
 } from "../types.ts";
 import { COMPACT_SYSTEM_PREFIX, SINGLE_PASS_PREFIX, SINGLE_PASS_SUFFIX, BATCH_PROMPT_PREFIX, BATCH_PROMPT_SUFFIX, ASSEMBLY_PROMPT_PREFIX, ASSEMBLY_PROMPT_SUFFIX, SESSION_TYPE_INSTRUCTIONS, TRUNC } from "../constants.ts";
-import { estimateTokens, getProviderCaps } from "../utils/tokens.ts";
+import { getProviderCaps, makeTokenEstimator, type TokenEstimator } from "../utils/tokens.ts";
 import { trackedComplete } from "../utils/cache.ts";
 import { extractText } from "../utils/extraction.ts";
 import { filterToolCalls } from "../utils/type-guards.ts";
 import { buildExtractionContext, buildExplorationContext, createBatches, preProcessSummaries, inferSessionType } from "../utils/helpers.ts";
 import type { SmartCompactServices } from "../infra/services.ts";
 
-/** Token estimation for a chunk of messages — uses text-only extraction, not JSON.stringify */
-function estimateChunkTokens(msgs: LlmMessage[]): number {
-  return estimateTokens(msgs.map(m => extractText(m.content)).join(""));
+function boundedToolArgs(value: unknown, depth = 0): unknown {
+  if (typeof value === "string") return value.length > TRUNC.DETAIL ? value.slice(0, TRUNC.DETAIL) + "…" : value;
+  if (value == null || typeof value !== "object" || depth >= 2) return value;
+  if (Array.isArray(value)) return value.slice(0, 8).map(item => boundedToolArgs(item, depth + 1));
+  return Object.fromEntries(Object.entries(value as Record<string, unknown>).slice(0, 12).map(([key, item]) => [key, boundedToolArgs(item, depth + 1)]));
 }
 
-export function chunkLlmMessages(msgs: LlmMessage[], boundaries: import("../types.ts").TopicBoundary[], pc: ProfileConfig): LlmChunk[] {
+/** The exact per-message representation used by batch prompts and planning. */
+export function renderBatchMessage(message: LlmMessage): string {
+  const content = extractText(message.content).slice(0, TRUNC.PREVIEW_XL);
+  const toolCalls = filterToolCalls(message.content)
+    .map(call => call.name + " " + JSON.stringify(boundedToolArgs(call.arguments)).slice(0, TRUNC.DETAIL))
+    .join("; ");
+  return "[" + message.role + "] " + content + (toolCalls ? "\n[tool_calls] " + toolCalls : "");
+}
+
+function estimateChunkTokens(msgs: LlmMessage[], estimator: TokenEstimator): number {
+  return estimator.text(msgs.map(renderBatchMessage).join("\n"));
+}
+
+export function chunkLlmMessages(
+  msgs: LlmMessage[],
+  boundaries: import("../types.ts").TopicBoundary[],
+  pc: ProfileConfig,
+  estimator: TokenEstimator = makeTokenEstimator(),
+  focus?: string,
+): LlmChunk[] {
   if (!msgs.length) return [];
   if (!boundaries.length) {
     return [{
       startIndex: 0, endIndex: msgs.length - 1,
-      tokenEstimate: estimateChunkTokens(msgs),
+      tokenEstimate: estimateChunkTokens(msgs, estimator),
       topic: "Full conversation", priority: "normal", messages: msgs,
     }];
   }
@@ -40,7 +61,7 @@ export function chunkLlmMessages(msgs: LlmMessage[], boundaries: import("../type
       const slice = msgs.slice(start, end);
       chunks.push({
         startIndex: start, endIndex: end - 1,
-        tokenEstimate: estimateChunkTokens(slice),
+        tokenEstimate: estimateChunkTokens(slice, estimator),
         topic: bp.topic || "Segment " + (chunks.length + 1),
         priority: bp.priority,
         messages: slice,
@@ -54,7 +75,7 @@ export function chunkLlmMessages(msgs: LlmMessage[], boundaries: import("../type
     const lastTopic = sorted.length ? "After: " + sorted[sorted.length - 1].topic : "Full conversation";
     chunks.push({
       startIndex: start, endIndex: msgs.length - 1,
-      tokenEstimate: estimateChunkTokens(slice),
+      tokenEstimate: estimateChunkTokens(slice, estimator),
       topic: lastTopic, priority: "normal", messages: slice,
     });
   }
@@ -71,6 +92,13 @@ export function chunkLlmMessages(msgs: LlmMessage[], boundaries: import("../type
       merged.push(ch);
     }
   }
+  if (focus) {
+    const needle = focus.toLowerCase();
+    for (const chunk of merged) {
+      const haystack = (chunk.topic + " " + chunk.messages.map(renderBatchMessage).join(" ")).toLowerCase();
+      if (haystack.includes(needle) && (chunk.priority === "normal" || chunk.priority === "low")) chunk.priority = "high";
+    }
+  }
   return merged;
 }
 
@@ -78,7 +106,7 @@ export async function singlePassCompact(
   convText: string, extraction: StructuredExtraction, report: ExplorationReport | null,
   prevContext: string,
   model: Model<Api>, auth: { apiKey: string; headers?: Record<string, string> }, budgetTokens: number, signal?: AbortSignal,
-  services?: SmartCompactServices,
+  services?: SmartCompactServices, focus?: string,
 ): Promise<{ summary: string; llmCalls: 1 }> {
   const extractionCtx = buildExtractionContext(extraction);
   const explorationCtx = report ? buildExplorationContext(report) : "";
@@ -86,7 +114,7 @@ export async function singlePassCompact(
   const sessionType = inferSessionType(extraction, report);
   const sessionInstruction = SESSION_TYPE_INSTRUCTIONS[sessionType] ?? SESSION_TYPE_INSTRUCTIONS.implementation;
   const adaptedPrefix = SINGLE_PASS_PREFIX + "\nSession-specific instructions:\n" + sessionInstruction;
-  const dynamicSuffix = SINGLE_PASS_SUFFIX
+  const dynamicSuffix = (focus ? "## User Focus\nPreserve extra detail about: " + focus + "\n\n" : "") + SINGLE_PASS_SUFFIX
     .replace("{PREV_CONTEXT}", prevContext)
     .replace("{EXTRACTION_CONTEXT}", extractionCtx)
     .replace("{EXPLORATION_CONTEXT}", explorationCtx)
@@ -122,15 +150,7 @@ export async function summarizeBatch(
   // Stabil chunk IDs for robust parsing (index-based mapping breaks if LLM skips/adds sections)
   const text = batch.map((ch, i) => {
     const id = i + 1;
-    return "--- CHUNK " + id + ": " + ch.topic + " (" + ch.priority + ") ---\n" + ch.messages.map((m) => {
-      const role = m?.role ?? "unknown";
-      const content = extractText(m?.content).slice(0, TRUNC.PREVIEW_XL);
-      const toolCalls = filterToolCalls(m?.content)
-        .map(tc => tc.name + " " + JSON.stringify(tc.arguments).slice(0, TRUNC.DETAIL))
-        .join("; ");
-      const toolSuffix = toolCalls ? "\n[tool_calls] " + toolCalls : "";
-      return "[" + role + "] " + content + toolSuffix;
-    }).join("\n");
+    return "--- CHUNK " + id + ": " + ch.topic + " (" + ch.priority + ") ---\n" + ch.messages.map(renderBatchMessage).join("\n");
   }).join("\n\n");
 
   const promptPrefix = BATCH_PROMPT_PREFIX;
@@ -177,9 +197,9 @@ export async function summarizeBatch(
 export async function assembleLLM(
   summaries: ChunkSummary[], extraction: StructuredExtraction, report: ExplorationReport | null,
   model: Model<Api>, auth: { apiKey: string; headers?: Record<string, string> }, budget: number,
-  prevContext: string, signal?: AbortSignal, services?: SmartCompactServices,
+  prevContext: string, signal?: AbortSignal, services?: SmartCompactServices, focus?: string,
 ): Promise<string> {
-  const pp = preProcessSummaries(summaries, budget);
+  const pp = preProcessSummaries(summaries, budget, focus);
   const detModified = extraction.modifiedFiles.map(f => f.path);
   const detRead = extraction.readFiles;
   const explorationCtx = report ? buildExplorationContext(report) : "";

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -1,252 +1,205 @@
 /**
- * Phase 4: Verification + Quality Score.
+ * Phase 4: deterministic verification and repair.
  *
- * Verification was historically a long chain of `summary.toLowerCase().includes(...)`
- * checks. That worked but coupled the score to the exact markdown wording, so
- * `### Goal` instead of `## Goal` registered as a missing section even though
- * the content was right there. We now parse the summary once into a
- * `CanonicalSummary` (see `domain/summary-schema.ts`) and run section-level
- * checks against the structured form. The text-content checks (file names,
- * error snippets, decisions) still run on the body string, but only after the
- * section has been positively identified by `kind`.
- *
- * Deterministic patching writes structured sections back into the summary via
- * `appendToSection` / `upsertSection`, so a follow-up parse round always sees
- * the canonical headings even when the LLM produced something idiosyncratic.
+ * Verification findings are structured data. Formatting belongs at the UI/LLM
+ * boundary; repair logic switches on `kind` and never reparses its own prose.
  */
 
 import type { Model, Api } from "@earendil-works/pi-ai";
-import type { StructuredExtraction, VerificationResult } from "../types.ts";
+import type { StructuredExtraction, VerificationGap, VerificationResult } from "../types.ts";
 import { COMPACT_SYSTEM_PREFIX, TRUNC } from "../constants.ts";
 import { trackedComplete } from "../utils/cache.ts";
 import { getProviderCaps } from "../utils/tokens.ts";
 import { extractFileRefs } from "../utils/file-ref-detect.ts";
+import { buildUniquePathNeedles, isKnownPathReference } from "../utils/file-needles.ts";
 import * as log from "../utils/logger.ts";
 import { parseSummary, findSection, appendToSection, renderSummary, upsertSection } from "../domain/summary-parse.ts";
+import { canonicalHeading } from "../domain/summary-schema.ts";
 import { extractCheckKeywords } from "../domain/keywords.ts";
 import type { CanonicalSummary } from "../domain/summary-schema.ts";
 import type { SmartCompactServices } from "../infra/services.ts";
 
+export function formatVerificationGap(gap: VerificationGap): string {
+  switch (gap.kind) {
+    case "missing-section": return "Missing section: " + canonicalHeading(gap.section);
+    case "missing-file": return "Missing modified file: " + gap.path;
+    case "missing-error": return "Missing error: " + gap.message.slice(0, TRUNC.SNIPPET);
+    case "missing-constraint": return "Missing constraint: " + gap.text.slice(0, TRUNC.TOPIC_LABEL);
+    case "missing-decision": return "Missing decision: " + gap.summary.slice(0, TRUNC.TOPIC_LABEL);
+    case "missing-goal": return "Main goal may be missing from summary";
+    case "fabricated-file": return "Potentially fabricated file: " + gap.ref;
+    case "inconsistency": return "Inconsistency: " + gap.detail;
+    case "missing-open-loops": return "Missing Open Loops section despite " + gap.unresolvedCount + " unresolved errors";
+  }
+}
+
+export function isDeterministicallyPatchable(gap: VerificationGap): boolean {
+  return gap.kind !== "fabricated-file" && gap.kind !== "inconsistency";
+}
+
 export function verifySummary(summary: string, extraction: StructuredExtraction): VerificationResult {
   const parsed = parseSummary(summary);
-  const gaps: string[] = [];
-  const lower = summary.toLowerCase();
+  const gaps: VerificationGap[] = [];
+  const lower = summary.toLowerCase().replace(/\\/g, "/");
   let score = 100;
 
-  // Section presence checks now run on parsed kinds, which means `### Goal`
-  // and `## Goals` both satisfy the `goal` requirement.
-  const requiredSections: Array<{ kind: import("../domain/summary-schema.ts").SectionKind; label: string; penalty: number }> = [
-    { kind: "goal", label: "## Goal", penalty: 5 },
-    { kind: "progress", label: "## Progress", penalty: 5 },
-    { kind: "critical-context", label: "## Critical Context", penalty: 3 },
+  const requiredSections: Array<{ kind: "goal" | "progress" | "critical-context"; penalty: number }> = [
+    { kind: "goal", penalty: 5 },
+    { kind: "progress", penalty: 5 },
+    { kind: "critical-context", penalty: 3 },
   ];
   for (const req of requiredSections) {
     if (!findSection(parsed, req.kind)) {
-      gaps.push("Missing section: " + req.label);
+      gaps.push({ kind: "missing-section", section: req.kind });
       score -= req.penalty;
     }
   }
 
-  for (const f of extraction.modifiedFiles) {
-    const pathLower = f.path.toLowerCase();
-    const parts = pathLower.split("/");
-    const suffixes: string[] = [];
-    for (let j = 0; j < parts.length; j++) {
-      suffixes.push(parts.slice(j).join("/"));
-    }
-    const pathMatch = suffixes.some(s => s.length > 2 && lower.includes(s));
-    if (!pathMatch) {
-      gaps.push("Missing modified file: " + f.path);
+  const modifiedPaths = extraction.modifiedFiles.map(file => file.path);
+  for (const file of extraction.modifiedFiles) {
+    const needles = buildUniquePathNeedles(file.path, modifiedPaths);
+    if (!needles.some(needle => lower.includes(needle))) {
+      gaps.push({ kind: "missing-file", path: file.path });
       score -= 5;
     }
   }
 
-  for (const e of extraction.errors.filter(e => !e.resolved)) {
-    // Normalize whitespace before slicing: a leading "\n  " on the raw error
-    // text broke the exact-substring match even when the error was quoted verbatim.
-    const snippet = e.message.trim().replace(/\s+/g, " ").slice(0, TRUNC.ERROR_SNIPPET).toLowerCase();
+  for (const error of extraction.errors.filter(error => !error.resolved)) {
+    const snippet = error.message.trim().replace(/\s+/g, " ").slice(0, TRUNC.ERROR_SNIPPET).toLowerCase();
     if (snippet.length > 5 && !lower.includes(snippet)) {
-      gaps.push("Missing error: " + e.message.slice(0, TRUNC.SNIPPET));
+      gaps.push({ kind: "missing-error", message: error.message });
       score -= 5;
     }
   }
 
-  for (const c of extraction.constraints.filter(c => c.confidence >= 0.8)) {
-    const keywords = extractCheckKeywords(c.text, 3);
-    const found = keywords.some(k => lower.includes(k.toLowerCase()));
-    if (!found && keywords.length > 0) {
-      gaps.push("Missing constraint: " + c.text.slice(0, TRUNC.TOPIC_LABEL));
+  for (const constraint of extraction.constraints.filter(constraint => constraint.confidence >= 0.8)) {
+    const keywords = extractCheckKeywords(constraint.text, 3);
+    if (keywords.length > 0 && !keywords.some(keyword => lower.includes(keyword.toLowerCase()))) {
+      gaps.push({ kind: "missing-constraint", text: constraint.text });
       score -= 3;
     }
   }
 
   if (extraction.mainGoal) {
-    const goalWords = extractCheckKeywords(extraction.mainGoal, 4);
-    const goalFound = goalWords.some(w => lower.includes(w.toLowerCase()));
-    if (!goalFound) { gaps.push("Main goal may be missing from summary"); score -= 10; }
+    const keywords = extractCheckKeywords(extraction.mainGoal, 4);
+    if (keywords.length > 0 && !keywords.some(keyword => lower.includes(keyword.toLowerCase()))) {
+      gaps.push({ kind: "missing-goal", goal: extraction.mainGoal });
+      score -= 10;
+    }
   }
 
-  // File-ref heuristic delegated to `utils/file-ref-detect.ts` so the
-  // version-vs-path classifier can be unit-tested in isolation. The
-  // contract is the same: only return tokens that look like real file
-  // references (no SemVer literals, no bare names without an extension).
-  const summaryFileRefs = extractFileRefs(summary);
-  // Plain array (not Set): membership is suffix-based, so every lookup scans
-  // all entries anyway — the previous `[...set].some(...)` re-materialized
-  // the array on every ref, O(refs × files) allocations for zero benefit.
-  const knownFiles = [
-    ...extraction.modifiedFiles.map(f => f.path.toLowerCase()),
-    ...extraction.readFiles.map(f => f.toLowerCase()),
-  ];
-  for (const ref of summaryFileRefs) {
-    const refLower = ref.toLowerCase();
-    const isKnown = knownFiles.some(kf => (kf.endsWith("/" + refLower) || kf === refLower || (kf.endsWith(refLower) && refLower.length > 3)));
-    if (!isKnown) {
-      gaps.push("Potentially fabricated file: " + ref);
+  const knownFiles = [...modifiedPaths, ...extraction.readFiles];
+  for (const ref of extractFileRefs(summary)) {
+    if (!isKnownPathReference(ref, knownFiles)) {
+      gaps.push({ kind: "fabricated-file", ref });
       score -= 4;
     }
   }
 
-  // Inconsistency check: a file marked Done that has an unresolved error in
-  // the extraction signals stale completion claims. We pull the Progress
-  // section structurally so heading-case differences don't bypass the check.
   const progressSection = findSection(parsed, "progress");
   if (progressSection) {
-    const doneMatch = progressSection.body.match(/###\s*Done[\s\S]*?(?=###|$)/i);
-    const doneSection = doneMatch?.[0] ?? "";
-    if (doneSection) {
-      for (const f of extraction.modifiedFiles) {
-        const bn = f.path.split("/").pop() ?? "";
-        const markedDone = doneSection.toLowerCase().includes(bn.toLowerCase());
-        if (!markedDone) continue;
-        const unresolved = extraction.errors.find(e => e.message.toLowerCase().includes(bn.toLowerCase()) && !e.resolved);
-        if (unresolved) {
-          gaps.push("Inconsistency: " + bn + " marked Done but has unresolved error");
-          score -= 5;
-        }
+    const doneSection = progressSection.body.match(/###\s*Done[\s\S]*?(?=###|$)/i)?.[0] ?? "";
+    for (const file of extraction.modifiedFiles) {
+      const basename = file.path.split("/").pop() ?? "";
+      if (!doneSection.toLowerCase().includes(basename.toLowerCase())) continue;
+      const unresolved = extraction.errors.find(error => !error.resolved && error.message.toLowerCase().includes(basename.toLowerCase()));
+      if (unresolved) {
+        gaps.push({ kind: "inconsistency", detail: basename + " marked Done but has unresolved error" });
+        score -= 5;
       }
     }
   }
 
-  const highConfDecisions = extraction.decisions.filter(d => d.type === "explicit");
-  if (highConfDecisions.length > 0) {
-    const decisionSection = findSection(parsed, "decisions");
-    const decisionBody = decisionSection?.body.toLowerCase() ?? "";
-    for (const d of highConfDecisions) {
-      const keywords = extractCheckKeywords(d.summary, 3);
-      if (keywords.length > 0 && !keywords.some(k => decisionBody.includes(k.toLowerCase()))) {
-        gaps.push("Missing decision: " + d.summary.slice(0, TRUNC.TOPIC_LABEL));
-        score -= 3;
-      }
+  const decisionBody = findSection(parsed, "decisions")?.body.toLowerCase() ?? "";
+  for (const decision of extraction.decisions.filter(decision => decision.type === "explicit")) {
+    const keywords = extractCheckKeywords(decision.summary, 3);
+    if (keywords.length > 0 && !keywords.some(keyword => decisionBody.includes(keyword.toLowerCase()))) {
+      gaps.push({ kind: "missing-decision", summary: decision.summary });
+      score -= 3;
     }
   }
 
-  // Open Loop coverage: if extraction surfaces multiple unresolved errors but
-  // the summary has no dedicated open-loop section (or any unresolved-style
-  // language), call out the gap structurally.
-  const unresolvedCount = extraction.errors.filter(e => !e.resolved).length;
-  if (unresolvedCount >= 2) {
-    const hasOpenLoops = findSection(parsed, "open-loops") || lower.includes("unresolved");
-    if (!hasOpenLoops) {
-      gaps.push("Missing Open Loops section despite " + unresolvedCount + " unresolved errors");
-      score -= 5;
-    }
+  const unresolvedCount = extraction.errors.filter(error => !error.resolved).length;
+  if (unresolvedCount >= 2 && !findSection(parsed, "open-loops") && !lower.includes("unresolved")) {
+    gaps.push({ kind: "missing-open-loops", unresolvedCount });
+    score -= 5;
   }
 
   const finalScore = Math.max(0, score);
   return { ok: gaps.length === 0 && finalScore >= 85, gaps, score: finalScore };
 }
 
-/**
- * Deterministic patch — injects missing items directly into the summary
- * without an LLM call. All structural mutations go through the canonical
- * parse/upsert path so the resulting markdown always has the canonical
- * headings, even if the LLM produced lowercase or differently punctuated ones.
- */
-export function patchDeterministic(summary: string, gaps: string[], extraction: StructuredExtraction): string {
+/** Apply every safe, deterministic repair. Hallucination/inconsistency gaps stay visible for LLM/user review. */
+export function patchDeterministic(summary: string, gaps: VerificationGap[], extraction: StructuredExtraction): string {
   let canonical: CanonicalSummary = parseSummary(summary);
+  const verificationNotes: string[] = [];
 
-  const fileGaps = gaps.filter(g => g.startsWith("Missing modified file:"));
-  const errorGaps = gaps.filter(g => g.startsWith("Missing error:"));
-  const constraintGaps = gaps.filter(g => g.startsWith("Missing constraint:"));
-  const decisionGaps = gaps.filter(g => g.startsWith("Missing decision:"));
-  const sectionGaps = gaps.filter(g => g.startsWith("Missing section:"));
-  const otherGaps = gaps.filter(g =>
-    !g.startsWith("Missing modified file:") &&
-    !g.startsWith("Missing error:") &&
-    !g.startsWith("Missing constraint:") &&
-    !g.startsWith("Missing decision:") &&
-    !g.startsWith("Missing section:") &&
-    !g.startsWith("Potentially fabricated") &&
-    !g.startsWith("Inconsistency")
-  );
-
-  const ensureMissingSection = (header: string): void => {
-    // Map the heading literal back to a structural kind so upsertSection can
-    // produce canonical markdown regardless of what the LLM emitted before.
-    if (header === "## Goal") {
-      canonical = upsertSection(canonical, "goal", (extraction.mainGoal ?? "Continue the current coding task.") + "\n");
-    } else if (header === "## Progress") {
-      canonical = upsertSection(canonical, "progress", "### Done\n- See preceding summary.\n### In Progress\n- Continue from the latest user request.\n### Blocked\n- None recorded.\n");
-    } else if (header === "## Critical Context") {
-      canonical = upsertSection(canonical, "critical-context", "- None recorded.\n");
+  for (const gap of gaps) {
+    switch (gap.kind) {
+      case "missing-section": {
+        if (gap.section === "goal") {
+          canonical = upsertSection(canonical, "goal", extraction.mainGoal ?? "Continue the current coding task.");
+        } else if (gap.section === "progress") {
+          canonical = upsertSection(canonical, "progress", "### Done\n- See preceding summary.\n### In Progress\n- Continue from the latest user request.\n### Blocked\n- None recorded.");
+        } else if (gap.section === "critical-context") {
+          canonical = upsertSection(canonical, "critical-context", "- None recorded.");
+        }
+        break;
+      }
+      case "missing-file":
+        canonical = appendToSection(canonical, "files-modified", "- " + gap.path);
+        break;
+      case "missing-error":
+        canonical = appendToSection(canonical, "critical-context", "- Unresolved error: " + gap.message.slice(0, TRUNC.MESSAGE));
+        break;
+      case "missing-constraint":
+        canonical = appendToSection(canonical, "constraints", "- " + gap.text.slice(0, TRUNC.CONSTRAINT_TEXT));
+        break;
+      case "missing-decision":
+        canonical = appendToSection(canonical, "decisions", "- **" + gap.summary.slice(0, TRUNC.DECISION_DETAIL) + "**");
+        break;
+      case "missing-goal":
+        canonical = upsertSection(canonical, "goal", gap.goal);
+        break;
+      case "missing-open-loops": {
+        const unresolved = extraction.errors.filter(error => !error.resolved).slice(0, gap.unresolvedCount);
+        const body = unresolved.map(error => "- [high] Resolve " + error.message.slice(0, TRUNC.SNIPPET)).join("\n");
+        canonical = upsertSection(canonical, "open-loops", body || "- Review unresolved errors.", "next-steps");
+        break;
+      }
+      case "fabricated-file":
+      case "inconsistency":
+        verificationNotes.push(formatVerificationGap(gap));
+        break;
     }
-  };
-
-  for (const gap of sectionGaps) {
-    ensureMissingSection(gap.replace("Missing section: ", ""));
   }
 
-  if (fileGaps.length > 0) {
-    const entries = fileGaps.map(g => "- " + g.replace("Missing modified file: ", "")).join("\n");
-    canonical = appendToSection(canonical, "files-modified", entries);
+  if (verificationNotes.length > 0) {
+    canonical = upsertSection(canonical, "verification-note", verificationNotes.map(note => "- " + note).join("\n"));
   }
-
-  if (errorGaps.length > 0) {
-    const entries = errorGaps.map(g => "- " + g).join("\n");
-    canonical = appendToSection(canonical, "critical-context", entries);
-  }
-
-  if (constraintGaps.length > 0) {
-    const entries = constraintGaps.map(g => "- " + g).join("\n");
-    canonical = appendToSection(canonical, "constraints", entries);
-  }
-
-  if (decisionGaps.length > 0) {
-    const entries = decisionGaps.map(g => "- **" + g.replace("Missing decision: ", "") + "**").join("\n");
-    canonical = appendToSection(canonical, "decisions", entries);
-  }
-
-  // Patching renders with canonical headings so a later verify pass cannot
-  // miss a section because the original markdown used `### Goal` or `Goals:`.
-  let rendered = renderSummary(canonical, { canonicalHeadings: true });
-  if (otherGaps.length > 0) {
-    rendered += "\n## Verification Note\n" + otherGaps.map(g => "- " + g).join("\n") + "\n";
-  }
-  return rendered;
+  return renderSummary(canonical, { canonicalHeadings: true });
 }
 
 export async function patchSummary(
-  summary: string, gaps: string[],
+  summary: string, gaps: VerificationGap[],
   model: Model<Api>, auth: { apiKey: string; headers?: Record<string, string> }, signal?: AbortSignal,
   services?: SmartCompactServices,
 ): Promise<string> {
   const patchPrompt = "The summary below is missing some critical information. Add the missing items WITHOUT restructuring the summary.\n\nMissing items:\n" +
-    gaps.map((g, i) => (i + 1) + ". " + g).join("\n") +
+    gaps.map((gap, index) => (index + 1) + ". " + formatVerificationGap(gap)).join("\n") +
     "\n\nCurrent summary:\n" + summary +
     "\n\nReturn the COMPLETE updated summary with missing items integrated. Keep the same format.";
 
   try {
-    // Cap maxTokens to the provider's true output ceiling. The previous
-    // hard-coded 8192 caused provider-side errors for DeepSeek/MiniMax
-    // (4096) and silently wasted budget on providers with higher ceilings.
-    const providerCap = getProviderCaps(model.provider).maxOutputTokens;
-    const maxTokens = Math.min(8192, providerCap);
-    const resp = await trackedComplete("patch", model, {
+    const maxTokens = Math.min(8192, getProviderCaps(model.provider).maxOutputTokens);
+    const response = await trackedComplete("patch", model, {
       systemPrompt: COMPACT_SYSTEM_PREFIX,
       messages: [{ role: "user" as const, content: [{ type: "text" as const, text: patchPrompt }], timestamp: Date.now() }],
     }, { apiKey: auth.apiKey, headers: auth.headers, maxTokens, signal }, services);
-    const patched = resp.content.filter((c): c is import("@earendil-works/pi-ai").TextContent => c.type === "text").map(c => c.text).join("\n").trim();
+    const patched = response.content.filter((content): content is import("@earendil-works/pi-ai").TextContent => content.type === "text").map(content => content.text).join("\n").trim();
     return patched.startsWith("##") ? patched : summary;
-  } catch (e) { log.debug("patchSummary LLM failed", e); return summary; }
+  } catch (error) {
+    log.debug("patchSummary LLM failed", error);
+    return summary;
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Model, Api } from "@earendil-works/pi-ai";
+import type { SectionKind } from "./domain/summary-schema.ts";
 
 /** Session type classification */
 export type SessionType = "implementation" | "review" | "debugging" | "discussion";
@@ -28,6 +29,14 @@ export interface CompactConfig {
   backupEnabled: boolean;
   backupDir: string;
   minContextPercent: number; // Don't compact below this threshold
+  requireApproval: boolean;
+  scrubSecrets: boolean;
+  scrubPii: boolean;
+  maxLlmCalls: number; // 0 = unlimited
+  maxLatencyMs: number; // 0 = unlimited soft budget; hard timeout stays separate
+  focusWeighting: boolean;
+  adaptiveDamageFeedback: boolean;
+  onlineDamageMonitor: boolean;
   /** File paths that must always survive compaction, regardless of what the
    *  LLM summary chooses to include. Surfaced in the summary's Files Read. */
   pinPaths: string[];
@@ -85,7 +94,7 @@ export interface CompactMetricsEntry {
   model?: string;
   provider?: string;
   runType?: "manual" | "auto" | "tool";
-  status?: "success" | "timeout" | "error" | "dry-run";
+  status?: "success" | "timeout" | "error" | "dry-run" | "cancelled";
   contextPercent?: number;
   toolPercent?: number;
   tokensBefore?: number;
@@ -97,6 +106,8 @@ export interface CompactMetricsEntry {
   verificationGaps?: number;
   phaseTimings?: PipelinePhaseTiming[];
   durationMs?: number;
+  redactions?: number;
+  adapted?: boolean;
 }
 
 export interface TopicBoundary {
@@ -136,6 +147,8 @@ export interface SmartCompactDetails {
   model: string;
   qualityScore: number;
   tokensBefore: number;
+  provenance?: VerificationProvenance;
+  redactions?: number;
   compactionState?: CompactionState;
   openLoops?: OpenLoop[];
 }
@@ -198,10 +211,29 @@ export interface ModelOption {
   supportsTools: boolean | "probe";
 }
 
+export type VerificationGap =
+  | { kind: "missing-section"; section: SectionKind }
+  | { kind: "missing-file"; path: string }
+  | { kind: "missing-error"; message: string }
+  | { kind: "missing-constraint"; text: string }
+  | { kind: "missing-decision"; summary: string }
+  | { kind: "missing-goal"; goal: string }
+  | { kind: "fabricated-file"; ref: string }
+  | { kind: "inconsistency"; detail: string }
+  | { kind: "missing-open-loops"; unresolvedCount: number };
+
 export interface VerificationResult {
   ok: boolean;
-  gaps: string[];
+  gaps: VerificationGap[];
   score: number;
+}
+
+export interface VerificationProvenance {
+  initialScore: number;
+  deterministicPatched: VerificationGap[];
+  llmPatched: boolean;
+  finalScore: number;
+  remainingGaps: VerificationGap[];
 }
 
 export interface ExplorationReport {
@@ -328,6 +360,14 @@ export interface OpenLoop {
   sourceIndex?: number;
 }
 
+export interface LoopOverride {
+  id: string;
+  summaryKey: string;
+  status?: OpenLoop["status"];
+  priority?: OpenLoop["priority"];
+  pinned?: boolean;
+}
+
 /** Structured machine-readable compaction state */
 export interface CompactionState {
   goal: string | null;
@@ -339,6 +379,7 @@ export interface CompactionState {
   unresolvedErrors: Array<{ id: string; message: string; tool: string; files: string[] }>;
   resolvedErrors: Array<{ id: string; message: string; tool: string }>;
   openLoops: OpenLoop[];
+  loopOverrides?: LoopOverride[];
   topics: Array<{ title: string; type: string; priority: string }>;
   nextActions: string[];
   criticalContext: string[];

--- a/src/ui/metrics-report.ts
+++ b/src/ui/metrics-report.ts
@@ -25,7 +25,7 @@ function compactNumber(value: number): string {
 
 function statusClass(status?: string): "good" | "warn" | "bad" {
   if (status === "timeout" || status === "error") return "bad";
-  if (status === "dry-run") return "warn";
+  if (status === "dry-run" || status === "cancelled") return "warn";
   return "good";
 }
 

--- a/src/ui/overlays.ts
+++ b/src/ui/overlays.ts
@@ -9,7 +9,7 @@ import { Container, Key, matchesKey, type SelectItem, SelectList, Text, truncate
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type {
   CompactMetricsEntry, CompressionProfile, ModelOption, ProgressState,
-  SmartCompactDetails, StructuredExtraction,
+  SmartCompactDetails, StructuredExtraction, OpenLoop, LoopOverride,
 } from "../types.ts";
 import type { BackupEntry } from "../utils/helpers.ts";
 import type { SmartCompactServices } from "../infra/services.ts";
@@ -26,6 +26,7 @@ import {
   metricScore,
 } from "./dashboard-format.ts";
 import path from "node:path";
+import { applyLoopOverrides, upsertLoopOverride } from "../utils/state.ts";
 
 export function renderContextBar(theme: Theme, pct: number, tokens: number, barLen = 24): string {
   const clamped = Math.min(Math.max(pct, 0), 100);
@@ -173,11 +174,12 @@ export async function showResultScreen(
   details: SmartCompactDetails,
   extraction: StructuredExtraction,
   services: SmartCompactServices,
-): Promise<void> {
+  opts: { approval?: boolean } = {},
+): Promise<"apply" | "cancel" | "closed"> {
   await ctx.ui.custom<void>((tui, theme, _kb, done) => {
     const c = new Container();
     c.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
-    c.addChild(new Text(theme.fg("accent", theme.bold("  \u2705 Smart Compact Complete")), 1, 0));
+    c.addChild(new Text(theme.fg("accent", theme.bold(opts.approval ? "  \uD83D\uDD0E Smart Compact Review" : "  \u2705 Smart Compact Complete")), 1, 0));
     c.addChild(new Text("", 0, 0));
 
     const estimatedAfter = (details.tokensBefore ?? 0) - (details.tokensSaved ?? 0);
@@ -199,6 +201,18 @@ export async function showResultScreen(
 
     const scoreColor = details.qualityScore >= 80 ? "success" : details.qualityScore >= 50 ? "warning" : "error";
     c.addChild(new Text(theme.fg("text", "  Quality: ") + theme.fg(scoreColor, details.qualityScore + "/100"), 0, 0));
+    if (details.provenance) {
+      const provenance = details.provenance;
+      c.addChild(new Text(
+        theme.fg("dim", "  Provenance: score " + provenance.initialScore + " → deterministic " + provenance.deterministicPatched.length +
+          (provenance.llmPatched ? " → LLM patch" : "") + " → " + provenance.finalScore +
+          " (" + provenance.remainingGaps.length + " remaining)"),
+        0, 0,
+      ));
+    }
+    if ((details.redactions ?? 0) > 0) {
+      c.addChild(new Text(theme.fg("warning", "  Security: " + details.redactions + " sensitive value(s) redacted"), 0, 0));
+    }
     c.addChild(new Text("", 0, 0));
 
     c.addChild(new Text(theme.fg("text", theme.bold("  \uD83D\uDCCB Extraction")), 0, 0));
@@ -322,7 +336,7 @@ export async function showResultScreen(
       c.addChild(new Text("", 0, 0));
     }
 
-    c.addChild(new Text(theme.fg("dim", "  Press any key to close"), 0, 0));
+    c.addChild(new Text(theme.fg("dim", opts.approval ? "  Press any key to continue to Apply/Cancel" : "  Press any key to close"), 0, 0));
     c.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
 
     return {
@@ -331,6 +345,14 @@ export async function showResultScreen(
       handleInput: (_d: string) => done(undefined),
     };
   }, { overlay: true, overlayOptions: { width: "70%", anchor: "center", maxHeight: "80%" } });
+
+  if (!opts.approval) return "closed";
+  const approved = await ctx.ui.confirm(
+    "Apply Smart Compact?",
+    "Quality " + details.qualityScore + "/100 · " + details.gaps.length + " remaining gap(s) · " +
+      details.tokensSaved.toLocaleString() + " estimated tokens saved.\n\nCancel keeps the current conversation unchanged.",
+  );
+  return approved ? "apply" : "cancel";
 }
 
 type DashboardView = "menu" | "overview" | "latest" | "session" | "recent";
@@ -482,6 +504,45 @@ export async function showRestorePicker(
       handleInput: (d: string) => { sel.handleInput(d); tui.requestRender(); },
     };
   });
+}
+
+export async function showOpenLoopsUI(
+  ctx: ExtensionCommandContext,
+  sourceLoops: OpenLoop[],
+  initialOverrides: LoopOverride[] = [],
+): Promise<LoopOverride[] | null> {
+  let overrides = initialOverrides.slice();
+  let changed = false;
+  while (true) {
+    const loops = applyLoopOverrides(sourceLoops, overrides);
+    const labels = loops.map((loop, index) =>
+      (index + 1) + ". [" + loop.status + "/" + loop.priority + "] " + loop.summary.slice(0, TRUNC.TOPIC_LABEL),
+    );
+    const choice = await ctx.ui.select("Open loops", [...labels, "Done"]);
+    if (!choice || choice === "Done") return changed ? overrides : null;
+    const index = labels.indexOf(choice);
+    const loop = loops[index];
+    if (!loop) continue;
+    const summaryKey = loop.summary.toLowerCase().replace(/\s+/g, " ").trim();
+    const existing = overrides.find(item => item.summaryKey === summaryKey);
+    const action = await ctx.ui.select("Manage: " + loop.summary.slice(0, 60), [
+      loop.status === "resolved" ? "Reopen" : "Resolve",
+      existing?.pinned ? "Unpin" : "Pin",
+      "Set priority",
+      "Back",
+    ]);
+    if (!action || action === "Back") continue;
+    if (action === "Resolve" || action === "Reopen") {
+      overrides = upsertLoopOverride(overrides, loop, { status: action === "Resolve" ? "resolved" : "open" });
+    } else if (action === "Pin" || action === "Unpin") {
+      overrides = upsertLoopOverride(overrides, loop, { pinned: action === "Pin" });
+    } else if (action === "Set priority") {
+      const priority = await ctx.ui.select("Priority", ["critical", "high", "normal", "low"]);
+      if (priority) overrides = upsertLoopOverride(overrides, loop, { priority: priority as OpenLoop["priority"] });
+      else continue;
+    }
+    changed = true;
+  }
 }
 
 /** Scrollable viewer for a restored backup's content. */

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -11,13 +11,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
-import type { LLMCallMetric, StructuredExtraction, CachedExtraction, CacheAwareOptions, CompactMetricsEntry } from "../types.ts";
+import type { LLMCallMetric, StructuredExtraction, CachedExtraction, CacheAwareOptions, CompactMetricsEntry, LlmMessage } from "../types.ts";
+import { flattenToolCallBlock, type ToolCallIndex } from "./extraction.ts";
 import { estimateTokens, calibrateFromResponse, getProviderCaps } from "./tokens.ts";
 import * as log from "./logger.ts";
 import type { Model, Api, AssistantMessage, Context } from "@earendil-works/pi-ai";
 import { extractionCacheFile, metricsLogFile } from "../infra/paths.ts";
 import { appendLineLocked, readJsonSync, writeJsonSync, scheduleFileTailTrim } from "../infra/fs.ts";
-import { ONE_HOUR_MS, SEVEN_DAYS_MS, EXTRACTION_CACHE_PREFIX, RUNTIME_LOG_MAX_BYTES } from "../constants.ts";
+import { ONE_HOUR_MS, SEVEN_DAYS_MS, EXTRACTION_CACHE_PREFIX, RUNTIME_LOG_MAX_BYTES, ERROR_RETRY_WINDOW, ERROR_RESOLVE_WINDOW } from "../constants.ts";
 import { buildEntryIdFingerprint } from "./id-fingerprint.ts";
 import { getDefaultServices, type SmartCompactServices } from "../infra/services.ts";
 
@@ -96,10 +97,12 @@ export async function trackedComplete(
   // may omit services; everything downstream of here receives the resolved
   // bag explicitly.
   const svc = services ?? getDefaultServices();
+  svc.budget.reserveCall();
+  const safeRequest = svc.scrubber.scrubValue(reqBody).value;
   const start = Date.now();
   try {
     const resolvedOpts = cacheOpts(opts, model.provider, phase, svc);
-    const resp = await svc.llm.complete(model, reqBody, resolvedOpts as import("@earendil-works/pi-ai").ProviderStreamOptions);
+    const resp = await svc.llm.complete(model, safeRequest, resolvedOpts as import("@earendil-works/pi-ai").ProviderStreamOptions);
     const latency = Date.now() - start;
     const usage = resp.usage;
     const inputT = usage?.input ?? 0;
@@ -110,8 +113,8 @@ export async function trackedComplete(
       cacheHitTokens: cacheT, latencyMs: latency, success: true,
     }, svc);
     try {
-      if (inputT > 0 && "messages" in reqBody) {
-        const rawText = JSON.stringify((reqBody as unknown as Record<string, unknown>).messages);
+      if (inputT > 0 && "messages" in safeRequest) {
+        const rawText = JSON.stringify((safeRequest as unknown as Record<string, unknown>).messages);
         const calibration = svc.tokenCalibration;
         calibrateFromResponse(
           estimateTokens(rawText, model.provider, model.id, calibration),
@@ -245,7 +248,45 @@ function scheduleExtractionCacheCleanup(): void {
  * Without this offset, incremental extraction produces corrupted indexes that
  * break timeline ordering, topic segmentation, and downstream verification.
  */
-export function mergeExtractions(base: StructuredExtraction, delta: StructuredExtraction, baseMsgCount: number): StructuredExtraction {
+export function reconcileCachedErrors(
+  errors: StructuredExtraction["errors"],
+  deltaMessages: LlmMessage[],
+  deltaToolCalls: ToolCallIndex,
+  baseMsgCount: number,
+): StructuredExtraction["errors"] {
+  return errors.map(error => {
+    if (error.resolved) return { ...error };
+    let retryAttempted = error.retryAttempted;
+    let resolved = false;
+    for (let j = 0; j < deltaMessages.length; j++) {
+      const globalIndex = baseMsgCount + j;
+      if (globalIndex <= error.index || globalIndex >= error.index + ERROR_RETRY_WINDOW) continue;
+      const message = deltaMessages[j];
+      if (message.role !== "assistant" || !Array.isArray(message.content)) continue;
+      const retry = message.content.flatMap(flattenToolCallBlock).find(call => call.name === error.tool);
+      if (!retry) continue;
+      retryAttempted = true;
+      for (let k = j + 1; k < Math.min(deltaMessages.length, j + ERROR_RESOLVE_WINDOW); k++) {
+        const result = deltaMessages[k];
+        if (result.role !== "toolResult" || result.isError) continue;
+        const matches = retry.id != null
+          ? result.toolCallId === retry.id
+          : deltaToolCalls.get(result.toolCallId ?? "")?.name === error.tool;
+        if (matches) { resolved = true; break; }
+      }
+      break;
+    }
+    return { ...error, retryAttempted, resolved };
+  });
+}
+
+export function mergeExtractions(
+  base: StructuredExtraction,
+  delta: StructuredExtraction,
+  baseMsgCount: number,
+  deltaMessages: LlmMessage[] = [],
+  deltaToolCalls: ToolCallIndex = new Map(),
+): StructuredExtraction {
   // ── Offset every index-bearing field in delta ──
   const offsetErrors = delta.errors.map(e => ({ ...e, index: e.index + baseMsgCount }));
   const offsetDecisions = delta.decisions.map(d => ({ ...d, index: d.index + baseMsgCount }));
@@ -262,12 +303,22 @@ export function mergeExtractions(base: StructuredExtraction, delta: StructuredEx
   }));
   const offsetMedia = (delta.mediaAttachments ?? []).map(a => ({ ...a, index: a.index + baseMsgCount }));
 
+  const modified = new Map(base.modifiedFiles.map(file => [file.path, { ...file }]));
+  for (const file of offsetModifiedFiles) {
+    const previous = modified.get(file.path);
+    modified.set(file.path, previous
+      ? { ...file, toolCalls: previous.toolCalls + file.toolCalls, lastModifiedIndex: Math.max(previous.lastModifiedIndex, file.lastModifiedIndex) }
+      : file);
+  }
+  const reconciledBaseErrors = reconcileCachedErrors(base.errors, deltaMessages, deltaToolCalls, baseMsgCount);
+  const mergedErrors = [...reconciledBaseErrors, ...offsetErrors];
+
   return {
-    modifiedFiles: [...new Map([...base.modifiedFiles, ...offsetModifiedFiles].map(f => [f.path, f])).values()],
+    modifiedFiles: [...modified.values()],
     readFiles: [...new Set([...base.readFiles, ...delta.readFiles])],
     deletedFiles: [...new Set([...base.deletedFiles, ...delta.deletedFiles])],
     mediaAttachments: [...(base.mediaAttachments ?? []), ...offsetMedia],
-    errors: [...base.errors, ...offsetErrors],
+    errors: mergedErrors,
     decisions: [...base.decisions, ...offsetDecisions],
     constraints: [...base.constraints, ...offsetConstraints],
     topics: [...base.topics, ...offsetTopics],
@@ -278,7 +329,7 @@ export function mergeExtractions(base: StructuredExtraction, delta: StructuredEx
     // "last N" must span the cache boundary: the suffix alone is incomplete
     // when it carries fewer than N user messages / errors.
     lastUserMessages: [...base.lastUserMessages, ...delta.lastUserMessages].slice(-5),
-    lastErrors: [...base.lastErrors, ...delta.lastErrors].slice(-3),
+    lastErrors: mergedErrors.filter(error => !error.resolved).map(error => error.message).slice(-3),
     messageCount: baseMsgCount + delta.messageCount,
   };
 }

--- a/src/utils/damage.ts
+++ b/src/utils/damage.ts
@@ -6,10 +6,10 @@
 import type { LlmMessage, SmartCompactDetails } from "../types.ts";
 import { isToolCallBlock } from "../utils/type-guards.ts";
 import { extractText } from "./extraction.ts";
-import { classifyTool, extractToolPath } from "../domain/tool-semantics.ts";
+import { classifyToolOperation, extractToolPath } from "../domain/tool-semantics.ts";
 import * as log from "./logger.ts";
 import { damageReportsFile, remediationHintsFile } from "../infra/paths.ts";
-import { appendLineLocked, scheduleFileTailTrim, writeJsonSync, readJsonSync } from "../infra/fs.ts";
+import { appendLineLocked, readJsonlTail, scheduleFileTailTrim, writeJsonSync, readJsonSync } from "../infra/fs.ts";
 import { RUNTIME_LOG_MAX_BYTES, SEVEN_DAYS_MS, TRUNC } from "../constants.ts";
 import { extractCheckKeywords } from "../domain/keywords.ts";
 
@@ -59,12 +59,11 @@ export function detectDamage(
     if (msg.role === "assistant") {
       const blocks = Array.isArray(msg.content) ? msg.content : [];
       for (const b of blocks) {
-        // Classify by argument shape, not name — see domain/tool-semantics.ts.
-        // bash was never reachable here anyway (it carries `command`, not a
-        // path, so fp was always undefined); accesses now also covers
-        // grep/find/ls re-reads of compacted files.
-        if (isToolCallBlock(b) && classifyTool(b.arguments) === "accesses") {
-          const fp = extractToolPath(b.arguments);
+        if (isToolCallBlock(b)) {
+          const operation = classifyToolOperation(b.arguments, b.name);
+          const fp = operation === "read" || operation === "search" || operation === "list"
+            ? extractToolPath(b.arguments)
+            : undefined;
           if (fp) {
             const fpLower = fp.toLowerCase();
             if (compactedFiles.has(fpLower) || compactedReadFiles.has(fpLower)) {
@@ -145,11 +144,13 @@ export function logDamageReport(
   sessionId: string,
   report: DamageReport,
   details: SmartCompactDetails,
+  projectId?: string,
 ): void {
   try {
     const entry = {
       ts: new Date().toISOString(),
       sessionId,
+      projectId,
       method: details.method,
       profile: details.profile,
       qualityScore: details.qualityScore,
@@ -162,6 +163,46 @@ export function logDamageReport(
     appendLineLocked(logPath, JSON.stringify(entry));
     scheduleFileTailTrim(logPath, RUNTIME_LOG_MAX_BYTES);
   } catch (e) { log.warn("logDamageReport failed", e); }
+}
+
+export interface OnlineDamageObservation {
+  projectId: string;
+  details: SmartCompactDetails;
+  report: DamageReport;
+  complete: boolean;
+}
+
+/** Session-keyed monitor activated only after Pi confirms `session_compact`. */
+export class OnlineDamageMonitor {
+  private readonly active = new Map<string, { projectId: string; details: SmartCompactDetails; messages: LlmMessage[] }>();
+
+  constructor(private readonly maxMessages = 15) {}
+
+  activate(sessionId: string, projectId: string, details: SmartCompactDetails): void {
+    this.active.set(sessionId, { projectId, details, messages: [] });
+  }
+
+  observe(sessionId: string, message: LlmMessage): OnlineDamageObservation | null {
+    const monitor = this.active.get(sessionId);
+    if (!monitor) return null;
+    monitor.messages.push(message);
+    const report = detectDamage(monitor.messages, monitor.details);
+    const complete = report.damageScore > 0 || monitor.messages.length >= this.maxMessages;
+    if (!complete) return null;
+    this.active.delete(sessionId);
+    return { projectId: monitor.projectId, details: monitor.details, report, complete };
+  }
+
+  clear(sessionId: string): void { this.active.delete(sessionId); }
+  size(): number { return this.active.size; }
+}
+
+export function readRecentDamageScores(projectId: string, limit = 5): number[] {
+  const entries = readJsonlTail<{ projectId?: string; damageScore?: number }>(damageReportsFile(), Math.max(limit * 8, 40));
+  return entries
+    .filter(entry => entry.projectId === projectId && typeof entry.damageScore === "number")
+    .slice(-limit)
+    .map(entry => entry.damageScore!);
 }
 
 const REMEDIATION_TTL_MS = SEVEN_DAYS_MS;

--- a/src/utils/extraction.ts
+++ b/src/utils/extraction.ts
@@ -8,7 +8,7 @@ import { NO_OP_RE, SHIFT_RE, CHOICE_RE, LIKELY_ERROR_RE, ERROR_SCAN_MAX_LEN, ERR
 import { estimateTokens } from "./tokens.ts";
 import { isToolCallBlock, isTextBlock } from "../utils/type-guards.ts";
 import { buildPathNeedles } from "./file-needles.ts";
-import { classifyTool, extractToolPath } from "../domain/tool-semantics.ts";
+import { classifyToolOperation, extractToolPath } from "../domain/tool-semantics.ts";
 
 /** pi-toolkit truncation marker: content.slice(0, 20) + `…✂${content.length}` */
 export const TRUNCATE_RE = /…✂\d+$/;
@@ -144,10 +144,8 @@ export function trackFileOps(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): { modi
     const filePath = extractToolPath(tc.arguments);
     if (!filePath) continue;
 
-    // Classify by argument shape, not tool name (domain/tool-semantics.ts) —
-    // auto-adapts to any tool without a name list.
-    const cls = classifyTool(tc.arguments);
-    if (cls === "mutates") {
+    const operation = classifyToolOperation(tc.arguments, tc.name);
+    if (operation === "mutate") {
       // pi-toolkit truncation hides whether a write was a no-op, so a truncated
       // result is treated as modified (safe default); otherwise skip true no-ops.
       const resultText = extractText(m.content);
@@ -155,9 +153,11 @@ export function trackFileOps(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): { modi
         const existing = modMap.get(filePath);
         modMap.set(filePath, { toolCalls: (existing?.toolCalls ?? 0) + 1, lastIdx: i });
       }
-    } else if (cls === "accesses") {
-      // path-only: could be a read or a delete. Args can't tell them apart, so
-      // fall back to the result text (see DELETE_RESULT_RE). Defaults to read.
+    } else if (operation === "delete") {
+      delSet.add(filePath);
+    } else if (operation === "read" || operation === "search" || operation === "list") {
+      // Unknown path-only tools default to read; preserve result-text fallback
+      // for providers whose delete tool has no useful name.
       if (DELETE_RESULT_RE.test(extractText(m.content))) delSet.add(filePath);
       else readSet.add(filePath);
     }
@@ -186,7 +186,7 @@ export function catalogErrors(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): Struc
     // Error-pattern scan for command-executing tools (bash/hypa_shell/...).
     // Gated by argument shape, not by tool name, so it auto-covers shell-like
     // tools this code has never seen. Explicit m.isError is handled above.
-    if (tc && classifyTool(tc.arguments) === "executes") {
+    if (tc && classifyToolOperation(tc.arguments, tc.name) === "execute") {
       const txt = extractText(m.content);
       if (LIKELY_ERROR_RE.test(txt) && txt.length < ERROR_SCAN_MAX_LEN) {
         errors.push({ index: i, tool: tc.name, message: txt.slice(0, TRUNC.MESSAGE), retryAttempted: false, resolved: false });
@@ -299,16 +299,16 @@ export function segmentTopicsHeuristic(msgs: LlmMessage[], pc: ProfileConfig, ma
           if (lastFile && fn !== lastFile && tokenAcc > pc.minChunkTokens) brk = true;
           lastFile = fn;
           currentPrimaryFile = fp;
-          const toolCls = classifyTool(tool.arguments);
-          if (toolCls === "mutates") { if (currentType !== "implementation") currentType = "implementation"; }
-          else if (toolCls === "accesses") { if (currentType === "exploration") currentType = "review"; }
+          const operation = classifyToolOperation(tool.arguments, tool.name);
+          if (operation === "mutate" || operation === "delete") { if (currentType !== "implementation") currentType = "implementation"; }
+          else if (operation === "read" || operation === "search" || operation === "list") { if (currentType === "exploration") currentType = "review"; }
         }
       }
     }
     if (m.role === "toolResult" && m.isError) { errAcc++; if (currentType !== "implementation") currentType = "debugging"; }
     if (m.role === "toolResult" && !m.isError) {
       const tc = tcIdx.get(m.toolCallId ?? "");
-      if (tc && classifyTool(tc.arguments) === "executes" && /error|fail/i.test(txt)) { errAcc++; if (currentType !== "implementation") currentType = "debugging"; }
+      if (tc && classifyToolOperation(tc.arguments, tc.name) === "execute" && /error|fail/i.test(txt)) { errAcc++; if (currentType !== "implementation") currentType = "debugging"; }
     }
     if (m.role === "user" && SHIFT_RE.test(txt) && tokenAcc > pc.minChunkTokens) brk = true;
     if (tokenAcc >= pc.maxChunkTokens) brk = true;

--- a/src/utils/file-needles.ts
+++ b/src/utils/file-needles.ts
@@ -47,8 +47,12 @@ export const MIN_BARE_BASENAME_LEN = 5;
  * path. All needles are lowercased so substring matching can be done with
  * `errorMessage.toLowerCase().includes(needle)` cheaply.
  */
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, "/").replace(/^\.\//, "").toLowerCase();
+}
+
 export function buildPathNeedles(filePath: string): string[] {
-  const parts = filePath.toLowerCase().split("/").filter(Boolean);
+  const parts = normalizePath(filePath).split("/").filter(Boolean);
   if (parts.length === 0) return [];
   const needles: string[] = [];
   const basename = parts[parts.length - 1];
@@ -63,4 +67,30 @@ export function buildPathNeedles(filePath: string): string[] {
     needles.push(parts.slice(j).join("/"));
   }
   return needles;
+}
+
+/**
+ * Return only suffixes that identify exactly one path in the supplied set.
+ * A bare `auth.ts` is useful when unique, but must not let one monorepo package
+ * satisfy verification for every sibling package that owns an `auth.ts`.
+ */
+export function buildUniquePathNeedles(filePath: string, allPaths: readonly string[]): string[] {
+  const normalized = allPaths.map(normalizePath);
+  return buildPathNeedles(filePath).filter(needle => {
+    let owners = 0;
+    for (const candidate of normalized) {
+      if (candidate === needle || candidate.endsWith("/" + needle)) owners++;
+      if (owners > 1) return false;
+    }
+    return owners === 1;
+  });
+}
+
+/** Whether an extracted file reference can refer to at least one known path. */
+export function isKnownPathReference(ref: string, knownPaths: readonly string[]): boolean {
+  const normalizedRef = normalizePath(ref);
+  return knownPaths.some(path => {
+    const normalizedPath = normalizePath(path);
+    return normalizedPath === normalizedRef || normalizedPath.endsWith("/" + normalizedRef);
+  });
 }

--- a/src/utils/fingerprint.ts
+++ b/src/utils/fingerprint.ts
@@ -159,6 +159,10 @@ function deriveFromRelativePaths(paths: string[]): string {
  * Using cwd/git-root as primary prevents cross-project fingerprint contamination
  * when a session has no file operations (review, discussion, debugging).
  */
+export function deriveProjectIdFromCwd(cwd: string): string {
+  return hashProjectId(findGitRoot(cwd) ?? cwd);
+}
+
 export function deriveProjectId(cwd: string, extraction: StructuredExtraction, sessionId?: string): string {
   // Priority 1: cwd / git root (most stable across sessions)
   if (cwd && cwd !== "/" && cwd !== process.env.HOME) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -36,6 +36,12 @@ export function validateSmartCompactConfig(sc: Record<string, unknown>): void {
     log.warn("smart-compact config: backupEnabled must be boolean, got " + typeof sc.backupEnabled);
     delete sc.backupEnabled;
   }
+  for (const key of ["requireApproval", "scrubSecrets", "scrubPii", "focusWeighting", "adaptiveDamageFeedback", "onlineDamageMonitor"] as const) {
+    if (key in sc && typeof sc[key] !== "boolean") {
+      log.warn("smart-compact config: " + key + " must be boolean, got " + typeof sc[key]);
+      delete sc[key];
+    }
+  }
   if ("summaryModel" in sc && sc.summaryModel !== null && typeof sc.summaryModel !== "string") {
     log.warn("smart-compact config: summaryModel must be string|null, got " + typeof sc.summaryModel);
     delete sc.summaryModel;
@@ -81,6 +87,20 @@ export function validateSmartCompactConfig(sc: Record<string, unknown>): void {
     if (typeof v !== "number" || !Number.isFinite(v) || v < 1000 || v > 300000) {
       log.warn("smart-compact config: autoTriggerTimeoutMs must be 1000–300000, got " + v + ". Using default " + DEFAULT_CONFIG.autoTriggerTimeoutMs + "ms.");
       delete sc.autoTriggerTimeoutMs;
+    }
+  }
+  if ("maxLlmCalls" in sc) {
+    const value = sc.maxLlmCalls;
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 100) {
+      log.warn("smart-compact config: maxLlmCalls must be 0–100; 0 means unlimited.");
+      delete sc.maxLlmCalls;
+    }
+  }
+  if ("maxLatencyMs" in sc) {
+    const value = sc.maxLatencyMs;
+    if (typeof value !== "number" || !Number.isFinite(value) || (value !== 0 && (value < 5000 || value > 600000))) {
+      log.warn("smart-compact config: maxLatencyMs must be 0 or 5000–600000; 0 means unlimited.");
+      delete sc.maxLatencyMs;
     }
   }
   if ("minContextPercent" in sc) {
@@ -491,7 +511,7 @@ export function createBatches(chunks: LlmChunk[], maxTokens: number): LlmChunk[]
  * Allocate token budget per topic based on priority, error density, and recency.
  * Topics with higher weights get more detail preserved.
  */
-function allocateTopicBudgets(summaries: ChunkSummary[], totalBudget: number): Map<string, number> {
+function allocateTopicBudgets(summaries: ChunkSummary[], totalBudget: number, focus?: string): Map<string, number> {
   const n = summaries.length;
   if (n === 0) return new Map();
 
@@ -509,6 +529,11 @@ function allocateTopicBudgets(summaries: ChunkSummary[], totalBudget: number): M
     w *= (0.6 + recency * 0.4);
     // Topics with decisions are important
     if (s.keyDecisions.length > 0) w *= 1.3;
+    if (focus) {
+      const needle = normalizeFactKey(focus);
+      const haystack = normalizeFactKey([s.topic, s.summary, ...s.filesModified, ...s.filesRead].join(" "));
+      if (needle && haystack.includes(needle)) w *= 1.75;
+    }
     return w;
   });
 
@@ -522,8 +547,8 @@ function allocateTopicBudgets(summaries: ChunkSummary[], totalBudget: number): M
   return budgetMap;
 }
 
-export function preProcessSummaries(summaries: ChunkSummary[], budgetTokens?: number) {
-  const topicBudgets = budgetTokens ? allocateTopicBudgets(summaries, budgetTokens) : null;
+export function preProcessSummaries(summaries: ChunkSummary[], budgetTokens?: number, focus?: string) {
+  const topicBudgets = budgetTokens ? allocateTopicBudgets(summaries, budgetTokens, focus) : null;
   return {
     decisions: [...new Set(summaries.flatMap(s => s.keyDecisions))],
     modified: [...new Set(summaries.flatMap(s => s.filesModified))].sort(),
@@ -536,6 +561,21 @@ export function preProcessSummaries(summaries: ChunkSummary[], budgetTokens?: nu
   };
 }
 
+export function normalizeFactKey(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function renderDeduped<T>(items: readonly T[], keyOf: (item: T) => string, render: (item: T) => string): string {
+  const grouped = new Map<string, { item: T; count: number }>();
+  for (const item of items) {
+    const key = normalizeFactKey(keyOf(item));
+    const existing = grouped.get(key);
+    if (existing) existing.count++;
+    else grouped.set(key, { item, count: 1 });
+  }
+  return [...grouped.values()].map(({ item, count }) => render(item) + (count > 1 ? " ×" + count : "")).join("; ");
+}
+
 export function buildExtractionContext(extraction: StructuredExtraction, forRange?: { start: number; end: number }): string {
   const files = forRange ? extraction.modifiedFiles.filter(f => f.lastModifiedIndex >= forRange.start && f.lastModifiedIndex <= forRange.end) : extraction.modifiedFiles;
   const errors = forRange ? extraction.errors.filter(e => e.index >= forRange.start && e.index <= forRange.end) : extraction.errors;
@@ -543,9 +583,9 @@ export function buildExtractionContext(extraction: StructuredExtraction, forRang
   return [
     "## Deterministic Extraction (verified facts)",
     "Files modified: " + (files.map(f => f.path).join(", ") || "none"),
-    "Errors: " + (errors.map(e => "[" + e.tool + "] " + e.message.slice(0, TRUNC.SNIPPET) + (e.resolved ? " ✓" : "")).join("; ") || "none"),
-    "Decisions: " + (extraction.decisions.map(d => d.type + ": " + d.summary.slice(0, TRUNC.DECISION_DETAIL)).join("; ") || "none"),
-    "Constraints: " + (extraction.constraints.map(c => "[" + c.category + "] " + c.text.slice(0, TRUNC.DECISION_DETAIL)).join("; ") || "none"),
+    "Errors: " + (renderDeduped(errors, e => e.tool + ":" + e.message + ":" + e.resolved, e => "[" + e.tool + "] " + e.message.slice(0, TRUNC.SNIPPET) + (e.resolved ? " ✓" : "")) || "none"),
+    "Decisions: " + (renderDeduped(extraction.decisions, d => d.type + ":" + d.summary, d => d.type + ": " + d.summary.slice(0, TRUNC.DECISION_DETAIL)) || "none"),
+    "Constraints: " + (renderDeduped(extraction.constraints, c => c.category + ":" + c.text, c => "[" + c.category + "] " + c.text.slice(0, TRUNC.DECISION_DETAIL)) || "none"),
     "Media attachments: " + (media.map(a => a.kind + (a.name ? ":" + a.name : "") + (a.mimeType ? " (" + a.mimeType + ")" : "") + " @msg" + a.index).join("; ") || "none"),
   ].join("\n");
 }

--- a/src/utils/pruning.ts
+++ b/src/utils/pruning.ts
@@ -15,15 +15,6 @@ export interface PruningResult {
   prunedCount: number;
   prunedTokenSaving: number;
   reasons: Array<{ count: number; reason: string }>;
-  /**
-   * ToolCallIndex computed during pruning, keyed by **input** (unpruned)
-   * message offsets. Downstream consumers that work against the pruned
-   * message list (e.g. `extractStructured`) MUST NOT reuse this map verbatim
-   * because `msgIndex` values refer to the pre-prune positions. It is still
-   * useful for callers that want a quick `toolCallId → {name, arguments}`
-   * lookup over the original list.
-   */
-  toolCallIndex: ToolCallIndex;
 }
 
 // Pattern for agent acknowledgment messages with no information
@@ -34,7 +25,14 @@ const PI_STATUS_RE = /^\[pi-auto-context\]/;
 
 // Maximum chars to keep from a tool result output
 import { MAX_TOOL_OUTPUT_CHARS, LIKELY_ERROR_RE, ERROR_SCAN_MAX_LEN } from "../constants.ts";
-import { classifyTool, extractToolPath } from "../domain/tool-semantics.ts";
+import { classifyToolOperation, normalizeToolName } from "../domain/tool-semantics.ts";
+
+function stableArguments(args: Record<string, unknown>): string {
+  return JSON.stringify(args, (_key, value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+    return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0));
+  });
+}
 
 /**
  * Detect and collapse redundant message sequences.
@@ -54,7 +52,6 @@ export function pruneRedundant(msgs: LlmMessage[], precomputedTcIdx?: ToolCallIn
       prunedCount: 0,
       prunedTokenSaving: 0,
       reasons: [],
-      toolCallIndex: ensuredIndex,
     };
   }
 
@@ -66,22 +63,22 @@ export function pruneRedundant(msgs: LlmMessage[], precomputedTcIdx?: ToolCallIn
   const removedToolCallIds = new Set<string>();
   const reasonMap = new Map<string, number>();
 
-  // ── 1. Duplicate file reads: keep only last read per file ──
-  const readIndices = new Map<string, number[]>(); // filepath → [indices of toolResult]
+  // ── 1. Identical idempotent access calls: keep only the last ──
+  const accessIndices = new Map<string, number[]>();
   for (let i = 0; i < msgs.length; i++) {
-    if (msgs[i].role !== "toolResult") continue;
+    if (msgs[i].role !== "toolResult" || msgs[i].isError) continue;
     const tc = tcIdx.get(msgs[i].toolCallId ?? "");
-    // Dedup lookups by argument shape (read/grep/find/ls…), not tool name —
-    // same name-agnostic rule as the other consumers. See domain/tool-semantics.ts.
-    if (!tc || classifyTool(tc.arguments) !== "accesses") continue;
-    const fp = extractToolPath(tc.arguments);
-    if (!fp) continue;
-    const arr = readIndices.get(fp) ?? [];
+    if (!tc) continue;
+    const operation = classifyToolOperation(tc.arguments, tc.name);
+    if (operation !== "read" && operation !== "search" && operation !== "list") continue;
+    const key = normalizeToolName(tc.name) + "\0" + stableArguments(tc.arguments);
+    const arr = accessIndices.get(key) ?? [];
     arr.push(i);
-    readIndices.set(fp, arr);
+    accessIndices.set(key, arr);
   }
-  for (const [fp, indices] of readIndices) {
-    // Keep last read, prune the rest
+  for (const indices of accessIndices.values()) {
+    // Remove the paired result and only its matching call block. An assistant
+    // message may contain unrelated calls that must survive.
     for (let j = 0; j < indices.length - 1; j++) {
       const toolCallId = msgs[indices[j]].toolCallId ?? "";
       keep.delete(indices[j]);
@@ -255,6 +252,5 @@ export function pruneRedundant(msgs: LlmMessage[], precomputedTcIdx?: ToolCallIn
     prunedCount,
     prunedTokenSaving: Math.max(0, originalTokens - prunedTokens),
     reasons,
-    toolCallIndex: tcIdx,
   };
 }

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -5,9 +5,9 @@
  */
 
 import fs from "node:fs";
-import type { StructuredExtraction, OpenLoop, CompactionState, ExplorationReport, SessionType } from "../types.ts";
+import type { StructuredExtraction, OpenLoop, CompactionState, ExplorationReport, SessionType, LoopOverride } from "../types.ts";
 import { VERSION, SEVEN_DAYS_MS, TRUNC, ID_PREFIX } from "../constants.ts";
-import { inferSessionType } from "./helpers.ts";
+import { inferSessionType, normalizeFactKey } from "./helpers.ts";
 import * as log from "./logger.ts";
 import { compactionStateFile } from "../infra/paths.ts";
 import { writeJsonSync, readJsonSync } from "../infra/fs.ts";
@@ -49,12 +49,41 @@ export function loadCompactionState(projectId: string): CompactionState | null {
   return data;
 }
 
+export function applyLoopOverrides(loops: OpenLoop[], overrides: LoopOverride[]): OpenLoop[] {
+  // Loop ids are positional (`loop-1`, `loop-2`) and regenerated every run;
+  // normalized summary identity is the only stable cross-compaction key.
+  const bySummary = new Map(overrides.map(override => [override.summaryKey, override]));
+  return loops.map(loop => {
+    const override = bySummary.get(normalizeFactKey(loop.summary));
+    return override ? {
+      ...loop,
+      ...(override.status ? { status: override.status } : {}),
+      ...(override.priority ? { priority: override.priority } : {}),
+    } : loop;
+  }).sort((a, b) => {
+    const aOverride = bySummary.get(normalizeFactKey(a.summary));
+    const bOverride = bySummary.get(normalizeFactKey(b.summary));
+    return Number(Boolean(bOverride?.pinned)) - Number(Boolean(aOverride?.pinned));
+  });
+}
+
+export function upsertLoopOverride(overrides: LoopOverride[], loop: OpenLoop, patch: Partial<Omit<LoopOverride, "id" | "summaryKey">>): LoopOverride[] {
+  const summaryKey = normalizeFactKey(loop.summary);
+  const index = overrides.findIndex(override => override.summaryKey === summaryKey);
+  const next: LoopOverride = { ...(index >= 0 ? overrides[index] : { id: loop.id, summaryKey }), ...patch, id: loop.id, summaryKey };
+  if (index < 0) return [...overrides, next];
+  const copy = overrides.slice();
+  copy[index] = next;
+  return copy;
+}
+
 export function buildCompactionState(
   extraction: StructuredExtraction,
   openLoops: OpenLoop[],
   report: ExplorationReport | null,
   nextActions: string[],
   criticalContext: string[],
+  loopOverrides: LoopOverride[] = [],
 ): CompactionState {
   let decisionId = 0;
   let constraintId = 0;
@@ -98,6 +127,7 @@ export function buildCompactionState(
       tool: e.tool,
     })),
     openLoops,
+    ...(loopOverrides.length ? { loopOverrides } : {}),
     topics: extraction.topics.map((t, i) => ({
       title: t.primaryFile ? t.primaryFile.split("/").pop() + " (" + t.type + ")" : "Topic " + (i + 1),
       type: t.type,
@@ -177,8 +207,8 @@ export function computeDelta(prev: CompactionState, current: CompactionState): C
     .map(d => d.summary);
 
   // Open loops (summaries are already bounded to ~120 chars at extraction time)
-  const prevLoopSummaries = new Map(prev.openLoops.map(l => [key(l.summary), l]));
-  const currLoopKeys = new Set(current.openLoops.map(l => key(l.summary)));
+  const prevLoopSummaries = new Map(prev.openLoops.filter(loop => loop.status !== "resolved").map(l => [key(l.summary), l]));
+  const currLoopKeys = new Set(current.openLoops.filter(loop => loop.status !== "resolved").map(l => key(l.summary)));
   const resolvedLoops: string[] = [];
   const persistentLoops: string[] = [];
   for (const [k, loop] of prevLoopSummaries) {
@@ -186,6 +216,7 @@ export function computeDelta(prev: CompactionState, current: CompactionState): C
     else resolvedLoops.push(loop.summary);
   }
   const newLoops = current.openLoops
+    .filter(loop => loop.status !== "resolved")
     .filter(l => !prevLoopSummaries.has(key(l.summary)))
     .map(l => l.summary);
 

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -3,7 +3,7 @@
  */
 
 import { CHARS_PER_TOKEN, TUNING } from "../constants.ts";
-import type { ProviderCapabilities } from "../types.ts";
+import type { LlmMessage, ProviderCapabilities } from "../types.ts";
 
 const PROVIDER_MAP: Record<string, ProviderCapabilities> = {
   // ── Anthropic family ──
@@ -204,4 +204,35 @@ export function estimateTokens(text: string, provider?: string, model?: string, 
 
 export function calibrateFromResponse(estimated: number, actual: number, provider?: string, model?: string, calibration = _fallbackCalibration): void {
   calibration.calibrate(estimated, actual, provider, model);
+}
+
+export interface TokenEstimator {
+  text(text: string): number;
+  message(message: Pick<LlmMessage, "role" | "content" | "toolCallId" | "toolName" | "isError">): number;
+  messages(messages: ReadonlyArray<Pick<LlmMessage, "role" | "content" | "toolCallId" | "toolName" | "isError">>): number;
+}
+
+/**
+ * Bind provider/model calibration once per run. Message estimates use the
+ * actual structured content, including tool-call arguments that text-only
+ * extraction intentionally omits.
+ */
+export function makeTokenEstimator(
+  provider?: string,
+  model?: string,
+  calibration: TokenCalibrationStore = _fallbackCalibration,
+): TokenEstimator {
+  const text = (value: string) => estimateTokens(value, provider, model, calibration);
+  const serializable = (message: Pick<LlmMessage, "role" | "content" | "toolCallId" | "toolName" | "isError">) => ({
+    role: message.role,
+    content: message.content,
+    ...(message.toolCallId ? { toolCallId: message.toolCallId } : {}),
+    ...(message.toolName ? { toolName: message.toolName } : {}),
+    ...(message.isError ? { isError: true } : {}),
+  });
+  return {
+    text,
+    message: message => text(JSON.stringify(serializable(message))),
+    messages: messages => text(JSON.stringify(messages.map(serializable))),
+  };
 }

--- a/test/approval.test.ts
+++ b/test/approval.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { showResultScreen } from "../src/ui/overlays.ts";
+import { createServices } from "../src/infra/services.ts";
+import type { SmartCompactDetails, StructuredExtraction } from "../src/types.ts";
+
+const details: SmartCompactDetails = {
+  method: "eesv", chunkCount: 1, topics: ["auth"], readFiles: [], modifiedFiles: ["src/auth.ts"],
+  totalMessages: 10, totalTokensSummarized: 1000, llmCalls: 2, profile: "balanced", backupPath: null,
+  tokensSaved: 500, verified: true, gaps: [], explorationRounds: 1, explorationBoundaries: 1,
+  model: "openai/test", qualityScore: 100, tokensBefore: 1500,
+  provenance: { initialScore: 95, deterministicPatched: [{ kind: "missing-file", path: "src/auth.ts" }], llmPatched: false, finalScore: 100, remainingGaps: [] },
+};
+const extraction: StructuredExtraction = {
+  modifiedFiles: [{ path: "src/auth.ts", toolCalls: 1, lastModifiedIndex: 1 }], readFiles: [], deletedFiles: [],
+  errors: [], decisions: [], constraints: [], topics: [], timeline: [], mainGoal: "auth", lastUserMessages: [], lastErrors: [], messageCount: 10,
+};
+
+function context(confirmed: boolean) {
+  const theme = {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  };
+  return {
+    ui: {
+      custom: async (factory: any) => await new Promise(resolve => {
+        const component = factory({ requestRender: () => {} }, theme, {}, resolve);
+        component.handleInput("x");
+      }),
+      confirm: async () => confirmed,
+    },
+  } as any;
+}
+
+describe("manual compaction approval", () => {
+  it("returns cancel when the user declines after reviewing provenance", async () => {
+    expect(await showResultScreen(context(false), details, extraction, createServices(), { approval: true })).toBe("cancel");
+  });
+
+  it("returns apply only after explicit confirmation", async () => {
+    expect(await showResultScreen(context(true), details, extraction, createServices(), { approval: true })).toBe("apply");
+  });
+});

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import { mergeExtractions, saveCachedExtraction, loadCachedExtraction } from "../src/utils/cache.ts";
 import { pruneRedundant } from "../src/utils/pruning.ts";
-import { extractStructured } from "../src/utils/extraction.ts";
+import { extractStructured, buildToolCallIndex } from "../src/utils/extraction.ts";
 import { PROFILES } from "../src/constants.ts";
 import { buildEntryIdFingerprint, isPrefixOf } from "../src/utils/id-fingerprint.ts";
 import type { LlmMessage, StructuredExtraction } from "../src/types.ts";
@@ -167,7 +167,7 @@ describe("mergeExtractions — index offset", () => {
 // ── Deduplication and field merge ──
 
 describe("mergeExtractions — deduplication", () => {
-  it("deduplicates modifiedFiles by path (delta overwrites base)", () => {
+  it("deduplicates modifiedFiles by path and accumulates tool-call counts", () => {
     const base = makeExtraction({
       modifiedFiles: [
         { path: "src/a.ts", toolCalls: 1, lastModifiedIndex: 3 },
@@ -183,8 +183,7 @@ describe("mergeExtractions — deduplication", () => {
     const merged = mergeExtractions(base, delta, 5);
 
     expect(merged.modifiedFiles.length).toBe(1);
-    // Last write wins (Map insertion order)
-    expect(merged.modifiedFiles[0].toolCalls).toBe(2);
+    expect(merged.modifiedFiles[0].toolCalls).toBe(3);
     expect(merged.modifiedFiles[0].lastModifiedIndex).toBe(7); // 2 + 5
   });
 
@@ -194,6 +193,33 @@ describe("mergeExtractions — deduplication", () => {
     const merged = mergeExtractions(base, delta, 5);
 
     expect([...merged.readFiles].sort()).toEqual(["a.ts", "b.ts", "c.ts"]);
+  });
+});
+
+// ── messageCount ──
+
+describe("mergeExtractions — cached error reconciliation", () => {
+  it("matches full extraction when a cached error is resolved in the delta", () => {
+    const failed: LlmMessage[] = [
+      { role: "user", content: [{ type: "text", text: "run tests" }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "f", name: "bash", arguments: { command: "bun test" } }] },
+      { role: "toolResult", toolCallId: "f", isError: true, content: [{ type: "text", text: "test failed" }] },
+    ];
+    const retry: LlmMessage[] = [
+      { role: "assistant", content: [{ type: "toolCall", id: "s", name: "bash", arguments: { command: "bun test" } }] },
+      { role: "toolResult", toolCallId: "s", isError: false, content: [{ type: "text", text: "all tests passed" }] },
+    ];
+    const base = extractStructured(failed, PROFILES.balanced);
+    const deltaIndex = buildToolCallIndex(retry);
+    const delta = extractStructured(retry, PROFILES.balanced, deltaIndex);
+
+    const merged = mergeExtractions(base, delta, failed.length, retry, deltaIndex);
+    const full = extractStructured([...failed, ...retry], PROFILES.balanced);
+
+    expect(merged.errors[0].resolved).toBe(true);
+    expect(merged.errors[0].retryAttempted).toBe(true);
+    expect(merged.errors[0].resolved).toBe(full.errors[0].resolved);
+    expect(merged.lastErrors).toEqual([]);
   });
 });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -155,6 +155,39 @@ describe("validateSmartCompactConfig", () => {
     validateSmartCompactConfig(sc);
     expect(sc.pinPaths).toEqual(["src/auth.ts", "README.md"]);
   });
+
+  it("validates roadmap security and policy flags", () => {
+    const sc: Record<string, unknown> = {
+      requireApproval: "yes",
+      scrubSecrets: true,
+      scrubPii: false,
+      focusWeighting: true,
+      adaptiveDamageFeedback: false,
+      onlineDamageMonitor: true,
+    };
+    validateSmartCompactConfig(sc);
+    expect(sc.requireApproval).toBeUndefined();
+    expect(sc.scrubSecrets).toBe(true);
+  });
+
+  it("validates optional call and latency budgets", () => {
+    const valid: Record<string, unknown> = { maxLlmCalls: 8, maxLatencyMs: 20_000 };
+    validateSmartCompactConfig(valid);
+    expect(valid).toEqual({ maxLlmCalls: 8, maxLatencyMs: 20_000 });
+    const invalid: Record<string, unknown> = { maxLlmCalls: -1, maxLatencyMs: 1000 };
+    validateSmartCompactConfig(invalid);
+    expect(invalid.maxLlmCalls).toBeUndefined();
+    expect(invalid.maxLatencyMs).toBeUndefined();
+  });
+
+  it("ships risky roadmap features behind safe defaults", () => {
+    expect(DEFAULT_CONFIG.requireApproval).toBe(false);
+    expect(DEFAULT_CONFIG.scrubSecrets).toBe(true);
+    expect(DEFAULT_CONFIG.scrubPii).toBe(false);
+    expect(DEFAULT_CONFIG.adaptiveDamageFeedback).toBe(false);
+    expect(DEFAULT_CONFIG.maxLlmCalls).toBe(0);
+    expect(DEFAULT_CONFIG.maxLatencyMs).toBe(0);
+  });
 });
 
 describe("computeToolCharPercentage", () => {

--- a/test/damage.test.ts
+++ b/test/damage.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { detectDamage } from "../src/utils/damage.ts";
+import { detectDamage, OnlineDamageMonitor } from "../src/utils/damage.ts";
 import type { LlmMessage, SmartCompactDetails } from "../src/types.ts";
 
 function userMsg(text: string): LlmMessage {
@@ -58,6 +58,26 @@ function makeDetails(over: Partial<SmartCompactDetails> = {}): SmartCompactDetai
   };
 }
 
+describe("OnlineDamageMonitor", () => {
+  it("activates after compaction and emits the first actionable observation", () => {
+    const monitor = new OnlineDamageMonitor(15);
+    monitor.activate("session-1", "project-1", makeDetails());
+    const observation = monitor.observe("session-1", assistantToolCall("read", { path: "src/auth.ts" }));
+    expect(observation?.report.damageScore).toBeGreaterThan(0);
+    expect(observation?.projectId).toBe("project-1");
+    expect(monitor.size()).toBe(0);
+  });
+
+  it("stops a clean monitor at the configured message window", () => {
+    const monitor = new OnlineDamageMonitor(2);
+    monitor.activate("session-1", "project-1", makeDetails());
+    expect(monitor.observe("session-1", assistantText("continue"))).toBeNull();
+    const observation = monitor.observe("session-1", assistantText("done"));
+    expect(observation?.report.damageScore).toBe(0);
+    expect(monitor.size()).toBe(0);
+  });
+});
+
 describe("detectDamage", () => {
   it("reports zero score for a clean post-compaction history", () => {
     const messages: LlmMessage[] = [
@@ -91,6 +111,14 @@ describe("detectDamage", () => {
     ];
     const report = detectDamage(messages, makeDetails());
     expect(report.signals.some(s => s.type === "re-read")).toBe(true);
+  });
+
+  it("does not mistake a path + text mutation for a re-read", () => {
+    const messages: LlmMessage[] = [
+      assistantToolCall("write_file", { path: "src/auth.ts", text: "replacement" }),
+    ];
+    const report = detectDamage(messages, makeDetails());
+    expect(report.signals.filter(s => s.type === "re-read")).toHaveLength(0);
   });
 
   it("does not flag a re-read for a file that was never in the compacted section", () => {

--- a/test/eval-adversarial.test.ts
+++ b/test/eval-adversarial.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import { parseSummary, renderSummary } from "../src/domain/summary-parse.ts";
+import { verifySummary, patchDeterministic } from "../src/phases/verify.ts";
+import { injectOpenLoopsSection, applyLoopOverrides, upsertLoopOverride } from "../src/utils/state.ts";
+import { classifyToolOperation } from "../src/domain/tool-semantics.ts";
+import { pruneRedundant } from "../src/utils/pruning.ts";
+import { extractStructured, buildToolCallIndex } from "../src/utils/extraction.ts";
+import { mergeExtractions } from "../src/utils/cache.ts";
+import { resolveCompactionWindow } from "../src/app/steps/window.ts";
+import { chunkLlmMessages } from "../src/phases/synthesize.ts";
+import { makeTokenEstimator } from "../src/utils/tokens.ts";
+import { SecretScrubber } from "../src/domain/scrub.ts";
+import { BudgetExceededError, BudgetGuard, createServices } from "../src/infra/services.ts";
+import { trackedComplete } from "../src/utils/cache.ts";
+import { OnlineDamageMonitor } from "../src/utils/damage.ts";
+import { PROFILES } from "../src/constants.ts";
+import type { LlmMessage, OpenLoop, StructuredExtraction } from "../src/types.ts";
+
+const extraction = (extra: Partial<StructuredExtraction> = {}): StructuredExtraction => ({
+  modifiedFiles: [], readFiles: [], deletedFiles: [], errors: [], decisions: [], constraints: [], topics: [], timeline: [],
+  mainGoal: null, lastUserMessages: [], lastErrors: [], messageCount: 0, ...extra,
+});
+
+describe("adversarial summary shapes", () => {
+  it("preserves an H3-only summary through state injection", () => {
+    const summary = "### Goal\nBuild auth\n### Progress\n### Done\n- schema\n### Critical Context\n- rotate tokens";
+    const output = injectOpenLoopsSection(summary, [{ id: "l", type: "follow-up", priority: "high", status: "open", summary: "Finish API", files: [] }]);
+    expect(output).toContain("Build auth");
+    expect(output).toContain("rotate tokens");
+    expect(output).toContain("Finish API");
+  });
+
+  it("collapses duplicate canonical sections without duplicating exact evidence", () => {
+    const summary = Array.from({ length: 200 }, () => "## Goal\n- Build auth").join("\n");
+    const parsed = parseSummary(summary);
+    expect(parsed.sections).toHaveLength(1);
+    expect(renderSummary(parsed).match(/Build auth/g)).toHaveLength(1);
+  });
+
+  it("parses a one-megabyte section without dropping its tail", () => {
+    const tail = "x".repeat(1_000_000);
+    const parsed = parseSummary("## Goal\n" + tail);
+    expect(parsed.sections[0].body.length).toBe(1_000_000);
+  });
+});
+
+describe("adversarial verification", () => {
+  it("does not cross-satisfy colliding monorepo basenames", () => {
+    const facts = extraction({ modifiedFiles: [
+      { path: "packages/api/src/index.ts", toolCalls: 1, lastModifiedIndex: 1 },
+      { path: "packages/web/src/index.ts", toolCalls: 1, lastModifiedIndex: 2 },
+    ] });
+    const result = verifySummary("## Goal\nBuild\n## Progress\n- packages/api/src/index.ts\n## Critical Context\n- stable", facts);
+    expect(result.gaps.some(gap => gap.kind === "missing-file" && gap.path.includes("web"))).toBe(true);
+  });
+
+  it("patches every deterministic gap idempotently", () => {
+    const facts = extraction({ modifiedFiles: [{ path: "src/auth.ts", toolCalls: 1, lastModifiedIndex: 1 }] });
+    const summary = "## Goal\nBuild\n## Progress\n- setup\n## Critical Context\n- stable";
+    const once = patchDeterministic(summary, verifySummary(summary, facts).gaps, facts);
+    const twice = patchDeterministic(once, verifySummary(once, facts).gaps, facts);
+    expect(twice).toBe(once);
+    expect(verifySummary(once, facts).gaps.some(gap => gap.kind === "missing-file")).toBe(false);
+  });
+});
+
+describe("adversarial tool semantics and cache boundaries", () => {
+  it("keeps read and grep evidence independent", () => {
+    const messages: LlmMessage[] = [
+      { role: "user", content: [{ type: "text", text: "inspect" }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "r", name: "read", arguments: { path: "src/a.ts" } }] },
+      { role: "toolResult", toolCallId: "r", content: [{ type: "text", text: "full content" }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "g", name: "grep", arguments: { path: "src/a.ts", pattern: "x" } }] },
+      { role: "toolResult", toolCallId: "g", content: [{ type: "text", text: "no matches" }] },
+    ];
+    expect(pruneRedundant(messages).messages.filter(message => message.role === "toolResult")).toHaveLength(2);
+  });
+
+  it("recognizes MCP snake-case edits without treating path+text universally as mutation", () => {
+    expect(classifyToolOperation({ path: "src/a.ts", old_str: "a", new_str: "b" }, "mcp__fs__str_replace")).toBe("mutate");
+    expect(classifyToolOperation({ path: "src/a.ts", text: "find x" }, "search")).not.toBe("mutate");
+  });
+
+  it("reconciles an error resolved across the incremental cache boundary", () => {
+    const failed: LlmMessage[] = [
+      { role: "assistant", content: [{ type: "toolCall", id: "f", name: "bash", arguments: { command: "test" } }] },
+      { role: "toolResult", toolCallId: "f", isError: true, content: [{ type: "text", text: "test failed" }] },
+    ];
+    const retry: LlmMessage[] = [
+      { role: "assistant", content: [{ type: "toolCall", id: "s", name: "bash", arguments: { command: "test" } }] },
+      { role: "toolResult", toolCallId: "s", content: [{ type: "text", text: "passed" }] },
+    ];
+    const base = extractStructured(failed, PROFILES.balanced);
+    const index = buildToolCallIndex(retry);
+    const merged = mergeExtractions(base, extractStructured(retry, PROFILES.balanced, index), failed.length, retry, index);
+    expect(merged.errors[0].resolved).toBe(true);
+  });
+});
+
+describe("adversarial planning and safety", () => {
+  it("counts tool-only messages in both live-tail and batch planning", () => {
+    const estimator = makeTokenEstimator("openai", "test");
+    const toolMessages: LlmMessage[] = Array.from({ length: 100 }, (_, index) => ({
+      role: "assistant", content: [{ type: "toolCall", id: "w" + index, name: "write", arguments: { path: "src/f" + index + ".ts", content: "x".repeat(10_000) } }],
+    }));
+    expect(chunkLlmMessages(toolMessages, [], PROFILES.balanced, estimator)[0].tokenEstimate).toBeGreaterThan(1000);
+
+    const branch = toolMessages.flatMap((message, index) => [
+      { type: "message", id: "a" + index, parentId: index ? "r" + (index - 1) : null, timestamp: new Date().toISOString(), message },
+      { type: "message", id: "r" + index, parentId: "a" + index, timestamp: new Date().toISOString(), message: { role: "toolResult", toolCallId: "w" + index, content: [{ type: "text", text: "ok" }] } },
+    ]);
+    const window = resolveCompactionWindow({ ctx: { getContextUsage: () => ({ tokens: 100_000 }), model: { contextWindow: 120_000 }, sessionManager: { getBranch: () => branch, getSessionId: () => "s" } }, profileCfg: { keepRecentTokens: 20_000 }, estimator } as any);
+    expect(window!.accTokens).toBeGreaterThanOrEqual(20_000);
+  });
+
+  it("enforces the call budget at the shared LLM seam", async () => {
+    const services = createServices({
+      budget: new BudgetGuard(1),
+      llm: { complete: async () => ({ role: "assistant", content: [{ type: "text", text: "ok" }], usage: { input: 1, output: 1 } }) as any },
+    });
+    const args = [{ id: "m", provider: "openai" } as any, { messages: [] } as any, {}, services] as const;
+    await trackedComplete("single-pass", ...args);
+    expect(() => services.budget.reserveCall()).toThrow(BudgetExceededError);
+  });
+
+  it("redacts secrets recursively and preserves loop overrides", () => {
+    const secret = "AKIAABCDEFGHIJKLMNOP";
+    expect(new SecretScrubber().scrubValue({ nested: { secret } }).value.nested.secret).not.toContain(secret);
+    const loop: OpenLoop = { id: "old", type: "follow-up", priority: "normal", status: "open", summary: "Finish auth", files: [] };
+    const overrides = upsertLoopOverride([], loop, { pinned: true, priority: "critical" });
+    const applied = applyLoopOverrides([{ ...loop, id: "new" }], overrides);
+    expect(applied[0].priority).toBe("critical");
+  });
+
+  it("observes online damage only after activation", () => {
+    const monitor = new OnlineDamageMonitor();
+    const message: LlmMessage = { role: "assistant", content: [{ type: "toolCall", id: "r", name: "read", arguments: { path: "src/a.ts" } }] };
+    expect(monitor.observe("s", message)).toBeNull();
+    monitor.activate("s", "p", { modifiedFiles: ["src/a.ts"], readFiles: [], topics: [], method: "eesv" } as any);
+    expect(monitor.observe("s", message)?.report.damageScore).toBeGreaterThan(0);
+  });
+});

--- a/test/eval.test.ts
+++ b/test/eval.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from "bun:test";
 import { extractStructured, extractOpenLoops } from "../src/utils/extraction.ts";
 import { buildCompactionState, computeDelta } from "../src/utils/state.ts";
-import { verifySummary } from "../src/phases/verify.ts";
+import { verifySummary, formatVerificationGap } from "../src/phases/verify.ts";
 import { PROFILES } from "../src/constants.ts";
 import type { LlmMessage, StructuredExtraction, CompactionState } from "../src/types.ts";
 
@@ -292,7 +292,7 @@ describe("Fabrication Safety", () => {
 
     const result = verifySummary(fabricatedSummary, extraction);
     expect(result.ok).toBe(false);
-    expect(result.gaps.some(g => g.includes("fabricated"))).toBe(true);
+    expect(result.gaps.some(g => formatVerificationGap(g).includes("fabricated"))).toBe(true);
   });
 
   it("verification accepts all real files", () => {
@@ -314,6 +314,6 @@ describe("Fabrication Safety", () => {
     ].join("\n");
 
     const result = verifySummary(goodSummary, extraction);
-    expect(result.gaps.some(g => g.includes("fabricated"))).toBe(false);
+    expect(result.gaps.some(g => formatVerificationGap(g).includes("fabricated"))).toBe(false);
   });
 });

--- a/test/extraction-context.test.ts
+++ b/test/extraction-context.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { buildExtractionContext, preProcessSummaries } from "../src/utils/helpers.ts";
+import type { StructuredExtraction } from "../src/types.ts";
+
+function extraction(): StructuredExtraction {
+  return {
+    modifiedFiles: [], readFiles: [], deletedFiles: [], mediaAttachments: [],
+    errors: [
+      { index: 1, tool: "bash", message: "test failed", retryAttempted: false, resolved: false },
+      { index: 2, tool: "bash", message: "test failed", retryAttempted: false, resolved: false },
+      { index: 3, tool: "bash", message: "test failed", retryAttempted: false, resolved: false },
+    ],
+    decisions: [
+      { index: 1, type: "implicit", summary: "Use TypeScript" },
+      { index: 2, type: "implicit", summary: "Use TypeScript" },
+    ],
+    constraints: [], topics: [], timeline: [], mainGoal: null,
+    lastUserMessages: [], lastErrors: [], messageCount: 4,
+  };
+}
+
+describe("buildExtractionContext", () => {
+  it("deduplicates repeated facts and preserves their frequency", () => {
+    const context = buildExtractionContext(extraction());
+    expect(context.match(/test failed/g)).toHaveLength(1);
+    expect(context).toContain("test failed ×3");
+    expect(context.match(/Use TypeScript/g)).toHaveLength(1);
+    expect(context).toContain("Use TypeScript ×2");
+  });
+});
+
+describe("focus-weighted topic budgets", () => {
+  it("allocates more assembly budget to the focused topic", () => {
+    const result = preProcessSummaries([
+      { topic: "auth", startIndex: 0, endIndex: 1, summary: "JWT auth", keyDecisions: [], filesModified: ["src/auth.ts"], filesRead: [], priority: "normal" },
+      { topic: "billing", startIndex: 2, endIndex: 3, summary: "invoice UI", keyDecisions: [], filesModified: ["src/billing.ts"], filesRead: [], priority: "normal" },
+    ], 2000, "auth");
+    const budgets = [...result.text.matchAll(/Segment \d+: ([^\n]+)[\s\S]*?Budget: ~(\d+) tokens/g)]
+      .map(match => ({ topic: match[1], budget: Number(match[2]) }));
+    expect(budgets.find(item => item.topic === "auth")!.budget)
+      .toBeGreaterThan(budgets.find(item => item.topic === "billing")!.budget);
+  });
+});

--- a/test/extraction.test.ts
+++ b/test/extraction.test.ts
@@ -94,6 +94,21 @@ describe("trackFileOps", () => {
     expect(ops.modified.map(f => f.path).sort()).toEqual(["/tmp/a.ts", "/tmp/b.ts", "/tmp/c.ts", "/tmp/d.ts", "/tmp/e.ts", "/tmp/f.ts"]);
   });
 
+  it("detects MCP edit aliases without treating generic path + text as a write", () => {
+    const msgs: LlmMessage[] = [
+      { role: "assistant", content: [
+        { type: "toolCall", id: "1", name: "mcp__filesystem__edit_file", arguments: { target_file: "/tmp/a.ts", old_str: "a", new_str: "b" } },
+        { type: "toolCall", id: "2", name: "read_text_file", arguments: { absolute_path: "/tmp/b.ts", text: "display mode" } },
+      ] },
+      { role: "toolResult", toolCallId: "1", content: "edited" },
+      { role: "toolResult", toolCallId: "2", content: "content" },
+    ];
+
+    const ops = trackFileOps(msgs);
+    expect(ops.modified.map(file => file.path)).toEqual(["/tmp/a.ts"]);
+    expect(ops.read).toEqual(["/tmp/b.ts"]);
+  });
+
   it("ignores no-op edits", () => {
     const msgs: LlmMessage[] = [
       { role: "assistant", content: [{ type: "toolCall", id: "1", name: "edit", arguments: { path: "/tmp/x.ts", oldText: "a", newText: "b" } }] },

--- a/test/file-needles.test.ts
+++ b/test/file-needles.test.ts
@@ -16,6 +16,8 @@
 import { describe, it, expect } from "bun:test";
 import {
   buildPathNeedles,
+  buildUniquePathNeedles,
+  isKnownPathReference,
   GENERIC_BASENAMES,
   MIN_BARE_BASENAME_LEN,
 } from "../src/utils/file-needles.ts";
@@ -87,6 +89,23 @@ describe("buildPathNeedles — short basename gate", () => {
   it("keeps long, non-generic basenames", () => {
     const needles = buildPathNeedles("src/utils/file-needles.ts");
     expect(needles).toContain("file-needles.ts");
+  });
+});
+
+describe("buildUniquePathNeedles", () => {
+  it("drops a shared basename and keeps the shortest unique suffix", () => {
+    const paths = ["packages/api/src/auth.ts", "packages/web/src/auth.ts"];
+    expect(buildUniquePathNeedles(paths[0], paths)).toEqual(["api/src/auth.ts", "packages/api/src/auth.ts"]);
+    expect(buildUniquePathNeedles(paths[1], paths)).toEqual(["web/src/auth.ts", "packages/web/src/auth.ts"]);
+  });
+
+  it("normalizes Windows separators", () => {
+    expect(buildUniquePathNeedles("src\\auth.ts", ["src/auth.ts"])).toContain("src/auth.ts");
+  });
+
+  it("recognizes a suffix reference to a known path", () => {
+    expect(isKnownPathReference("api/src/auth.ts", ["packages/api/src/auth.ts"])).toBe(true);
+    expect(isKnownPathReference("src/missing.ts", ["packages/api/src/auth.ts"])).toBe(false);
   });
 });
 

--- a/test/loops-ui.test.ts
+++ b/test/loops-ui.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { showOpenLoopsUI } from "../src/ui/overlays.ts";
+import { applyLoopOverrides } from "../src/utils/state.ts";
+import type { OpenLoop } from "../src/types.ts";
+
+const loop: OpenLoop = {
+  id: "loop-1", type: "follow-up", priority: "normal", status: "open",
+  summary: "Finish authentication tests", files: ["src/auth.ts"],
+};
+
+describe("showOpenLoopsUI", () => {
+  it("persists a resolve action through a typed override", async () => {
+    const answers = ["1. [open/normal] Finish authentication tests", "Resolve", "Done"];
+    const ctx = { ui: { select: async () => answers.shift() } } as any;
+    const overrides = await showOpenLoopsUI(ctx, [loop], []);
+    expect(overrides).not.toBeNull();
+    expect(applyLoopOverrides([loop], overrides!)[0].status).toBe("resolved");
+  });
+
+  it("supports pinning a loop", async () => {
+    const answers = ["1. [open/normal] Finish authentication tests", "Pin", "Done"];
+    const ctx = { ui: { select: async () => answers.shift() } } as any;
+    const overrides = await showOpenLoopsUI(ctx, [loop], []);
+    expect(overrides?.[0].pinned).toBe(true);
+  });
+});

--- a/test/pipeline-integration.test.ts
+++ b/test/pipeline-integration.test.ts
@@ -37,6 +37,7 @@ import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { TieredRc } from "../src/app/run-context.ts";
 import type { LlmMessage } from "../src/types.ts";
 import { createServices } from "../src/infra/services.ts";
+import { makeTokenEstimator } from "../src/utils/tokens.ts";
 
 /**
  * Build a TieredRc with the minimum fields synthesizeConversation +
@@ -93,6 +94,7 @@ function makeTieredRc(messages: LlmMessage[]): TieredRc {
       singlePassMaxTokens: 50000, batchMaxTokens: 8000,
       summaryBudgetTokens: 2000, chunkTokenBudget: 4000, keepRecentTokens: 10000,
     },
+    estimator: makeTokenEstimator("openai", "gpt-5", services.tokenCalibration),
     providerCaps: {
       maxOutputTokens: 8192, supportsTools: true as boolean | "probe",
       jsonReliability: "high", instructionFollowing: "high",
@@ -165,7 +167,7 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
     const synthesized = await summarizeConversation(extracted);
     expect(synthesized.finalSummary).toContain("##");
     expect(synthesized.method).toBe("single-pass");
-    expect(synthesized.llmCalls).toBeGreaterThan(0);
+    expect(synthesized.llmCalls).toBe(callCount);
     expect(callCount).toBeGreaterThan(0);
   });
 
@@ -193,6 +195,6 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
     // failure cleanly.
     expect(synthesized.method).toBe("heuristic");
     expect(synthesized.finalSummary.length).toBeGreaterThan(0);
-    expect(synthesized.llmCalls).toBe(0);
+    expect(synthesized.llmCalls).toBe(1);
   });
 });

--- a/test/pruning.test.ts
+++ b/test/pruning.test.ts
@@ -46,6 +46,61 @@ describe("pruneRedundant", () => {
     const result = pruneRedundant(msgs);
     expect(result.prunedCount).toBeGreaterThan(0);
     expect(result.reasons.some(r => r.reason.includes("Duplicate file reads"))).toBe(true);
+    expect(result.messages.some(message => message.toolCallId === "r1")).toBe(false);
+    expect(result.messages.some(message => message.toolCallId === "r2")).toBe(true);
+  });
+
+  it("does not collapse read and grep calls for the same path", () => {
+    const msgs: LlmMessage[] = [
+      makeMsg("user", "inspect a.ts"),
+      makeAssistantWithToolCall("r1", "read", { path: "a.ts" }),
+      makeToolResult("r1", "file content"),
+      makeAssistantWithToolCall("g1", "grep", { path: "a.ts", pattern: "foo" }),
+      makeToolResult("g1", "foo:1"),
+    ];
+
+    const result = pruneRedundant(msgs);
+    expect(result.messages.filter(message => message.role === "toolResult").map(message => message.toolCallId)).toEqual(["r1", "g1"]);
+  });
+
+  it("does not collapse grep calls with different patterns", () => {
+    const msgs: LlmMessage[] = [
+      makeMsg("user", "search a.ts"),
+      makeAssistantWithToolCall("g1", "grep", { path: "a.ts", pattern: "foo" }),
+      makeToolResult("g1", "foo:1"),
+      makeAssistantWithToolCall("g2", "grep", { pattern: "bar", path: "a.ts" }),
+      makeToolResult("g2", "bar:2"),
+    ];
+
+    const result = pruneRedundant(msgs);
+    expect(result.messages.filter(message => message.role === "toolResult")).toHaveLength(2);
+  });
+
+  it("does not collapse reads with different offsets or limits", () => {
+    const msgs: LlmMessage[] = [
+      makeMsg("user", "read chunks"),
+      makeAssistantWithToolCall("r1", "read", { path: "a.ts", offset: 1, limit: 20 }),
+      makeToolResult("r1", "first chunk"),
+      makeAssistantWithToolCall("r2", "read", { limit: 20, path: "a.ts", offset: 21 }),
+      makeToolResult("r2", "second chunk"),
+    ];
+
+    const result = pruneRedundant(msgs);
+    expect(result.messages.filter(message => message.role === "toolResult")).toHaveLength(2);
+  });
+
+  it("collapses identical reads despite argument key order", () => {
+    const msgs: LlmMessage[] = [
+      makeMsg("user", "read twice"),
+      makeAssistantWithToolCall("r1", "functions.read", { path: "a.ts", offset: 1, limit: 20 }),
+      makeToolResult("r1", "first"),
+      makeAssistantWithToolCall("r2", "read", { limit: 20, offset: 1, path: "a.ts" }),
+      makeToolResult("r2", "second"),
+    ];
+
+    const result = pruneRedundant(msgs);
+    expect(result.messages.some(message => message.toolCallId === "r1")).toBe(false);
+    expect(result.messages.some(message => message.toolCallId === "r2")).toBe(true);
   });
 
   it("preserves an unrelated edit beside a duplicate read", () => {

--- a/test/scrub.test.ts
+++ b/test/scrub.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { SecretScrubber } from "../src/domain/scrub.ts";
+import { createServices } from "../src/infra/services.ts";
+import { trackedComplete } from "../src/utils/cache.ts";
+
+describe("SecretScrubber", () => {
+  it("redacts high-confidence credentials and is idempotent", () => {
+    const source = [
+      "AWS=AKIAABCDEFGHIJKLMNOP",
+      "token=abcdefghijklmnopqrstuvwxyz123456",
+      "Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456",
+      "jwt eyJabcdefghijk.abcdefghijklmnop.abcdefghijklmnop",
+    ].join("\n");
+    const scrubber = new SecretScrubber(true, false);
+    const once = scrubber.scrubText(source).value;
+    const twice = scrubber.scrubText(once).value;
+    expect(once).not.toContain("AKIAABCDEFGHIJKLMNOP");
+    expect(once).not.toContain("abcdefghijklmnopqrstuvwxyz123456");
+    expect(twice).toBe(once);
+  });
+
+  it("does not redact benign short lookalikes", () => {
+    const result = new SecretScrubber(true, false).scrubText("sk-example and token=userToken and version 7.20.0").value;
+    expect(result).toBe("sk-example and token=userToken and version 7.20.0");
+  });
+
+  it("keeps PII disabled by default and supports opt-in", () => {
+    const text = "Contact dev@example.com";
+    expect(new SecretScrubber(true, false).scrubText(text).value).toContain("dev@example.com");
+    expect(new SecretScrubber(true, true).scrubText(text).value).not.toContain("dev@example.com");
+  });
+
+  it("scrubs nested tool-call arguments without mutating the source", () => {
+    const source = { messages: [{ content: [{ type: "toolCall", arguments: { token: "ghp_abcdefghijklmnopqrstuvwxyz1234567890" } }] }] };
+    const result = new SecretScrubber().scrubValue(source).value;
+    expect(result.messages[0].content[0].arguments.token).toContain("REDACTED");
+    expect(source.messages[0].content[0].arguments.token).toContain("ghp_");
+  });
+});
+
+describe("trackedComplete secret boundary", () => {
+  it("sends only scrubbed request content to the provider", async () => {
+    let observed = "";
+    const services = createServices({
+      scrubber: new SecretScrubber(true, false),
+      llm: {
+        complete: async (_model, context) => {
+          observed = JSON.stringify(context);
+          return { role: "assistant", content: [{ type: "text", text: "ok" }], usage: { input: 1, output: 1 }, stopReason: "stop" } as any;
+        },
+      },
+    });
+    await trackedComplete(
+      "single-pass",
+      { id: "test", provider: "openai" } as any,
+      { messages: [{ role: "user", content: [{ type: "text", text: "token=abcdefghijklmnopqrstuvwxyz123456" }] }] } as any,
+      {},
+      services,
+    );
+    expect(observed).toContain("REDACTED");
+    expect(observed).not.toContain("abcdefghijklmnopqrstuvwxyz123456");
+  });
+});

--- a/test/semantic-compact.test.ts
+++ b/test/semantic-compact.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { parseExplorationReport } from "../src/phases/explore";
-import { verifySummary } from "../src/phases/verify";
+import { verifySummary, formatVerificationGap } from "../src/phases/verify";
 import type { LlmMessage, ProfileConfig, StructuredExtraction } from "../src/types";
 import { extractStructured } from "../src/utils/extraction";
 import { estimateTokens } from "../src/utils/tokens";
@@ -111,7 +111,7 @@ describe("verifySummary", () => {
 
     const result = verifySummary(summary, extraction);
     expect(result.ok).toBe(false);
-    expect(result.gaps.some(gap => gap.includes("Missing modified file"))).toBe(true);
+    expect(result.gaps.some(gap => formatVerificationGap(gap).includes("Missing modified file"))).toBe(true);
     expect(result.score).toBeLessThan(100);
   });
 });

--- a/test/services.test.ts
+++ b/test/services.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, beforeEach } from "bun:test";
 import {
-  ToolSupportCache, MetricsSink, ExtractionCacheStats,
+  ToolSupportCache, MetricsSink, ExtractionCacheStats, BudgetGuard, BudgetExceededError,
   createServices, getDefaultServices, resetDefaultServices, setDefaultServices,
 } from "../src/infra/services.ts";
 import { getMetricsSummary, trackedComplete } from "../src/utils/cache.ts";
@@ -70,6 +70,25 @@ describe("MetricsSink", () => {
     // implementation detail we deliberately don't lock down — we only assert
     // the bound.
     expect(sink.snapshot().length).toBeLessThanOrEqual(10);
+  });
+});
+
+describe("BudgetGuard", () => {
+  it("reserves calls atomically and rejects the first call over budget", () => {
+    const guard = new BudgetGuard(2);
+    guard.reserveCall();
+    guard.reserveCall();
+    expect(() => guard.reserveCall()).toThrow(BudgetExceededError);
+    expect(guard.reason()).toBe("calls");
+    expect(guard.callCount()).toBe(2);
+  });
+
+  it("rejects calls after the latency deadline with a fake clock", () => {
+    let now = 100;
+    const guard = new BudgetGuard(0, 5000, { now: () => now });
+    now = 5100;
+    expect(() => guard.reserveCall()).toThrow("latency budget exhausted");
+    expect(guard.reason()).toBe("latency");
   });
 });
 

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { extractOpenLoops } from "../src/utils/extraction.ts";
-import { buildCompactionState, injectOpenLoopsSection, extractNextActions, extractCriticalContext, computeDelta, formatDeltaSection, hasDeltaChanges, injectDeltaSection, saveCompactionState, loadCompactionState } from "../src/utils/state.ts";
+import { buildCompactionState, injectOpenLoopsSection, extractNextActions, extractCriticalContext, computeDelta, formatDeltaSection, hasDeltaChanges, injectDeltaSection, saveCompactionState, loadCompactionState, applyLoopOverrides, upsertLoopOverride } from "../src/utils/state.ts";
 import type { LlmMessage, StructuredExtraction, OpenLoop, ExplorationReport, CompactionState } from "../src/types.ts";
 
 function makeExtraction(partial: Partial<StructuredExtraction> = {}): StructuredExtraction {
@@ -103,6 +103,34 @@ describe("extractOpenLoops", () => {
   });
 });
 
+describe("loop overrides", () => {
+  const loops: OpenLoop[] = [
+    { id: "loop-1", type: "follow-up", priority: "normal", status: "open", summary: "Finish auth", files: ["src/auth.ts"] },
+    { id: "loop-2", type: "blocked", priority: "high", status: "open", summary: "Unblock billing", files: [] },
+  ];
+
+  it("applies status and priority overrides", () => {
+    let overrides = upsertLoopOverride([], loops[0], { status: "resolved", priority: "critical" });
+    const result = applyLoopOverrides(loops, overrides);
+    expect(result[0].status).toBe("resolved");
+    expect(result[0].priority).toBe("critical");
+  });
+
+  it("never applies an override to a different loop that reused the same positional id", () => {
+    const overrides = upsertLoopOverride([], loops[0], { status: "resolved" });
+    const unrelated: OpenLoop = { ...loops[1], id: loops[0].id };
+    expect(applyLoopOverrides([unrelated], overrides)[0].status).toBe("open");
+  });
+
+  it("matches regenerated ids through the normalized summary key and sorts pins first", () => {
+    const overrides = upsertLoopOverride([], loops[0], { pinned: true });
+    const regenerated = [loops[1], { ...loops[0], id: "loop-new" }];
+    const result = applyLoopOverrides(regenerated, overrides);
+    expect(result[0].id).toBe("loop-new");
+    expect(result[0].summary).toBe("Finish auth");
+  });
+});
+
 describe("buildCompactionState", () => {
   it("builds full state from extraction", () => {
     const extraction = makeExtraction({
@@ -156,6 +184,17 @@ describe("injectOpenLoopsSection", () => {
     ];
     const result = injectOpenLoopsSection(summary, loops);
     expect(result).toContain("## Open Loops");
+  });
+
+  it("preserves an H3-only summary while injecting", () => {
+    const summary = "### Goal\nBuild app\n### Next Steps\n1. Write tests\n";
+    const loops: OpenLoop[] = [
+      { id: "loop-1", type: "follow-up", priority: "normal", status: "open", summary: "add tests", files: [] },
+    ];
+    const result = injectOpenLoopsSection(summary, loops);
+    expect(result).toContain("Build app");
+    expect(result).toContain("1. Write tests");
+    expect(result.indexOf("## Open Loops")).toBeLessThan(result.indexOf("## Next Steps"));
   });
 
   it("returns unchanged if no loops", () => {

--- a/test/summary-parse.test.ts
+++ b/test/summary-parse.test.ts
@@ -19,31 +19,34 @@ describe("parseSummary", () => {
     ]);
   });
 
-  it("tolerates heading drift like # Goal or Goals:", () => {
-    // Both H1 and H2 are treated as top-level section starts so a model that
-    // emits `# Goal` or `## Goals` ends up in the same `goal` bucket. H3 is
-    // deliberately not promoted (see below).
-    const md = "# Goal\nA\n## Goals\nB\n";
-    const parsed = parseSummary(md);
-    expect(parsed.sections.filter(s => s.kind === "goal").length).toBe(2);
+  it("starts sections for H1/H2 and merges recognized aliases", () => {
+    const parsed = parseSummary("# Goal\nA\n## Goals\nB\n## Done\nC\n");
+    expect(parsed.sections.map(s => s.kind)).toEqual(["goal", "unknown"]);
+    expect(parsed.sections[0].body).toBe("A\nB");
   });
 
-  it("keeps H3 sub-headings inside the parent section body", () => {
-    // Earlier versions promoted H3 to top level which flattened the
-    // Progress -> {Done, In Progress, Blocked} structure into 4 unrelated
-    // sections and left Progress empty. We now keep H3 inside the body so
-    // verification + delta paths can rely on Progress holding the whole block.
-    const md = "## Progress\n### Done\n- a\n### In Progress\n- b\n## Files Modified\n- f.ts\n";
+  it("starts recognized H3 sections, including an H3-only summary", () => {
+    const parsed = parseSummary("### Goal\nBuild it\n### Critical Context\n- Keep this\n### Next Steps\n1. Test it\n");
+    expect(parsed.sections.map(s => s.kind)).toEqual(["goal", "critical-context", "next-steps"]);
+    expect(findSection(parsed, "goal")?.body).toBe("Build it");
+  });
+
+  it("keeps unknown H3 progress subsections inside the parent body", () => {
+    const md = "## Progress\n### Done\n- a\n### In Progress\n- b\n### Blocked\n- c\n## Files Modified\n- f.ts\n";
     const parsed = parseSummary(md);
     expect(parsed.sections.map(s => s.kind)).toEqual(["progress", "files-modified"]);
-    const progressBody = parsed.sections[0].body;
-    expect(progressBody).toContain("### Done");
-    expect(progressBody).toContain("### In Progress");
-    expect(progressBody).toContain("- a");
-    expect(progressBody).toContain("- b");
+    expect(parsed.sections[0].body).toBe("### Done\n- a\n### In Progress\n- b\n### Blocked\n- c");
   });
 
-  it("treats unrelated headings as unknown", () => {
+  it("merges duplicate canonical kinds, dedupes exact lines, and keeps unknown sections separate", () => {
+    const parsed = parseSummary("## Goal\nShared\n- first\n## Custom\none\n### Goal\nShared\n- second\n## Custom\ntwo\n");
+    expect(parsed.sections.map(s => s.kind)).toEqual(["goal", "unknown", "unknown"]);
+    expect(parsed.sections[0].body).toBe("Shared\n- first\n- second");
+    expect(parsed.sections[1].body).toBe("one");
+    expect(parsed.sections[2].body).toBe("two");
+  });
+
+  it("treats unrelated H1/H2 headings as unknown sections", () => {
     const parsed = parseSummary("## Some Other Heading\nbody");
     expect(parsed.sections[0].kind).toBe("unknown");
   });
@@ -138,5 +141,10 @@ describe("renderSummary", () => {
     const rendered = renderSummary(parsed, { canonicalHeadings: true });
     expect(rendered).toContain("## Goal");
     expect(rendered).toContain("## Next Steps");
+  });
+
+  it("round-trips H3-only summaries deterministically", () => {
+    const once = renderSummary(parseSummary("### Goal\nA\n### Next Steps\n- B\n"));
+    expect(renderSummary(parseSummary(once))).toBe(once);
   });
 });

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { estimateTokens, calibrateFromResponse, getProviderCaps } from "../src/utils/tokens.ts";
+import { estimateTokens, calibrateFromResponse, getProviderCaps, makeTokenEstimator, TokenCalibrationStore } from "../src/utils/tokens.ts";
 
 describe("estimateTokens", () => {
   it("estimates based on char length", () => {
@@ -18,6 +18,26 @@ describe("estimateTokens", () => {
 
   it("returns 0 for empty", () => {
     expect(estimateTokens("")).toBe(0);
+  });
+});
+
+describe("makeTokenEstimator", () => {
+  it("counts structured tool-call arguments", () => {
+    const estimator = makeTokenEstimator("openai", "test", new TokenCalibrationStore());
+    const textOnly = estimator.message({ role: "assistant", content: [{ type: "text", text: "ok" }] });
+    const withToolArgs = estimator.message({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "w1", name: "write", arguments: { path: "src/a.ts", content: "x".repeat(4000) } }],
+    });
+    expect(withToolArgs).toBeGreaterThan(textOnly + 500);
+  });
+
+  it("applies the run-scoped provider/model calibration", () => {
+    const store = new TokenCalibrationStore();
+    const before = makeTokenEstimator("openai", "model-a", store).text("x".repeat(1000));
+    store.calibrate(before, Math.floor(before / 2), "openai", "model-a");
+    const after = makeTokenEstimator("openai", "model-a", store).text("x".repeat(1000));
+    expect(after).toBeLessThan(before);
   });
 });
 

--- a/test/tool-semantics.test.ts
+++ b/test/tool-semantics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { classifyTool, extractToolPath } from "../src/domain/tool-semantics.ts";
+import { classifyTool, classifyToolOperation, extractToolPath, normalizeToolName } from "../src/domain/tool-semantics.ts";
 
 describe("classifyTool", () => {
   it("classifies path + content payload as mutates (name-agnostic)", () => {
@@ -10,6 +10,8 @@ describe("classifyTool", () => {
     expect(classifyTool({ path: "a.ts", edits: [{ oldText: "a", newText: "b" }] })).toBe("mutates");
     expect(classifyTool({ path: "a.ts", patch: "@@ diff @@" })).toBe("mutates");
     expect(classifyTool({ path: "a.ts", replacement: "y" })).toBe("mutates");
+    expect(classifyTool({ target_file: "a.ts", old_str: "x", new_str: "y" })).toBe("mutates");
+    expect(classifyTool({ file_uri: "file:///a.ts", old_string: "x", new_string: "y" })).toBe("mutates");
     expect(classifyTool({ path: "a.ts", content: "" })).toBe("mutates"); // empty-file write still mutates
   });
 
@@ -43,6 +45,28 @@ describe("classifyTool", () => {
   });
 });
 
+describe("classifyToolOperation", () => {
+  it("classifies the fine EESV operation taxonomy", () => {
+    expect(classifyToolOperation({ path: "a.ts" }, "functions.read")).toBe("read");
+    expect(classifyToolOperation({ path: "a.ts", pattern: "foo" }, "grep")).toBe("search");
+    expect(classifyToolOperation({ path: "src" }, "list_files")).toBe("list");
+    expect(classifyToolOperation({ absolute_path: "a.ts", old_string: "x", new_string: "y" }, "mcp__edit_file")).toBe("mutate");
+    expect(classifyToolOperation({ path: "a.ts" }, "delete_file")).toBe("delete");
+    expect(classifyToolOperation({ command: "bun test" }, "bash")).toBe("execute");
+    expect(classifyToolOperation({}, "ask_user")).toBe("unknown");
+  });
+
+  it("uses a mutation tool name only as a safe path + text tie-breaker", () => {
+    expect(classifyToolOperation({ path: "a.ts", text: "x" }, "read_text_file")).toBe("read");
+    expect(classifyToolOperation({ target_file: "a.ts", text: "x" }, "mcp__write_file")).toBe("mutate");
+    expect(classifyTool({ path: "a.ts", text: "x" })).toBe("accesses");
+  });
+
+  it("normalizes provider wrappers and separators", () => {
+    expect(normalizeToolName("functions.readFile")).toBe("read_file");
+  });
+});
+
 describe("extractToolPath", () => {
   it("returns the path across common key names", () => {
     expect(extractToolPath({ path: "a.ts" })).toBe("a.ts");
@@ -50,6 +74,9 @@ describe("extractToolPath", () => {
     expect(extractToolPath({ filePath: "a.ts" })).toBe("a.ts");
     expect(extractToolPath({ filename: "a.ts" })).toBe("a.ts");
     expect(extractToolPath({ file: "a.ts" })).toBe("a.ts");
+    expect(extractToolPath({ target_file: "a.ts" })).toBe("a.ts");
+    expect(extractToolPath({ file_uri: "file:///a.ts" })).toBe("file:///a.ts");
+    expect(extractToolPath({ absolute_path: "/a.ts" })).toBe("/a.ts");
   });
 
   it("returns undefined when no usable path is present", () => {

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
-import { verifySummary, patchDeterministic } from "../src/phases/verify.ts";
+import { verifySummary, patchDeterministic, formatVerificationGap } from "../src/phases/verify.ts";
+import { verifyAndPatch } from "../src/app/steps/verify.ts";
 import type { StructuredExtraction } from "../src/types.ts";
 
 function makeExtraction(partial: Partial<StructuredExtraction> = {}): StructuredExtraction {
@@ -54,7 +55,7 @@ Something
 `;
     const result = verifySummary(summary, extraction);
     expect(result.ok).toBe(false);
-    expect(result.gaps.some(g => g.includes("Auth.ts"))).toBe(true);
+    expect(result.gaps.some(g => formatVerificationGap(g).includes("Auth.ts"))).toBe(true);
     expect(result.score).toBeLessThan(100);
   });
 
@@ -73,7 +74,7 @@ Something
 `;
     const result = verifySummary(summary, extraction);
     expect(result.ok).toBe(false);
-    expect(result.gaps.some(g => g.includes("Syntax error"))).toBe(true);
+    expect(result.gaps.some(g => formatVerificationGap(g).includes("Syntax error"))).toBe(true);
   });
 
   it("detects missing high-confidence constraints", () => {
@@ -91,7 +92,7 @@ Something
 `;
     const result = verifySummary(summary, extraction);
     expect(result.ok).toBe(false);
-    expect(result.gaps.some(g => g.includes("constraint"))).toBe(true);
+    expect(result.gaps.some(g => formatVerificationGap(g).includes("constraint"))).toBe(true);
   });
 
   it("detects missing structure sections", () => {
@@ -99,8 +100,20 @@ Something
     const summary = "Just some random text without headers";
     const result = verifySummary(summary, extraction);
     expect(result.ok).toBe(false);
-    expect(result.gaps.some(g => g.includes("## Goal"))).toBe(true);
+    expect(result.gaps.some(g => formatVerificationGap(g).includes("## Goal"))).toBe(true);
     expect(result.score).toBeLessThan(100);
+  });
+
+  it("does not let one basename satisfy two monorepo paths", () => {
+    const extraction = makeExtraction({
+      modifiedFiles: [
+        { path: "packages/api/src/auth.ts", toolCalls: 1, lastModifiedIndex: 1 },
+        { path: "packages/web/src/auth.ts", toolCalls: 1, lastModifiedIndex: 2 },
+      ],
+    });
+    const summary = "## Goal\nRefactor auth\n## Progress\n- packages/api/src/auth.ts updated\n## Critical Context\n- none";
+    const result = verifySummary(summary, extraction);
+    expect(result.gaps.some(gap => gap.kind === "missing-file" && gap.path === "packages/web/src/auth.ts")).toBe(true);
   });
 
   it("penalizes potentially fabricated files", () => {
@@ -117,7 +130,24 @@ Build
 - none
 `;
     const result = verifySummary(summary, extraction);
-    expect(result.gaps.some(g => g.includes("fabricated"))).toBe(true);
+    expect(result.gaps.some(g => formatVerificationGap(g).includes("fabricated"))).toBe(true);
+  });
+});
+
+describe("verifyAndPatch", () => {
+  it("repairs a patchable high-score gap instead of skipping it", async () => {
+    const extraction = makeExtraction({ modifiedFiles: [{ path: "src/auth.ts", toolCalls: 1, lastModifiedIndex: 1 }] });
+    const result = await verifyAndPatch({
+      finalSummary: "## Goal\nBuild auth\n## Progress\n- setup\n## Critical Context\n- stable",
+      extraction,
+      flags: { autoTriggered: true },
+      notify: () => {},
+      vlog: () => {},
+    } as any);
+    expect(result.finalSummary).toContain("src/auth.ts");
+    expect(result.verificationProvenance.initialScore).toBe(95);
+    expect(result.verificationProvenance.deterministicPatched).toHaveLength(1);
+    expect(result.verificationScore).toBe(100);
   });
 });
 
@@ -127,8 +157,7 @@ describe("patchDeterministic", () => {
       modifiedFiles: [{ path: "/src/Auth.ts", toolCalls: 1, lastModifiedIndex: 2 }],
     });
     const summary = "## Goal\nBuild app\n## Files Modified\n- none\n## Critical Context\n- none";
-    const gaps = ["Missing modified file: /src/Auth.ts"];
-    const patched = patchDeterministic(summary, gaps, extraction);
+    const patched = patchDeterministic(summary, [{ kind: "missing-file", path: "/src/Auth.ts" }], extraction);
     expect(patched).toContain("/src/Auth.ts");
     expect(patched).toContain("## Files Modified");
   });
@@ -148,32 +177,29 @@ describe("patchDeterministic", () => {
     expect(patched).toContain("## Files Modified");
     expect(patched).toContain("/web/src/pages/sessions.tsx");
     expect(patched).toContain("## Progress");
-    expect(after.gaps.some(g => g.startsWith("Missing section:"))).toBe(false);
+    expect(after.gaps.some(g => g.kind === "missing-section")).toBe(false);
     expect(after.score).toBeGreaterThan(before.score);
   });
 
   it("injects missing errors into Critical Context section", () => {
     const extraction = makeExtraction({});
     const summary = "## Goal\nFix bug\n## Critical Context\n- none";
-    const gaps = ["Missing error: test failed at line 42"];
-    const patched = patchDeterministic(summary, gaps, extraction);
+    const patched = patchDeterministic(summary, [{ kind: "missing-error", message: "test failed at line 42" }], extraction);
     expect(patched).toContain("test failed");
   });
 
   it("injects missing decisions into Key Decisions section", () => {
     const extraction = makeExtraction({});
     const summary = "## Goal\nBuild\n## Key Decisions\n- none\n## Critical Context\n- none";
-    const gaps = ["Missing decision: Use React instead of Vue"];
-    const patched = patchDeterministic(summary, gaps, extraction);
+    const patched = patchDeterministic(summary, [{ kind: "missing-decision", summary: "Use React instead of Vue" }], extraction);
     expect(patched).toContain("Use React instead of Vue");
   });
 
-  it("appends other gaps as Verification Note", () => {
+  it("keeps non-deterministic findings as a Verification Note", () => {
     const extraction = makeExtraction({});
     const summary = "## Goal\nBuild\n## Critical Context\n- none";
-    const gaps = ["Main goal may be missing from summary"];
-    const patched = patchDeterministic(summary, gaps, extraction);
+    const patched = patchDeterministic(summary, [{ kind: "fabricated-file", ref: "src/fake.ts" }], extraction);
     expect(patched).toContain("Verification Note");
-    expect(patched).toContain("Main goal may be missing");
+    expect(patched).toContain("Potentially fabricated file: src/fake.ts");
   });
 });

--- a/test/window-boundary.test.ts
+++ b/test/window-boundary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { resolveCompactionWindow } from "../src/app/steps/window.ts";
 import type { PreparedRc } from "../src/app/run-context.ts";
 import type { SessionMessageEntry } from "../src/types.ts";
+import { makeTokenEstimator, TokenCalibrationStore } from "../src/utils/tokens.ts";
 
 function messageEntry(
   id: string,
@@ -28,6 +29,7 @@ function makePreparedRc(branch: SessionMessageEntry[], keepRecentTokens = 30_000
         getSessionId: () => "test-session",
       },
     },
+    estimator: makeTokenEstimator("openai", "test", new TokenCalibrationStore()),
     profileCfg: {
       keepRecentTokens,
       summaryBudgetTokens: 6_000,
@@ -115,6 +117,25 @@ describe("resolveCompactionWindow tool-result boundary", () => {
 
     expect(result).not.toBeNull();
     expect(result?.firstKeptId).toBe("m2-assistant-toolcall");
+  });
+
+  it("counts large tool-call arguments in the recent-tail budget", () => {
+    const branch: SessionMessageEntry[] = [];
+    for (let i = 0; i < 45; i++) {
+      branch.push(messageEntry("a" + i, i ? "r" + (i - 1) : null, {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "w" + i, name: "write", arguments: { path: "src/f" + i + ".ts", content: "x".repeat(2000) } }],
+      }));
+      branch.push(messageEntry("r" + i, "a" + i, {
+        role: "toolResult", toolCallId: "w" + i, content: [{ type: "text", text: "ok" }],
+      }));
+    }
+
+    const result = resolveCompactionWindow(makePreparedRc(branch, 20_000));
+
+    expect(result).not.toBeNull();
+    expect(branch.length - result!.keepFrom).toBeGreaterThan(50);
+    expect(result!.accTokens).toBeGreaterThanOrEqual(20_000);
   });
 
   it("does not emit a compaction if the first kept entry would still be a toolResult", () => {


### PR DESCRIPTION
## Summary
- harden canonical EESV parsing, tool semantics, token planning, cache reconciliation and mandatory verification repair
- add secret scrubbing, provenance, fail-closed approval, focus/call/latency controls and online damage feedback
- add persisted open-loop management and deterministic adversarial release gate
- redesign the public README for npm, GitHub and Pi package surfaces

## Validation
- 572/572 tests
- 67/67 adversarial gate
- typecheck + build
- latest Pi 0.80.7 compatibility
- npm pack dry-run
- diff-only independent code review; blocker fixed and regression covered

NPM publishing will be performed separately after the Git tag is pushed.