### PR TITLE
fix: correct real-session compaction evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 No changes yet.
 
+## [8.0.0-rc.3] - 2026-08-07
+
+### Fixed
+
+- Token savings now compare the normalized prefix actually replaced with its replacement summary instead of subtracting a differently scaled raw tail from Pi's measured context. Real tool-heavy sessions no longer report false `0%` savings, and one run's estimator stays stable while shared calibration learns for later runs.
+- Verification grounds file references already present in compacted prose/tool evidence, deduplicates repeated fabricated-file findings, and ignores successful or expected-exit `rg`/`grep` output instead of persisting it as an unresolved error.
+
 ## [8.0.0-rc.2] - 2026-08-06
 
 ### Fixed

--- a/docs/MIGRATING_TO_V8.md
+++ b/docs/MIGRATING_TO_V8.md
@@ -1,6 +1,6 @@
 # Migrating from v7 to v8
 
-This guide applies to `8.0.0-rc.2`. The release candidate is prepared but is
+This guide applies to `8.0.0-rc.3`. The release candidate is prepared but is
 not published or deployed by repository validation.
 
 ## Compatibility

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -8,7 +8,7 @@ Use this checklist before publishing `pi-smart-compact`.
 
 ## 1. Prepare the candidate
 
-- [ ] Choose a SemVer version. Use a prerelease such as `8.0.0-rc.2` until the
+- [ ] Choose a SemVer version. Use a prerelease such as `8.0.0-rc.3` until the
       stable/canary gates pass.
 - [ ] Update `package.json`; run `bun run sync-version` for `src/constants.ts`.
 - [ ] Move shipped notes from `[Unreleased]` into the dated version in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "8.0.0-rc.2",
+  "version": "8.0.0-rc.3",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/src/app/run-context.ts
+++ b/src/app/run-context.ts
@@ -160,6 +160,9 @@ export interface WindowedExt extends PreparedExt {
   keepFrom: number;
   toCompact: SessionMessageEntry[];
   firstKeptId: string;
+  /** Estimated tokens replaced by the summary, normalized to Pi's measured context. */
+  compactTokens: number;
+  /** Estimated retained-tail tokens, normalized to Pi's measured context. */
   accTokens: number;
 }
 export type WindowedRc = RcBase & WindowedExt;

