### PR TITLE
release: promote v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 No changes yet.
 
+## [8.0.0] - 2026-08-07
+
+### Added
+
+- Stable v8 release of the EESV compaction pipeline, scoped continuity and context graph, host-approved project memory, explicit provider routing, telemetry cohorts, damage correlation, and local release dashboards.
+
+### Changed
+
+- Promotes the fully validated `8.0.0-rc.4` tree without runtime changes. The maintainer explicitly accepted promotion while the advisory telemetry report remained `HOLD` for missing rc.4 cohort evidence; post-release defects follow the normal rollback/patch process.
+
 ## [8.0.0-rc.4] - 2026-08-07
 
 ### Fixed

--- a/docs/MIGRATING_TO_V8.md
+++ b/docs/MIGRATING_TO_V8.md
@@ -1,7 +1,6 @@
 # Migrating from v7 to v8
 
-This guide applies to `8.0.0-rc.4`. The release candidate is prepared but is
-not published or deployed by repository validation.
+This guide applies to the stable `8.0.0` release.
 
 ## Compatibility
 
@@ -11,8 +10,8 @@ not published or deployed by repository validation.
 - Modes never change the selected Pi model.
 - Settings are additive; an existing v7 configuration remains valid.
 
-The RC is validated against the locked Pi 0.84.0 baseline and the latest Pi
-compatibility job. Bun 1.3.14 is the reproducible build baseline.
+The release is validated against the locked Pi 0.84.0 baseline and the latest
+Pi compatibility job. Bun 1.3.14 is the reproducible build baseline.
 
 ## What changes on first run
 
@@ -79,18 +78,15 @@ All defaults preserve the selected model and require no migration edits.
 
 See the README configuration table for budgets and monitoring options.
 
-## Recommended RC rollout
+## Recommended rollout
 
 1. Back up `~/.pi/agent/settings.json` and the Smart Compact cache directory.
-2. Install the RC only after it is explicitly published to an RC tag.
-3. Leave all model routes null for the first cohort.
-4. Set `telemetryChannel: "canary"` only in that cohort.
-5. Collect at least 20 complete schema-v2 runs with ≥70% verifier-quality and
-   ≥70% correlated damage-observation coverage in both stable/canary cohorts.
-6. Run `bun run telemetry-report` from the installed package or open the local
-   dashboard.
-7. Promote only on a `PROMOTE` result, ≥95% canary success, ≥85 absolute
-   quality, no rollback triggers, and Data Confidence ≥85.
+2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.0`.
+3. Leave all model routes null initially.
+4. Keep `telemetryChannel: "stable"` unless intentionally running a separate
+   canary cohort.
+5. Monitor `bun run telemetry-report` or the local dashboard and use the
+   rollback procedure below if a rollback trigger appears.
 
 ## Rollback
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "8.0.0-rc.4",
+  "version": "8.0.0",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "8.0.0-rc.4";
+export const VERSION = "8.0.0";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =


### PR DESCRIPTION
## Summary

Promotes the exact validated `8.0.0-rc.4` runtime tree to stable `8.0.0`; only version, changelog, and migration metadata change.

## Release decision

The advisory telemetry report is still `HOLD` (Data Confidence 18; no rc.4 canary cohort). On 2026-08-07, the release owner explicitly chose immediate stable promotion and accepted rollback/patch hotfixes for post-release defects. This PR records that exception rather than representing `HOLD` as `PROMOTE`.

The captured rc.2 production failures that prompted rc.3/rc.4 were replayed against the final tree:

- false token savings corrected;
- the latest 108,420-token window verifies at **100/100 with 0 gaps** after deterministic repair;
- unsafe summaries now fail closed before staging/apply.

## Validation

- `bun test`: **694/694**
- `bun run gate`: **249/249**
- coverage: **82.51% functions / 84.91% lines**
- source + script typecheck
- build + **137-file** frozen/package/CLI audit
- Pi **0.84.0** and latest **0.84.1** compatibility
- `bun audit`: **0 vulnerabilities**
- `telemetry-report`: **HOLD**, explicitly overridden by release owner

## Publication

After merge and signed `v8.0.0` GitHub release, the owner publishes with npm `latest` using OTP. `next` remains `8.0.0-rc.4` unless deliberately moved later.
