### PR TITLE
fix: reject unverified compaction summaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -176,10 +176,11 @@ coverage, missing structure sections, suspicious fabricated file references,
 done/unresolved inconsistencies, missing explicit decisions, and missing
 open-loop coverage.
 
-**Repair order is intentional:** (1) accept if good enough → (2) deterministic
-patch first (free, idempotent) → (3) one LLM patch only in `thorough` mode if
-still insufficient → (4) replace lower-scoring output with the deterministic
-quality floor. Final verification runs again after continuity injection.
+**Repair order is intentional:** (1) deterministic patch first (free,
+idempotent) → (2) one LLM patch only in `thorough` mode if still insufficient
+→ (3) replace lower-scoring output with the deterministic quality floor → (4)
+reject unless final verification has no gaps and meets the verified threshold.
+Final verification runs again after continuity injection.
 
 ## EESV hardening and control surfaces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 No changes yet.
 
+## [8.0.0-rc.4] - 2026-08-07
+
+### Fixed
+
+- Verification now fails closed: a summary with any unresolved verification gap or a score below the verified threshold cannot be staged or applied. Manual runs leave the conversation unchanged; automatic runs fall through to Pi's native compactor.
+- Multiline recap constraints are mined per bullet/line and diagnostic `npm error`/`rg`/`grep` output is excluded, preventing command failures from becoming contradictory release constraints.
+- Unresolved-error coverage now compares normalized whitespace, so wrapped terminal evidence is recognized instead of repeatedly patched and re-reported.
+
 ## [8.0.0-rc.3] - 2026-08-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ The design principle is simple:
 
 > **Facts first. Synthesis second. Verification before apply.**
 
