### PR TITLE
fix: scope file completion contradictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 No changes yet.
 
+## [8.0.2] - 2026-08-07
+
+### Fixed
+
+- Done/error contradiction detection now associates an unresolved error with a completed file only when the error's first line directly identifies that file. Later grep/context output mentioning the filename no longer creates a false contradiction.
+- Legacy source-search output persisted as unresolved errors/open loops by older RCs is filtered on load and before persistence.
+
 ## [8.0.1] - 2026-08-07
 
 ### Fixed

--- a/docs/MIGRATING_TO_V8.md
+++ b/docs/MIGRATING_TO_V8.md
@@ -1,6 +1,6 @@
 # Migrating from v7 to v8
 
-This guide applies to the stable `8.0.1` release.
+This guide applies to the stable `8.0.2` release.
 
 ## Compatibility
 
@@ -27,8 +27,9 @@ v7's project-wide state file is left in place but is **not automatically
 injected**. Treating it as current could contaminate another session or a
 divergent branch. The first host-confirmed v8 `session_compact` seeds scoped
 state; staging, cancellation, or a failed native apply writes nothing. No conversation log is
-rewritten during migration. v8.0.1 also filters legacy RC state that misclassified
-`npm error`/`npm notice` diagnostics as constraints; the next confirmed save persists
+rewritten during migration. v8.0.1+ filters legacy RC state that misclassified
+`npm error`/`npm notice` diagnostics as constraints, and v8.0.2 also removes legacy
+source-search output persisted as unresolved work; the next confirmed save persists
 the sanitized state.
 
 Facts remain conservative: absence from a new window is not deletion. A fact is
@@ -83,7 +84,7 @@ See the README configuration table for budgets and monitoring options.
 ## Recommended rollout
 
 1. Back up `~/.pi/agent/settings.json` and the Smart Compact cache directory.
-2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.1`.
+2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.2`.
 3. Leave all model routes null initially.
 4. Keep `telemetryChannel: "stable"` unless intentionally running a separate
    canary cohort.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "8.0.1";
