### PR TITLE
release: v7.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [Unreleased]
+## [7.22.0] - 2026-07-15
 
 ### Added
-- Independent `summaryThinkingLevel` and `segmentationThinkingLevel` settings control per-phase reasoning while preserving provider defaults when unset.
+- Independent `summaryThinkingLevel` and `segmentationThinkingLevel` settings control per-phase reasoning, including `max`, while preserving provider defaults when unset.
 
 ## [7.21.0] - 2026-07-15
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "7.21.0",
+  "version": "7.22.0",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "7.21.0";
+export const VERSION = "7.22.0";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =


### PR DESCRIPTION
## Summary
- release pi-smart-compact 7.22.0
- add independent summary and segmentation reasoning levels, including `max`
- preserve provider defaults when unset and route configured reasoning through pi-ai's generic option mapper
- snapshot reasoning configuration per compaction run

## Validation
- 575/575 tests
- 67/67 adversarial gate cases across 6 suites
- typecheck + build
- latest Pi 0.80.7 compatibility
- npm pack dry-run for 7.22.0

NPM publishing and the GitHub release will be performed after the release commit is merged and tagged.
