### PR TITLE
fix: sanitize legacy continuity evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 No changes yet.
 
+## [8.0.1] - 2026-08-07
+
+### Fixed
+
+- Legacy rc.2 continuity state now drops diagnostic `npm error`/`npm notice` text that had been persisted as a user prohibition, both when loaded and before future persistence.
+- Remote registry URLs such as `https://registry.npmjs.org/` are no longer interpreted as local file references.
+- File paths present inside trusted error/constraint/decision/goal continuity evidence are grounded during verification, so deterministically preserved legacy errors cannot create fabricated-file gaps.
+
 ## [8.0.0] - 2026-08-07
 
 ### Added

--- a/docs/MIGRATING_TO_V8.md
+++ b/docs/MIGRATING_TO_V8.md
@@ -1,6 +1,6 @@
 # Migrating from v7 to v8
 
-This guide applies to the stable `8.0.0` release.
+This guide applies to the stable `8.0.1` release.
 
 ## Compatibility
 
@@ -27,7 +27,9 @@ v7's project-wide state file is left in place but is **not automatically
 injected**. Treating it as current could contaminate another session or a
 divergent branch. The first host-confirmed v8 `session_compact` seeds scoped
 state; staging, cancellation, or a failed native apply writes nothing. No conversation log is
-rewritten during migration.
+rewritten during migration. v8.0.1 also filters legacy RC state that misclassified
+`npm error`/`npm notice` diagnostics as constraints; the next confirmed save persists
+the sanitized state.
 
 Facts remain conservative: absence from a new window is not deletion. A fact is
 removed only by an explicit resolved/superseded override.
@@ -81,7 +83,7 @@ See the README configuration table for budgets and monitoring options.
 ## Recommended rollout
 
 1. Back up `~/.pi/agent/settings.json` and the Smart Compact cache directory.
-2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.0`.
+2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.1`.
 3. Leave all model routes null initially.
 4. Keep `telemetryChannel: "stable"` unless intentionally running a separate
    canary cohort.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "8.0.0";
+export const VERSION = "8.0.1";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -11,6 +11,7 @@ import { COMPACT_SYSTEM_PREFIX, TRUNC } from "../constants.ts";
 import { trackedComplete } from "../utils/cache.ts";
 import { getProviderCaps } from "../utils/tokens.ts";
 import { extractFileRefs } from "../utils/file-ref-detect.ts";
+import { isDiagnosticConstraintText } from "../utils/extraction.ts";
 import { buildUniquePathNeedles, isKnownPathReference } from "../utils/file-needles.ts";
 import * as log from "../utils/logger.ts";
 import { parseSummary, findSection, appendToSection, renderSummary, upsertSection } from "../domain/summary-parse.ts";