+export const VERSION = "8.0.2";
 export const CHARS_PER_TOKEN = 3.8;
 
 export const COMPACT_SYSTEM_PREFIX =

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -261,7 +261,10 @@ export function verifySummary(
     for (const file of extraction.modifiedFiles) {
       const basename = file.path.split("/").pop() ?? "";
       if (!doneSection.toLowerCase().includes(basename.toLowerCase())) continue;
-      const unresolved = unresolvedEvidence.find(error => error.message.toLowerCase().includes(basename.toLowerCase()));
+      const unresolved = unresolvedEvidence.find(error => {
+        const firstLine = error.message.split(/\r?\n/, 1)[0] ?? "";
+        return extractFileRefs(firstLine).some(ref => isKnownPathReference(ref, [file.path]));
+      });
       if (unresolved) {
         gaps.push({ kind: "inconsistency", detail: basename + " marked Done but has unresolved error" });
         score -= 5;

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -24,9 +24,19 @@ function getStatePath(projectId: string, state?: CompactionState): string {
     : compactionStateFile(projectId);
 }
 
+function isLegacySearchOutput(text: string): boolean {
+  const firstLine = text.trim().split(/\r?\n/, 1)[0] ?? "";
+  return /^[^\s:][^:]*:\d+(?::\d+)?:/.test(firstLine);
+}
+
 export function sanitizeCompactionStateEvidence(state: CompactionState): CompactionState {
   const constraints = state.constraints.filter(item => !isDiagnosticConstraintText(item.text));
-  return constraints.length === state.constraints.length ? state : { ...state, constraints };
+  const unresolvedErrors = state.unresolvedErrors.filter(item => !isLegacySearchOutput(item.message));
+  const openLoops = state.openLoops.filter(item => !isLegacySearchOutput(item.summary));
+  if (constraints.length === state.constraints.length &&
+      unresolvedErrors.length === state.unresolvedErrors.length &&
+      openLoops.length === state.openLoops.length) return state;
+  return { ...state, constraints, unresolvedErrors, openLoops };
 }
 
 function freshState(fp: string, data: CompactionState | null): CompactionState | null {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -278,9 +278,13 @@ describe("continuity state", () => {
         { id: "constraint-1", text: "npm notice\nnpm notice Publishing to https://registry.npmjs.org/ with tag next and public access\nnpm error 404", category: "prohibition", confidence: 0.8 },
         { id: "constraint-2", text: "Do not publish without approval", category: "prohibition", confidence: 1 },
       ],
+      unresolvedErrors: [{ id: "error-1", message: "src/app.ts:10: const onError = true;\nsrc/index.ts:20: // matched search output", tool: "bash", files: ["src/app.ts"] }],
+      openLoops: [{ id: "loop-1", type: "bugfix", priority: "normal", status: "open", summary: "src/app.ts:10: const onError = true", files: ["src/app.ts"], sourceIndex: 1 }],
     });
     const merged = mergeCompactionStates(previous, makeFullState());
     expect(merged.constraints.map(item => item.text)).toEqual(["Do not publish without approval"]);
+    expect(merged.unresolvedErrors).toEqual([]);
+    expect(merged.openLoops).toEqual([]);
   });
 
   it("renders only continuity facts missing from the visible summary", () => {

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -174,6 +174,30 @@ Build
     expect(result.gaps.some(gap => gap.kind === "missing-constraint" || gap.kind === "inconsistency" || gap.kind === "fabricated-file")).toBe(false);
   });
 
+  it("does not tie a completed file to an unrelated search error that cites it later", () => {
+    const extraction = makeExtraction({
+      modifiedFiles: [{ path: "README.md", operations: ["write"], firstIndex: 1, lastIndex: 1, count: 1 }],
+      errors: [{
+        index: 2, tool: "bash", retryAttempted: false, resolved: false,
+        message: "rg: src/config.ts: No such file or directory\nREADME.md-194-matching search output",
+      }],
+    });
+    const summary = "## Goal\nClean up\n## Progress\n### Done\n- Updated README.md\n### Blocked\n- rg: src/config.ts: No such file or directory README.md-194-matching search output\n## Open Loops\n- investigate command\n## Critical Context\n- none";
+    expect(verifySummary(summary, extraction).gaps.some(gap => gap.kind === "inconsistency" && gap.detail.includes("README.md marked Done"))).toBe(false);
+  });
+
+  it("still rejects Done when the unresolved operation directly targets that file", () => {
+    const extraction = makeExtraction({
+      modifiedFiles: [{ path: "README.md", operations: ["write"], firstIndex: 1, lastIndex: 1, count: 1 }],
+      errors: [{
+        index: 2, tool: "edit", retryAttempted: false, resolved: false,
+        message: "Could not update README.md: exact text was not found",
+      }],
+    });
+    const summary = "## Goal\nClean up\n## Progress\n### Done\n- Updated README.md\n### Blocked\n- Could not update README.md: exact text was not found\n## Open Loops\n- retry README edit\n## Critical Context\n- none";
+    expect(verifySummary(summary, extraction).gaps).toContainEqual({ kind: "inconsistency", detail: "README.md marked Done but has unresolved error" });
+  });
+
   it("detects and deterministically repairs missing carried facts", () => {
     const continuity = makeState({
       goal: "Ship auth",


### PR DESCRIPTION
## Summary

Hotfixes the second stable fail-closed rejection. `8.0.1` reached 95/100 but incorrectly reported `README.md marked Done but has unresolved error`; the conversation remained unchanged.

## Root cause

Done/error contradiction detection searched the entire historical error message for a basename. The retained rc.2 error actually targeted missing `src/config.ts`; later `rg` context lines happened to quote `README.md`, so the verifier associated an unrelated diagnostic with the completed README work.

Older RC state also retained one successful source-search output as an unresolved error/open loop.

## Fix

- Associate an unresolved error with a completed file only when a file reference on the error's **first line** resolves to that exact file.
- Preserve rejection when the first-line failure really targets the completed file (for example, `Could not update README.md`).
- Filter legacy source-search result blocks whose first line has `path:line:` grep shape from unresolved errors/open loops during state sanitation.

## Captured-state replay

The exact polluted scoped state now loads without the false source-search error. Replaying verification with `README.md` in Done returns:

- **100/100**
- **verified: true**
- **0 gaps**
- genuine historical errors retained: 3
- false source-search error removed

## Validation

- `bun test`: **700/700**
- `bun run gate`: **254/254**
- coverage: **82.54% functions / 84.93% lines**
- source + script typecheck
- build + **137-file** frozen/package/CLI audit
- Pi **0.84.0** and latest **0.84.1** compatibility
- `bun audit`: **0 vulnerabilities**