--- a/src/app/steps/state.ts
+++ b/src/app/steps/state.ts
@@ -123,8 +123,10 @@ export function buildState(rc: VerifiedRc): StatedRc {
 
   const detModified = extraction.modifiedFiles.map(f => f.path);
   const detRead = extraction.readFiles;
-  const estimatedAfter = rc.estimator.text(summary) + rc.accTokens;
-  const tokensSaved = Math.max(0, rc.totalTokens - estimatedAfter);
+  // Compare the replaced prefix with its replacement summary. Subtracting an
+  // estimated retained tail from Pi's measured total mixes token scales when
+  // another context hook truncates tool output, producing false 0% savings.
+  const tokensSaved = Math.max(0, Math.min(rc.totalTokens, rc.compactTokens - rc.estimator.text(summary)));
 
   const details: SmartCompactDetails = {
     runId: rc.runId,

--- a/src/app/steps/window.ts
+++ b/src/app/steps/window.ts
@@ -74,9 +74,14 @@ export function resolveCompactionWindow(rc: PreparedRc): WindowedRc | null {
   keepFrom = guardToolCallBoundary(msgs, keepFrom);
 
   // Anchor/tool-call safety can move the boundary far earlier than the token
-  // walk selected. Recount the actual retained tail; keeping the stale ~20k
-  // estimate made metrics claim 100k+ savings while the context stayed full.
-  accTokens = rc.estimator.messages(msgs.slice(keepFrom).map(e => e.message as LlmMessage));
+  // walk selected. Recount both sides from the additive per-message estimates.
+  // Other context hooks may truncate tool payloads before the model sees them,
+  // so normalize an oversized raw estimate to Pi's measured context total.
+  const rawCompactTokens = messageTokens.slice(0, keepFrom).reduce((sum, tokens) => sum + tokens, 0);
+  const rawRetainedTokens = messageTokens.slice(keepFrom).reduce((sum, tokens) => sum + tokens, 0);
+  const messageScale = totalTokens > 0 && allMessageTokens > totalTokens ? totalTokens / allMessageTokens : 1;
+  const compactTokens = Math.round(rawCompactTokens * messageScale);
+  accTokens = Math.round(rawRetainedTokens * messageScale);
 
   if ((msgs[keepFrom]?.message as Record<string, unknown> | undefined)?.role === "toolResult") {
     return null;
@@ -109,7 +114,7 @@ export function resolveCompactionWindow(rc: PreparedRc): WindowedRc | null {
     sessionId: string; branch: unknown[]; msgs: SessionMessageEntry[];
     totalTokens: number; contextPercent: number; toolPercent: number;
     keepFrom: number; toCompact: SessionMessageEntry[]; firstKeptId: string;
-    accTokens: number;
+    compactTokens: number; accTokens: number;
   };
   out.sessionId = sessionId;
   out.branch = branch as unknown[];
@@ -120,6 +125,7 @@ export function resolveCompactionWindow(rc: PreparedRc): WindowedRc | null {
   out.keepFrom = keepFrom;
   out.toCompact = toCompact;
   out.firstKeptId = firstKeptId;
+  out.compactTokens = compactTokens;
   out.accTokens = accTokens;
   return advance<PreparedRc, WindowedRc>(out, "_windowed");
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "8.0.0-rc.2";
+export const VERSION = "8.0.0-rc.3";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -218,12 +218,12 @@ export function verifySummary(
   }
 
   const knownFiles = Array.from(new Set([
-    ...modifiedPaths, ...extraction.readFiles, ...extraction.deletedFiles,
+    ...modifiedPaths, ...extraction.readFiles, ...extraction.deletedFiles, ...(extraction.referencedFiles ?? []),
     ...(continuity?.modifiedFiles ?? []), ...(continuity?.readFiles ?? []), ...(continuity?.deletedFiles ?? []),
     ...(continuity?.unresolvedErrors ?? []).flatMap(error => error.files),
     ...(continuity?.openLoops ?? []).flatMap(loop => loop.files),
   ]));
-  for (const ref of extractFileRefs(summary)) {
+  for (const ref of new Set(extractFileRefs(summary))) {
     if (!isKnownPathReference(ref, knownFiles)) {
       gaps.push({ kind: "fabricated-file", ref });
       score -= 4;

--- a/src/types.ts
+++ b/src/types.ts
@@ -319,6 +319,8 @@ export interface StructuredExtraction {
   modifiedFiles: Array<{ path: string; toolCalls: number; lastModifiedIndex: number }>;
   readFiles: string[];
   deletedFiles: string[];
+  /** File paths grounded in compacted source evidence but not necessarily touched by a tool. */
+  referencedFiles?: string[];
   mediaAttachments?: MediaAttachment[];
   errors: Array<{ index: number; tool: string; message: string; retryAttempted: boolean; resolved: boolean }>;
   decisions: Array<{ index: number; type: "explicit" | "implicit"; summary: string; userResponse?: string }>;

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -339,6 +339,7 @@ export function mergeExtractions(
     modifiedFiles: [...modified.values()],
     readFiles: [...new Set([...base.readFiles, ...delta.readFiles])],
     deletedFiles: [...new Set([...base.deletedFiles, ...delta.deletedFiles])],
+    referencedFiles: [...new Set([...(base.referencedFiles ?? []), ...(delta.referencedFiles ?? [])])].slice(0, 200),
     mediaAttachments: [...(base.mediaAttachments ?? []), ...offsetMedia],
     errors: mergedErrors,
     decisions: [...base.decisions, ...offsetDecisions],

--- a/src/utils/extraction.ts
+++ b/src/utils/extraction.ts
@@ -9,6 +9,7 @@ import { estimateTokens } from "./tokens.ts";
 import { isToolCallBlock, isTextBlock } from "../utils/type-guards.ts";
 import { buildPathNeedles } from "./file-needles.ts";
 import { classifyToolOperation, extractToolPath } from "../domain/tool-semantics.ts";
+import { extractFileRefs } from "./file-ref-detect.ts";
 
 /** pi-toolkit truncation marker: content.slice(0, 20) + `…✂${content.length}` */
 export const TRUNCATE_RE = /…✂\d+$/;
@@ -169,6 +170,18 @@ export function trackFileOps(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): { modi
   };
 }
 
+function isBenignSearchResult(tc: { arguments: Record<string, unknown> }, result: string): boolean {
+  const command = typeof tc.arguments.command === "string"
+    ? tc.arguments.command
+    : typeof tc.arguments.cmd === "string" ? tc.arguments.cmd : "";
+  if (/[;\n]|\|\|/.test(command)) return false;
+  const segments = command.split("&&").map(segment => segment.trim()).filter(Boolean);
+  const searchOnly = segments.length > 0 && segments.every(segment => /^(?:rg|grep)\b/.test(segment));
+  if (!searchOnly || /(?:^|\n)(?:rg|grep):/m.test(result)) return false;
+  const exit = result.match(/Command exited with code (\d+)\s*$/i)?.[1];
+  return exit === undefined || exit === "1";
+}
+
 export function catalogErrors(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): StructuredExtraction["errors"] {
   const tcIdx = _tcIdx ?? buildToolCallIndex(msgs);
   const errors: StructuredExtraction["errors"] = [];
@@ -178,8 +191,11 @@ export function catalogErrors(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): Struc
     if (m.role !== "toolResult") continue;
     const tc = tcIdx.get(m.toolCallId ?? "");
 
+    const text = extractText(m.content);
+    if (tc && isBenignSearchResult(tc, text)) continue;
+
     if (m.isError) {
-      errors.push({ index: i, tool: tc?.name ?? "unknown", message: extractText(m.content).slice(0, TRUNC.ERROR_DETAIL), retryAttempted: false, resolved: false });
+      errors.push({ index: i, tool: tc?.name ?? "unknown", message: text.slice(0, TRUNC.ERROR_DETAIL), retryAttempted: false, resolved: false });
       continue;
     }
 
@@ -187,9 +203,8 @@ export function catalogErrors(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): Struc
     // Gated by argument shape, not by tool name, so it auto-covers shell-like
     // tools this code has never seen. Explicit m.isError is handled above.
     if (tc && classifyToolOperation(tc.arguments, tc.name) === "execute") {
-      const txt = extractText(m.content);
-      if (LIKELY_ERROR_RE.test(txt) && txt.length < ERROR_SCAN_MAX_LEN) {
-        errors.push({ index: i, tool: tc.name, message: txt.slice(0, TRUNC.MESSAGE), retryAttempted: false, resolved: false });
+      if (LIKELY_ERROR_RE.test(text) && text.length < ERROR_SCAN_MAX_LEN) {
+        errors.push({ index: i, tool: tc.name, message: text.slice(0, TRUNC.MESSAGE), retryAttempted: false, resolved: false });
       }
     }
   }
@@ -484,11 +499,13 @@ export function extractStructured(msgs: LlmMessage[], pc: ProfileConfig, precomp
   const topics = segmentTopicsHeuristic(msgs, pc, 20, tcIdx);
   const timeline = buildTimeline(msgs, errors);
   const mediaAttachments = extractMediaAttachments(msgs);
+  const referencedFiles = Array.from(new Set(msgs
+    .flatMap(message => extractFileRefs((JSON.stringify(message.content) ?? "").replace(/\\[nrt]/g, " "))))).slice(0, 200);
   const mainGoal = extractMainGoal(msgs);
   const lastUserMessages = msgs.filter(m => m.role === "user").slice(-5).map(m => extractText(m.content));
   const lastErrors = errors.slice(-3).map(e => e.message);
   return {
-    modifiedFiles: modified, readFiles: read, deletedFiles: deleted,
+    modifiedFiles: modified, readFiles: read, deletedFiles: deleted, referencedFiles,
     errors, decisions, constraints, topics, timeline, mediaAttachments,
     mainGoal, lastUserMessages, lastErrors, messageCount: msgs.length,
   };

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -181,7 +181,7 @@ const JSON_DENSITY_THRESHOLD = 0.05;
 /** Cap the density scan so a multi-MB conversation serialization can't pause the pipeline. */
 const JSON_DENSITY_SCAN_CAP = 8192;
 
-export function estimateTokens(text: string, provider?: string, model?: string, calibration = _fallbackCalibration): number {
+function estimateTokensAtFactor(text: string, provider: string | undefined, factor: number): number {
   const baseRatio = provider ? getProviderCaps(provider).tokenRatioEstimate : CHARS_PER_TOKEN;
   // JSON content has denser tokenization. The leading-brace check covers
   // per-message JSON tool results; the density fallback catches concatenations
@@ -205,8 +205,11 @@ export function estimateTokens(text: string, provider?: string, model?: string, 
   // over a multi-MB conversation serialization walks the whole string.
   const langSample = text.length > JSON_DENSITY_SCAN_CAP ? text.slice(0, JSON_DENSITY_SCAN_CAP) : text;
   const langPenalty = /[çğıöşüÇĞİÖŞÜ]/.test(langSample) ? 0.9 : 1.0;
-  const factor = calibration.get(provider, model);
   return Math.ceil((text.length / baseRatio) * jsonPenalty * langPenalty * factor);
+}
+
+export function estimateTokens(text: string, provider?: string, model?: string, calibration = _fallbackCalibration): number {
+  return estimateTokensAtFactor(text, provider, calibration.get(provider, model));
 }
 
 export function calibrateFromResponse(estimated: number, actual: number, provider?: string, model?: string, calibration = _fallbackCalibration): void {
@@ -229,7 +232,8 @@ export function makeTokenEstimator(
   model?: string,
   calibration: TokenCalibrationStore = _fallbackCalibration,
 ): TokenEstimator {
-  const text = (value: string) => estimateTokens(value, provider, model, calibration);
+  const factor = calibration.get(provider, model);
+  const text = (value: string) => estimateTokensAtFactor(value, provider, factor);
   const serializable = (message: Pick<LlmMessage, "role" | "content" | "toolCallId" | "toolName" | "isError">) => ({
     role: message.role,
     content: message.content,

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -187,6 +187,12 @@ describe("mergeExtractions — deduplication", () => {
     expect(merged.modifiedFiles[0].lastModifiedIndex).toBe(7); // 2 + 5
   });
 
+  it("deduplicates prose-grounded file references", () => {
+    const base = makeExtraction({ referencedFiles: ["a.ts", "b.ts"], messageCount: 5 });
+    const delta = makeExtraction({ referencedFiles: ["b.ts", "c.ts"], messageCount: 3 });
+    expect(mergeExtractions(base, delta, 5).referencedFiles).toEqual(["a.ts", "b.ts", "c.ts"]);
+  });
+
   it("deduplicates readFiles", () => {
     const base = makeExtraction({ readFiles: ["a.ts", "b.ts"], messageCount: 5 });
     const delta = makeExtraction({ readFiles: ["b.ts", "c.ts"], messageCount: 3 });

--- a/test/extraction.test.ts
+++ b/test/extraction.test.ts
@@ -130,6 +130,30 @@ describe("catalogErrors", () => {
     expect(errs[0].tool).toBe("bash");
   });
 
+  it("ignores rg/grep exit 1 when every chained command is a search", () => {
+    const msgs: LlmMessage[] = [
+      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "bash", arguments: { command: "rg missing src && grep absent README.md" } }] },
+      { role: "toolResult", toolCallId: "1", isError: true, content: "(no output)\n\nCommand exited with code 1" },
+    ];
+    expect(catalogErrors(msgs)).toEqual([]);
+  });
+
+  it("ignores a successful search whose piped output was truncated and marked as an error", () => {
+    const msgs: LlmMessage[] = [
+      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "bash", arguments: { command: "rg runId src | head -n 120" } }] },
+      { role: "toolResult", toolCallId: "1", isError: true, content: "src/index.ts:1: runId\n... [truncated 4805 chars] ..." },
+    ];
+    expect(catalogErrors(msgs)).toEqual([]);
+  });
+
+  it("does not hide a failing command chained after a search", () => {
+    const msgs: LlmMessage[] = [
+      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "bash", arguments: { command: "rg present src && bun test" } }] },
+      { role: "toolResult", toolCallId: "1", isError: true, content: "1 test failed\n\nCommand exited with code 1" },
+    ];
+    expect(catalogErrors(msgs)).toHaveLength(1);
+  });
+
   it("detects bash errors in successful results", () => {
     const msgs: LlmMessage[] = [
       { role: "assistant", content: [{ type: "toolCall", id: "1", name: "bash", arguments: { cmd: "npm test" } }] },
@@ -216,6 +240,13 @@ describe("extractStructured", () => {
     expect(ext.modifiedFiles[0].path).toBe("/src/Login.tsx");
     expect(ext.errors.length).toBe(1);
     expect(ext.mainGoal).toBe("Create a login page");
+  });
+
+  it("grounds file paths mentioned in compacted prose", () => {
+    const ext = extractStructured([
+      { role: "user", content: "The removed test/llm-retry.test.ts remains relevant." },
+    ], PC);
+    expect(ext.referencedFiles).toContain("test/llm-retry.test.ts");
   });
 });
 

--- a/test/pipeline-integration.test.ts
+++ b/test/pipeline-integration.test.ts
@@ -76,6 +76,7 @@ function makeTieredRc(messages: LlmMessage[]): TieredRc {
     keepFrom: 0,
     toCompact: messages.map((m, i) => ({ id: "m-" + i, type: "message", message: m })),
     firstKeptId: "m-0",
+    compactTokens: 500,
     accTokens: 500,
     llmMessages: messages,
     tier: "balanced",

--- a/test/state-step-continuity.test.ts
+++ b/test/state-step-continuity.test.ts
@@ -27,7 +27,7 @@ describe("buildState continuity integration", () => {
       llmMessages: [], explorationReport: null, config: { pinPaths: [] }, services,
       estimator: makeTokenEstimator("openai", "test", services.tokenCalibration),
       profile: "balanced", mode: "balanced", method: "eesv", chunkCount: 1, summaries: [],
-      toCompact: [{}, {}], convTokens: 1_000, totalTokens: 50_000, accTokens: 10_000,
+      toCompact: [{}, {}], convTokens: 1_000, totalTokens: 50_000, compactTokens: 20_000, accTokens: 10_000,
       backupPath: null, verified: true, verificationGaps: [], verificationScore: 100,
       verificationProvenance: { initialScore: 100, deterministicPatched: [], llmPatched: false, finalScore: 100, remainingGaps: [] },
       explorationRounds: 0, modelLabel: "openai/test", notify: () => {},
@@ -40,5 +40,7 @@ describe("buildState continuity integration", () => {
     expect(result.finalSummary).toContain("auth test still fails");
     expect(result.finalSummary).toContain("fix auth test");
     expect(result.details.mode).toBe("balanced");
+    expect(result.tokensSaved).toBeGreaterThan(10_000);
+    expect(result.tokensSaved).toBeLessThan(20_000);
   });
 });

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -40,6 +40,15 @@ describe("makeTokenEstimator", () => {
     expect(after).toBeLessThan(before);
   });
 
+  it("keeps one run's estimator stable while shared calibration changes", () => {
+    const store = new TokenCalibrationStore();
+    const estimator = makeTokenEstimator("openai", "model-a", store);
+    const before = estimator.text("x".repeat(1000));
+    store.calibrate(before, Math.floor(before / 2), "openai", "model-a");
+    expect(estimator.text("x".repeat(1000))).toBe(before);
+    expect(makeTokenEstimator("openai", "model-a", store).text("x".repeat(1000))).toBeLessThan(before);
+  });
+
   it("converges to the observed absolute factor rather than its square root", () => {
     const store = new TokenCalibrationStore();
     for (let i = 0; i < 20; i++) {

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -142,6 +142,15 @@ Build
     expect(result.gaps.some(g => formatVerificationGap(g).includes("fabricated"))).toBe(true);
   });
 
+  it("accepts file references grounded in compacted prose and deduplicates gaps", () => {
+    const grounded = makeExtraction({ referencedFiles: ["test/llm-retry.test.ts"] });
+    const groundedSummary = "## Goal\nClean up\n## Progress\n- deleted test/llm-retry.test.ts\n## Critical Context\n- test/llm-retry.test.ts is gone";
+    expect(verifySummary(groundedSummary, grounded).gaps.some(gap => gap.kind === "fabricated-file")).toBe(false);
+
+    const unknownSummary = "## Goal\nClean up\n## Progress\n- src/invented.ts\n## Critical Context\n- src/invented.ts";
+    expect(verifySummary(unknownSummary, makeExtraction()).gaps.filter(gap => gap.kind === "fabricated-file")).toHaveLength(1);
+  });
+
   it("accepts legitimate file references carried from scoped continuity", () => {
     const continuity = makeState({ modifiedFiles: ["src/legacy-auth.ts"] });
     const summary = "## Goal\nContinue auth\n## Progress\n- src/legacy-auth.ts remains relevant\n## Critical Context\n- stable";

--- a/test/window-boundary.test.ts
+++ b/test/window-boundary.test.ts
@@ -216,6 +216,20 @@ describe("resolveCompactionWindow tool-result boundary", () => {
     expect(result.accTokens).toBeLessThan(30_000); // bounded near the 40% target
   });
 
+  it("normalizes replaced and retained estimates to Pi's measured context", () => {
+    const branch = [
+      messageEntry("u1", null, { role: "user", content: [{ type: "text", text: "first" }] }),
+      messageEntry("a1", "u1", { role: "assistant", content: [{ type: "text", text: "x".repeat(300_000) }] }),
+      messageEntry("u2", "a1", { role: "user", content: [{ type: "text", text: "second" }] }),
+      messageEntry("a2", "u2", { role: "assistant", content: [{ type: "text", text: "y".repeat(300_000) }] }),
+      messageEntry("u3", "a2", { role: "user", content: [{ type: "text", text: "third" }] }),
+      messageEntry("a3", "u3", { role: "assistant", content: [{ type: "text", text: "z".repeat(300_000) }] }),
+    ];
+    const result = resolveCompactionWindow(makePreparedRc(branch, 1))!;
+    expect(result.compactTokens).toBeGreaterThan(20_000);
+    expect(result.compactTokens + result.accTokens).toBeLessThanOrEqual(result.totalTokens + 1);
+  });
+
   it("recounts the retained tail after anchor protection expands it", () => {
     const toolCallId = "anchor-call";
     const branch = [
@@ -232,7 +246,7 @@ describe("resolveCompactionWindow tool-result boundary", () => {
     const result = resolveCompactionWindow(rc);
 
     expect(result?.firstKeptId).toBe("anchor-request");
-    expect(result?.accTokens).toBe(rc.estimator.messages(branch.slice(1).map(item => item.message as any)));
+    expect(result?.accTokens).toBe(branch.slice(1).reduce((sum, item) => sum + rc.estimator.message(item.message as any), 0));
   });
 
   it("falls back before spending tokens when a protected tail cannot drop below the trigger", () => {


### PR DESCRIPTION
## Summary

Fixes two production canary compactions that reported `Before = After` / `Saved = 0%` despite replacing a substantial prefix, and removes false verification evidence observed in the same runs. Advances the immutable correction candidate to `8.0.0-rc.3`.

## Root cause

`tokensSaved` subtracted a raw retained-tail estimate from Pi's measured context total. With pi-toolkit/context-hook truncation, those values use different scales, so a valid compaction was clamped to zero. The run-bound token estimator also observed shared calibration changes mid-run.

Verification only trusted tool-classified read/modified/deleted files, so legitimate paths already present in compacted tool/prose evidence were labeled fabricated. Successful `rg` output containing identifiers such as `onNativeApplyError` was also cataloged as an unresolved error.

## Fix

- Normalize additive per-message prefix/tail estimates to Pi's measured context.
- Calculate savings as replaced prefix minus replacement summary; fixed/system context cancels correctly.
- Freeze each run's estimator factor while retaining shared learning for later runs.
- Ground bounded file references from compacted source evidence and preserve them across extraction-cache merges.
- Deduplicate fabricated-file findings.
- Treat search-only `rg`/`grep` results and expected exit 1 as evidence, not execution errors, without hiding chained command failures.

## Production replay

- The 122,331-token run previously displayed 0%; its first post-compaction model usage was 62,926 tokens, proving the UI/telemetry estimate false.
- Replaying both captured windows with the fix yields non-zero prefix savings estimates (~62% and ~5%).
- Re-verifying the captured summaries removes the false duplicate `test/llm-retry.test.ts` finding and the false `src/database.ts` / `src/mattermost-client.ts` / `src/service.ts` findings. A genuinely ungrounded path remains flagged.
- The first captured extraction no longer persists successful search output as unresolved errors.

## Validation

- `bun test`: **690/690**
- `bun run gate`: **246/246**
- coverage: **82.50% functions / 84.85% lines**
- source + script typecheck
- build + **137-file** frozen/package/CLI audit
- Pi **0.84.0** and latest **0.84.1** compatibility
- `bun audit`: **0 vulnerabilities**