@@ -164,7 +165,7 @@ export function verifySummary(
   const constraintEvidence = uniqueByText([
     ...extraction.constraints.filter(item => item.confidence >= 0.8).map(item => ({ text: item.text })),
     ...(continuity?.constraints ?? []).filter(item => item.confidence >= 0.8).map(item => ({ text: item.text })),
-  ], item => item.text);
+  ], item => item.text).filter(item => !isDiagnosticConstraintText(item.text));
   const decisionEvidence = uniqueByText([
     ...extraction.decisions.filter(item => item.type === "explicit").map(item => ({ summary: item.summary })),
     ...(continuity?.decisions ?? []).filter(item => item.type === "explicit").map(item => ({ summary: item.summary })),
@@ -227,8 +228,17 @@ export function verifySummary(
     }
   }
 
+  const groundedEvidenceFiles = [
+    ...unresolvedEvidence.map(item => item.message),
+    ...constraintEvidence.map(item => item.text),
+    ...decisionEvidence.map(item => item.summary),
+    ...(goalEvidence ? [goalEvidence] : []),
+    ...(continuity?.openLoops.map(item => item.summary) ?? []),
+    ...(continuity?.criticalContext ?? []),
+  ].flatMap(extractFileRefs);
   const knownFiles = Array.from(new Set([
     ...modifiedPaths, ...extraction.readFiles, ...extraction.deletedFiles, ...(extraction.referencedFiles ?? []),
+    ...groundedEvidenceFiles,
     ...(continuity?.modifiedFiles ?? []), ...(continuity?.readFiles ?? []), ...(continuity?.deletedFiles ?? []),
     ...(continuity?.unresolvedErrors ?? []).flatMap(error => error.files),
     ...(continuity?.openLoops ?? []).flatMap(loop => loop.files),

--- a/src/utils/extraction.ts
+++ b/src/utils/extraction.ts
@@ -275,6 +275,11 @@ const CONSTRAINT_PATTERNS: Array<{ re: RegExp; cat: StructuredExtraction["constr
   { re: /(?<![A-Za-z0-9_])(?:tercih|isterim|olsun|kullanalım|yapalım|istiyorum)(?![A-Za-z0-9_])/iu, cat: "preference", conf: TUNING.CONFIDENCE_LOW },
 ];
 
+export function isDiagnosticConstraintText(text: string): boolean {
+  const candidate = text.replace(/^\s*[-*]\s+/, "").trim();
+  return /^(?:\[[^\]]+\]\s*)?(?:npm\s+(?:error|warn|notice|audit|verbose|info)\b|(?:rg|grep):|command exited\b)/i.test(candidate);
+}
+
 export function mineConstraints(msgs: LlmMessage[]): StructuredExtraction["constraints"] {
   const constraints: StructuredExtraction["constraints"] = [];
   const seen = new Set<string>();
@@ -287,7 +292,7 @@ export function mineConstraints(msgs: LlmMessage[]): StructuredExtraction["const
     // the entire recap (including notices) into one bogus constraint.
     for (const raw of text.split(/\n+/)) {
       const candidate = raw.replace(/^\s*[-*]\s+/, "").trim();
-      if (candidate.length < 10 || /^(?:\[[^\]]+\]\s*)?(?:npm\s+(?:error|warn|notice)|(?:rg|grep):|command exited\b)/i.test(candidate)) continue;
+      if (candidate.length < 10 || isDiagnosticConstraintText(candidate)) continue;
       for (const { re, cat, conf } of CONSTRAINT_PATTERNS) {
         if (!re.test(candidate)) continue;
         const normalized = candidate.toLowerCase().replace(/\s+/g, " ");

--- a/src/utils/file-ref-detect.ts
+++ b/src/utils/file-ref-detect.ts
@@ -45,7 +45,9 @@ export const FILE_REF_CANDIDATE_RE = /[\w.\/-]+\.[\w]+/g;
  * the classifier without re-running the candidate generator.
  */
 export function isLikelyFileRef(candidate: string): boolean {
-  if (VERSION_RE.test(candidate)) return false;
+  // Candidate generation drops URL schemes at ':', leaving protocol-relative
+  // fragments such as //registry.npmjs.org. They are remote hosts, not files.
+  if (candidate.startsWith("//") || VERSION_RE.test(candidate)) return false;
   if (candidate.includes("/")) {
     // Path-segment match: must contain at least one directory component
     // and the last segment must not be a bare version literal (e.g.

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types.ts";
 import { VERSION, SEVEN_DAYS_MS, TRUNC, ID_PREFIX } from "../constants.ts";
 import { inferSessionType, normalizeFactKey } from "./helpers.ts";
+import { isDiagnosticConstraintText } from "./extraction.ts";
 import * as log from "./logger.ts";
 import { compactionStateFile, scopedCompactionStateFile } from "../infra/paths.ts";
 import { writeJsonSync, readJsonSync } from "../infra/fs.ts";
@@ -23,13 +24,18 @@ function getStatePath(projectId: string, state?: CompactionState): string {
     : compactionStateFile(projectId);
 }
 
+export function sanitizeCompactionStateEvidence(state: CompactionState): CompactionState {
+  const constraints = state.constraints.filter(item => !isDiagnosticConstraintText(item.text));
+  return constraints.length === state.constraints.length ? state : { ...state, constraints };
+}
+
 function freshState(fp: string, data: CompactionState | null): CompactionState | null {
   if (!data) return null;
   let updatedAt = data.updatedAt;
   if (!updatedAt) {
     try { updatedAt = fs.statSync(fp).mtimeMs; } catch (e) { log.debug("statSync failed for state file", e); updatedAt = 0; }
   }
-  return Date.now() - updatedAt > SEVEN_DAYS_MS ? null : data;
+  return Date.now() - updatedAt > SEVEN_DAYS_MS ? null : sanitizeCompactionStateEvidence(data);
 }
 
 /**
@@ -41,7 +47,7 @@ function freshState(fp: string, data: CompactionState | null): CompactionState |
  */
 export function saveCompactionState(projectId: string, state: CompactionState): void {
   try {
-    writeJsonSync(getStatePath(projectId, state), state, true);
+    writeJsonSync(getStatePath(projectId, state), sanitizeCompactionStateEvidence(state), true);
   } catch (e) { log.warn("saveCompactionState failed", e); }
 }
 
@@ -116,13 +122,14 @@ export function applyContinuityOverrides(state: CompactionState, overrides: Cont
   const replacements = overrides
     .filter(item => item.status === "superseded" && item.replacement)
     .map(item => "Superseded " + item.kind + ": " + item.replacement);
+  const cleanState = sanitizeCompactionStateEvidence(state);
   return {
-    ...state,
-    decisions: state.decisions.filter(item => !inactive.has("decision:" + normalizeFactKey(item.summary))),
-    constraints: state.constraints.filter(item => !inactive.has("constraint:" + normalizeFactKey(item.text))),
-    unresolvedErrors: state.unresolvedErrors.filter(item => !inactive.has("error:" + normalizeFactKey(item.message))),
-    openLoops: state.openLoops.filter(item => !inactive.has("loop:" + normalizeFactKey(item.summary))),
-    criticalContext: mergeBy(replacements, state.criticalContext, normalizeFactKey, 20),
+    ...cleanState,
+    decisions: cleanState.decisions.filter(item => !inactive.has("decision:" + normalizeFactKey(item.summary))),
+    constraints: cleanState.constraints.filter(item => !inactive.has("constraint:" + normalizeFactKey(item.text))),
+    unresolvedErrors: cleanState.unresolvedErrors.filter(item => !inactive.has("error:" + normalizeFactKey(item.message))),
+    openLoops: cleanState.openLoops.filter(item => !inactive.has("loop:" + normalizeFactKey(item.summary))),
+    criticalContext: mergeBy(replacements, cleanState.criticalContext, normalizeFactKey, 20),
     factOverrides: overrides,
   };
 }

--- a/test/file-ref-detect.test.ts
+++ b/test/file-ref-detect.test.ts
@@ -116,6 +116,12 @@ describe("extractFileRefs — integration", () => {
     expect(refs).not.toContain("1.3.14");
   });
 
+  it("does NOT treat registry URLs as local file paths", () => {
+    const refs = extractFileRefs("Publishing to https://registry.npmjs.org/pi-smart-compact with public access");
+    expect(refs).not.toContain("//registry.npmjs.org/pi-smart-compact");
+    expect(refs).toEqual([]);
+  });
+
   it("returns an empty array when no candidates exist", () => {
     expect(extractFileRefs("plain prose without file references")).toEqual([]);
   });

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -272,6 +272,17 @@ describe("continuity state", () => {
     expect(merged.openLoops.map(item => item.summary)).toContain("fix auth test");
   });
 
+  it("drops diagnostic constraints carried from legacy state", () => {
+    const previous = makeFullState({
+      constraints: [
+        { id: "constraint-1", text: "npm notice\nnpm notice Publishing to https://registry.npmjs.org/ with tag next and public access\nnpm error 404", category: "prohibition", confidence: 0.8 },
+        { id: "constraint-2", text: "Do not publish without approval", category: "prohibition", confidence: 1 },
+      ],
+    });
+    const merged = mergeCompactionStates(previous, makeFullState());
+    expect(merged.constraints.map(item => item.text)).toEqual(["Do not publish without approval"]);
+  });
+
   it("renders only continuity facts missing from the visible summary", () => {
     const state = makeFullState({
       goal: "Ship auth",
@@ -456,6 +467,17 @@ describe("saveCompactionState / loadCompactionState", () => {
     expect(loaded!.goal).toBe("Round trip test");
     expect(loaded!.decisions.length).toBe(1);
     // Cleanup
+    const fs = require("fs");
+    const p = require("path").join(process.env.HOME ?? "/tmp", ".pi", "agent", ".cache", "smart-compact", "states", testId + ".json");
+    try { fs.unlinkSync(p); } catch {}
+  });
+
+  it("sanitizes diagnostic constraints before persistence", () => {
+    const testId = "test-sanitize-" + Date.now();
+    saveCompactionState(testId, makeFullState({
+      constraints: [{ id: "constraint-1", text: "npm error You do not have permission", category: "prohibition", confidence: 0.8 }],
+    }));
+    expect(loadCompactionState(testId)?.constraints).toEqual([]);
     const fs = require("fs");
     const p = require("path").join(process.env.HOME ?? "/tmp", ".pi", "agent", ".cache", "smart-compact", "states", testId + ".json");
     try { fs.unlinkSync(p); } catch {}

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -159,6 +159,21 @@ Build
     expect(result.gaps.some(gap => gap.kind === "fabricated-file")).toBe(false);
   });
 
+  it("ignores legacy npm diagnostics stored as continuity constraints", () => {
+    const continuity = makeState({
+      constraints: [{
+        id: "constraint-1",
+        text: "npm notice\nnpm notice Publishing to https://registry.npmjs.org/ with tag next and public access\nnpm error 404",
+        category: "prohibition",
+        confidence: 0.8,
+      }],
+      unresolvedErrors: [{ id: "error-1", message: "rg: src/config.ts: No such file or directory", tool: "bash", files: [] }],
+    });
+    const summary = "## Goal\nClean up\n## Constraints & Preferences\n- npm notice Publishing to https://registry.npmjs.org/ with tag next and public access\n## Progress\n- complete\n## Open Loops\n- rg: src/config.ts: No such file or directory\n## Critical Context\n- stable";
+    const result = verifySummary(summary, makeExtraction(), continuity);
+    expect(result.gaps.some(gap => gap.kind === "missing-constraint" || gap.kind === "inconsistency" || gap.kind === "fabricated-file")).toBe(false);
+  });
+
   it("detects and deterministically repairs missing carried facts", () => {
     const continuity = makeState({
       goal: "Ship auth",


### PR DESCRIPTION
## Summary

Hotfixes the first stable `8.0.0` production rejection. Fail-closed protection worked correctly and left the conversation unchanged, but verifier migration did not sanitize diagnostic constraints already persisted by `rc.2`.

## Captured failure

`8.0.0` rejected the summary at 60/100 with five gaps, including:

- `npm notice ... registry.npmjs.org ...` treated as a prohibition;
- a semantic contradiction against that bogus constraint;
- `//registry.npmjs.org` treated as a fabricated local file.

The persisted scoped state confirmed one rc.2 constraint containing combined npm notice/E404 output.

## Root cause and fix

- Export and reuse strict diagnostic-constraint classification.
- Sanitize legacy constraints on state load, merge/override, and save; the next confirmed compaction heals the file on disk.
- Exclude protocol-relative URL fragments produced when the file candidate regex drops `https:`.
- Ground paths occurring inside trusted error/constraint/decision/goal continuity evidence. This lets deterministic repair preserve errors such as `rg: src/config.ts: No such file` without reclassifying the cited path as an LLM fabrication.

## Production-state replay

Loaded the exact polluted scoped state from the failed stable run. Before the fix it reproduced the rejection; after the fix, `verifyAndPatch()` returns:

- **100/100**
- **verified: true**
- **0 gaps**
- diagnostic constraints loaded: **0**

## Validation

- `bun test`: **698/698**
- `bun run gate`: **252/252**
- coverage: **82.52% functions / 84.91% lines**
- source + script typecheck
- build + **137-file** frozen/package/CLI audit
- Pi **0.84.0** and latest **0.84.1** compatibility
- `bun audit`: **0 vulnerabilities**