+Any unresolved verification gap rejects the custom summary before staging or apply. Automatic runs then leave Pi free to use its native compactor; manual runs leave the conversation unchanged.
+
 ## EESV pipeline
 
 ```text

--- a/docs/MIGRATING_TO_V8.md
+++ b/docs/MIGRATING_TO_V8.md
@@ -1,6 +1,6 @@
 # Migrating from v7 to v8
 
-This guide applies to `8.0.0-rc.3`. The release candidate is prepared but is
+This guide applies to `8.0.0-rc.4`. The release candidate is prepared but is
 not published or deployed by repository validation.
 
 ## Compatibility

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -8,7 +8,7 @@ Use this checklist before publishing `pi-smart-compact`.
 
 ## 1. Prepare the candidate
 
-- [ ] Choose a SemVer version. Use a prerelease such as `8.0.0-rc.3` until the
+- [ ] Choose a SemVer version. Use a prerelease such as `8.0.0-rc.4` until the
       stable/canary gates pass.
 - [ ] Update `package.json`; run `bun run sync-version` for `src/constants.ts`.
 - [ ] Move shipped notes from `[Unreleased]` into the dated version in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "8.0.0-rc.3",
+  "version": "8.0.0-rc.4",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/src/app/steps/state.ts
+++ b/src/app/steps/state.ts
@@ -22,7 +22,7 @@ import { readRemediationHints } from "../../utils/damage.ts";
 import type { SmartCompactDetails, OpenLoop, CompactionState } from "../../types.ts";
 import { VERSION } from "../../constants.ts";
 import {
-  verifySummary, patchDeterministic, formatVerificationGap, isDeterministicallyPatchable,
+  verifySummary, patchDeterministic, formatVerificationGap, isDeterministicallyPatchable, verificationFailureMessage,
 } from "../../phases/verify.ts";
 
 export function buildState(rc: VerifiedRc): StatedRc {
@@ -120,6 +120,11 @@ export function buildState(rc: VerifiedRc): StatedRc {
     finalScore: postVerification.score,
     remainingGaps: postVerification.gaps,
   };
+  const failure = verificationFailureMessage(postVerification);
+  if (failure) {
+    rc.notify(failure + " after continuity injection — current conversation left unchanged", "error");
+    throw new Error(failure);
+  }
 
   const detModified = extraction.modifiedFiles.map(f => f.path);
   const detRead = extraction.readFiles;

--- a/src/app/steps/verify.ts
+++ b/src/app/steps/verify.ts
@@ -10,7 +10,7 @@ import type { SynthesizedRc, VerifiedRc } from "../run-context.ts";
 import { advance } from "../run-context.ts";
 import {
   verifySummary, patchDeterministic, patchSummary,
-  formatVerificationGap, isDeterministicallyPatchable,
+  formatVerificationGap, isDeterministicallyPatchable, verificationFailureMessage,
 } from "../../phases/verify.ts";
 import { showProgressOverlay } from "../../ui/overlays.ts";
 import * as log from "../../utils/logger.ts";
@@ -89,6 +89,12 @@ export async function verifyAndPatch(rc: SynthesizedRc): Promise<VerifiedRc> {
       qualityFloorUsed = true;
       rc.notify("Quality floor replaced unsafe or materially lower-coverage model output", "warning");
     }
+  }
+
+  const failure = verificationFailureMessage(verification);
+  if (failure) {
+    rc.notify(failure + " — current conversation left unchanged", "error");
+    throw new Error(failure);
   }
 
   const out = rc as SynthesizedRc & {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "8.0.0-rc.3";
+export const VERSION = "8.0.0-rc.4";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -32,6 +32,15 @@ export function formatVerificationGap(gap: VerificationGap): string {
   }
 }
 
+export function verificationFailureMessage(result: VerificationResult): string | null {
+  if (result.ok) return null;
+  const findings = result.gaps.slice(0, 3)
+    .map(gap => formatVerificationGap(gap).replace(/\s+/g, " ").slice(0, 160))
+    .join("; ");
+  return "Verification gate rejected summary (" + result.score + "/100, " +
+    result.gaps.length + " unresolved gap(s))" + (findings ? ": " + findings : "");
+}
+
 const NEGATION_MARKERS = new Set([
   "no", "not", "never", "without", "avoid", "forbidden", "prohibit",
   "değil", "asla", "olmadan", "yasak", "hayır",
@@ -137,6 +146,7 @@ export function verifySummary(
   const parsed = parseSummary(summary);
   const gaps: VerificationGap[] = [];
   const lower = summary.toLowerCase().replace(/\\/g, "/");
+  const normalizedSummary = lower.replace(/\s+/g, " ");
   let score = 100;
   const uniqueByText = <T>(items: T[], text: (item: T) => string): T[] => {
     const seen = new Set<string>();
@@ -184,7 +194,7 @@ export function verifySummary(
 
   for (const error of unresolvedEvidence) {
     const snippet = error.message.trim().replace(/\s+/g, " ").slice(0, TRUNC.ERROR_SNIPPET).toLowerCase();
-    if (snippet.length > 5 && !lower.includes(snippet)) {
+    if (snippet.length > 5 && !normalizedSummary.includes(snippet)) {
       gaps.push({ kind: "missing-error", message: error.message });
       score -= 5;
     }

--- a/src/utils/extraction.ts
+++ b/src/utils/extraction.ts
@@ -277,13 +277,24 @@ const CONSTRAINT_PATTERNS: Array<{ re: RegExp; cat: StructuredExtraction["constr
 
 export function mineConstraints(msgs: LlmMessage[]): StructuredExtraction["constraints"] {
   const constraints: StructuredExtraction["constraints"] = [];
+  const seen = new Set<string>();
   for (let i = 0; i < msgs.length; i++) {
     if (msgs[i]?.role !== "user") continue;
-    const txt = extractText(msgs[i].content);
-    if (txt.length < 10 || txt.startsWith("/")) continue;
-    for (const { re, cat, conf } of CONSTRAINT_PATTERNS) {
-      if (re.test(txt)) {
-        constraints.push({ index: i, text: txt.slice(0, TRUNC.CONSTRAINT_TEXT), category: cat, confidence: conf });
+    const text = extractText(msgs[i].content);
+    if (text.length < 10 || text.startsWith("/")) continue;
+    // A prior compaction is represented as one multiline user message. Match
+    // individual bullets/lines so an npm error later in that recap cannot turn
+    // the entire recap (including notices) into one bogus constraint.
+    for (const raw of text.split(/\n+/)) {
+      const candidate = raw.replace(/^\s*[-*]\s+/, "").trim();
+      if (candidate.length < 10 || /^(?:\[[^\]]+\]\s*)?(?:npm\s+(?:error|warn|notice)|(?:rg|grep):|command exited\b)/i.test(candidate)) continue;
+      for (const { re, cat, conf } of CONSTRAINT_PATTERNS) {
+        if (!re.test(candidate)) continue;
+        const normalized = candidate.toLowerCase().replace(/\s+/g, " ");
+        if (!seen.has(normalized)) {
+          seen.add(normalized);
+          constraints.push({ index: i, text: candidate.slice(0, TRUNC.CONSTRAINT_TEXT), category: cat, confidence: conf });
+        }
         break;
       }
     }

--- a/test/extraction.test.ts
+++ b/test/extraction.test.ts
@@ -197,6 +197,15 @@ describe("mineConstraints", () => {
     expect(cons[0].category).toBe("requirement");
   });
 
+  it("mines multiline recap bullets without absorbing later command errors", () => {
+    const msgs: LlmMessage[] = [{
+      role: "user",
+      content: "## Constraints\n- Do not publish stable before approval\n\nnpm audit This command requires an existing lockfile\nnpm error The package could not be found or you do not have permission\nnpm notice Publishing with public access",
+    }];
+    const cons = mineConstraints(msgs);
+    expect(cons.map(item => item.text)).toEqual(["Do not publish stable before approval"]);
+  });
+
   it("ignores short messages and commands", () => {
     const msgs: LlmMessage[] = [
       { role: "user", content: "/help" },

--- a/test/state-step-continuity.test.ts
+++ b/test/state-step-continuity.test.ts
@@ -43,4 +43,32 @@ describe("buildState continuity integration", () => {
     expect(result.tokensSaved).toBeGreaterThan(10_000);
     expect(result.tokensSaved).toBeLessThan(20_000);
   });
+
+  it("rejects gaps introduced by merged continuity before state can be applied", () => {
+    const projectId = "continuity-conflict-" + Math.random().toString(36).slice(2);
+    const previous: CompactionState = {
+      goal: "Release", decisions: [],
+      constraints: [{ id: "old", text: "Do not publish stable", category: "prohibition", confidence: 1 }],
+      modifiedFiles: [], readFiles: [], deletedFiles: [], unresolvedErrors: [], resolvedErrors: [], openLoops: [],
+      topics: [], nextActions: [], criticalContext: [], sessionType: "implementation", compactionVersion: "8.0.0-rc.3",
+    };
+    const extraction: StructuredExtraction = {
+      modifiedFiles: [], readFiles: [], deletedFiles: [], errors: [], decisions: [],
+      constraints: [{ index: 1, text: "Must publish stable now", category: "requirement", confidence: 1 }],
+      topics: [], timeline: [], mainGoal: "Release", lastUserMessages: [], lastErrors: [], messageCount: 2,
+    };
+    const services = createServices();
+    expect(() => buildState({
+      extraction,
+      finalSummary: "## Goal\nRelease\n## Constraints & Preferences\n- Must publish stable now\n## Progress\n- working\n## Critical Context\n- none",
+      projectId, continuityScope: { schemaVersion: 2, projectId, sessionId: "s", branchHeadId: "b" }, previousState: previous,
+      llmMessages: [], explorationReport: null, config: { pinPaths: [] }, services,
+      estimator: makeTokenEstimator("openai", "test", services.tokenCalibration),
+      profile: "balanced", mode: "balanced", method: "eesv", chunkCount: 1, summaries: [],
+      toCompact: [{}, {}], convTokens: 1_000, totalTokens: 50_000, compactTokens: 20_000, accTokens: 10_000,
+      backupPath: null, verified: true, verificationGaps: [], verificationScore: 100,
+      verificationProvenance: { initialScore: 100, deterministicPatched: [], llmPatched: false, finalScore: 100, remainingGaps: [] },
+      explorationRounds: 0, modelLabel: "openai/test", notify: () => {},
+    } as any)).toThrow("Verification gate rejected summary");
+  });
 });

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -193,6 +193,15 @@ Build
     expect(result.score).toBeLessThan(50);
   });
 
+  it("matches unresolved error evidence across summary line wrapping", () => {
+    const message = "Unknown JSON field: url\nAvailable fields:\ncreatedAt\nisDraft\nisImmutable";
+    const extraction = makeExtraction({
+      errors: [{ index: 1, tool: "bash", message, retryAttempted: false, resolved: false }],
+    });
+    const summary = "## Goal\nInvestigate release\n## Progress\n### Blocked\n- Unknown JSON field: url Available fields: createdAt isDraft isImmutable\n## Critical Context\n- unresolved";
+    expect(verifySummary(summary, extraction).gaps.some(gap => gap.kind === "missing-error")).toBe(false);
+  });
+
   it("accepts a faithful positive restatement of a conditional prohibition", () => {
     const extraction = makeExtraction({
       mainGoal: "Release only after explicit approval",
@@ -260,6 +269,29 @@ describe("verifyAndPatch", () => {
     expect(result.verificationProvenance.qualityFloorUsed).toBe(true);
     expect(result.finalSummary).toContain("Do not publish without explicit approval");
     expect(result.verificationScore).toBeGreaterThanOrEqual(85);
+  });
+
+  it("fails closed when contradictory evidence cannot pass verification", async () => {
+    const extraction = makeExtraction({
+      constraints: [{ index: 1, text: "Must publish stable now", category: "requirement", confidence: 1 }],
+    });
+    await expect(verifyAndPatch({
+      finalSummary: "## Goal\nRelease\n## Constraints & Preferences\n- undecided\n## Progress\n- working\n## Critical Context\n- none",
+      extraction,
+      summaries: [],
+      previousState: {
+        goal: null,
+        decisions: [],
+        constraints: [{ id: "c1", text: "Do not publish stable", category: "prohibition", confidence: 1 }],
+        modifiedFiles: [], readFiles: [], deletedFiles: [], unresolvedErrors: [], resolvedErrors: [],
+        openLoops: [], topics: [], nextActions: [], criticalContext: [],
+        sessionType: "implementation", compactionVersion: "8.0.0-rc.3",
+      },
+      mode: "aggressive",
+      flags: { autoTriggered: true },
+      notify: () => {},
+      vlog: () => {},
+    } as any)).rejects.toThrow("Verification gate rejected summary");
   });
 
   it("repairs a patchable high-score gap instead of skipping it", async () => {


### PR DESCRIPTION
## Summary

Fixes a production canary where `8.0.0-rc.2` applied a summary at **0/100 quality with 32 unresolved verification gaps** (`runId cb5c9491-aeb8-4ea6-ac45-4ff205d4e816`). Advances the correction candidate to `8.0.0-rc.4`; the signed GitHub-only `rc.3` remains immutable and was never published to npm.

## Root cause

- `verifyAndPatch()` returned unverified output after deterministic/LLM/fallback repair failed; the pipeline ignored `verified: false` and continued to stage/apply.
- `buildState()` re-verified after continuity injection but likewise continued when the final result failed.
- A previous compacted recap is represented as one multiline user message. Constraint mining scanned the entire message, so `npm error ... you do not have permission` matched the generic `do not` prohibition and turned terminal diagnostics into a release constraint.
- Error evidence collapsed whitespace while the summary comparison did not, repeatedly reporting already-preserved wrapped errors as missing.

## Fix

- Require `VerificationResult.ok` after synthesis repair and again after continuity injection. Any remaining gap aborts before staging/apply.
- Manual failures leave the current conversation unchanged; automatic failures return control to Pi's native compactor.
- Mine multiline constraints per bullet/line, deduplicate them, and exclude diagnostic npm/rg/grep/exit lines.
- Normalize whitespace on both sides of unresolved-error coverage checks.

## Captured-session replay

The exact 108,420-token window and applied summary were reconstructed from the session JSONL:

- rc.2 runtime: `0/100`, 32 gaps, `Saved 0%`, applied.
- rc.4 verifier replay: `100/100`, 0 gaps after deterministic repair.
- rc.4 savings calculation: ~23,361 tokens / **22%** instead of 0%.
- The backup at `2026-08-07T11:32:43Z` remains available; no restore is required because the captured final summary passes the corrected verifier and the retained tail contains the recent work.

## Validation

- `bun test`: **694/694**
- `bun run gate`: **249/249**
- coverage: **82.51% functions / 84.91% lines**
- source + script typecheck
- build + **137-file** frozen/package/CLI audit
- Pi **0.84.0** and latest **0.84.1** compatibility
- `bun audit`: **0 vulnerabilities**
