### PR TITLE
fix: guarantee meaningful compaction yield

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,7 @@ section is about lifecycle.
 
 | Surface | Lifecycle |
 | --- | --- |
-| `/smart-compact` | Manual command. Interactive picker or direct args. Bypasses the adaptive gate. |
+| `/smart-compact` | Manual command. Explainable target-first preflight or direct args. Bypasses the adaptive pressure gate, not yield/verification gates. |
 | `session_before_compact` | Auto hook. Returns/stages a pending summary or runs under pressure; durable commit waits for matching `session_compact`. |
 | `smart_compact` tool | Agent-callable. Prepares a pending summary; never compacts mid-turn. |
 | `smart_recall` tool | Searches only the current project's bounded context graph; same session/branch ranks first. |
@@ -50,7 +50,9 @@ flowchart LR
     E --> H[Verify + repair]
     G --> H
     H --> I[Open loops + delta + state]
-    I --> J[Pending compaction returned to Pi]
+    I --> Y{Target + ≥10% yield?}
+    Y -- No --> X[Reject; conversation unchanged]
+    Y -- Yes --> J[Pending compaction returned to Pi]
 ```
 
 The orchestrator ([`src/app/run-smart-compact.ts`](./src/app/run-smart-compact.ts))
@@ -65,7 +67,7 @@ threads a typed context through ten stages:
 | 5 | extract | `app/steps/extract.ts` | prune + deterministic extraction + cache |
 | 6 | synthesize | `app/steps/synthesize.ts` | single-pass or EESV |
 | 7 | verify | `app/steps/verify.ts` | structural verify + repair |
-| 8 | state | `app/steps/state.ts` | state machine + open loops + delta |
+| 8 | state | `app/steps/state.ts` + `domain/yield-gate.ts` | state/open loops/delta + final yield proof |
 | 9 | persist | `app/steps/persist.ts` | stage pending, apply compaction |
 | 10 | metrics | `app/steps/metrics.ts` | success / failure record |
 
@@ -104,9 +106,11 @@ assertions: the type system proves `buildState` has run.
 `src/index.ts` resolves models, parses command arguments, and routes work into
 `runSmartCompact()`. Before any expensive work, the system checks context size
 against the threshold in `src/constants.ts`. Auto / tool runs are skipped while
-context is small; manual `/smart-compact` bypasses the gate with an advisory
-warning and uses an absolute adaptive safety tail rather than a percentage of
-large model windows. A pending summary
+context is small; manual `/smart-compact` uses an absolute adaptive safety tail
+rather than a percentage of large model windows. Its single preflight is built
+from the same config snapshot, calibrated estimator, adaptive profile, active
+branch, and pure window planner as execution. A plan must meet the tail target
+and at least 10% projected net savings before any model call. A pending summary
 for the same session is reused instead of invoking the pipeline again. The
 selected `CompactionMode` resolves to a concrete policy before the first model
 call; `auto` uses context pressure and deterministic extraction risk.
@@ -120,22 +124,24 @@ provider/model route; call metrics preserve the actual route.
 ### Keep window and preprocessing
 
 `app/steps/window.ts` starts from Pi's compaction-aware
-`buildContextEntries()` view, never the append-only session history, then keeps
-a recent tail untouched so very recent context stays live, anchored by:
+`buildContextEntries()` view, never the append-only session history, and builds
+a content-free `CompactionWindowPlan` from the selected mode budget:
 
-- **pi-toolkit anchor protection** — normally retain the latest on-branch anchor as a soft fidelity boundary
-- **`toolCall` / `toolResult` boundary guard** — never orphan a result from its call; this boundary remains hard
+- **hard `toolCall` / `toolResult` guard** — never orphan a result from its call
+- **soft recent-user/checkpoint/topical preferences** — retain raw only when the resulting suffix still fits the planned budget
+- **yield contract** — projected replacement must meet its target and save at least 10% after reserving the summary budget
 
-Boundary expansion is re-counted after both guards. If the protected tail plus
-the summary budget cannot fall below the configured context trigger, automatic
-and tool runs normally return control to Pi's native compactor before any LLM
-call. An already-overflowed context is the safety exception: measured usage is
-mapped across active messages, soft anchor/recent-turn expansion is removed,
-and EESV summarizes to the mode target while the tool boundary remains intact.
-This avoids sending a context larger than the active model window to native's
-single summarization call. Manual runs instead compact every eligible prefix
-outside the adaptive tail; empty/repeated/low-yield attempts are reported
-rather than silently ignored.
+The same pure planner powers manual preflight and execution. A soft boundary is
+recorded as relaxed rather than silently overriding the target. Long turns may
+be summarized through their older prefix; if the nominal cut lands inside a
+tool exchange, the planner either retains the complete pair within budget or
+advances past it so the complete exchange is summarized. If no safe hard
+boundary can meet the target, automatic/tool runs normally return control to
+Pi's native compactor before any LLM call. An already-overflowed context is
+the safety exception: measured usage is mapped across active messages and EESV
+keeps chunked recovery instead of sending an oversized one-shot prompt to
+native summarization. Manual runs use the profile's absolute adaptive tail, so
+model-window size cannot turn an explicit command into a full-context no-op.
 
 Before summarization the pipeline also prunes redundant messages, serializes the
 compacted portion, creates a backup, loads the previous verified summary plus
@@ -204,9 +210,12 @@ Final verification runs again after continuity injection.
 ## State, caching & persistence
 
 Post-verification, `app/steps/state.ts` + `src/utils/state.ts` enrich the
-summary. `session_before_compact` only stages it; after the host emits the
-matching `session_compact`, `app/steps/persist.ts` commits reusable state and
-success telemetry. Aborted/unconfirmed candidates write neither.
+summary, then `domain/yield-gate.ts` measures the final replacement. Missing
+the planned target or 10% net-saving floor throws before a `StatedRc` can reach
+staging/apply. `session_before_compact` only stages a passing candidate; after
+the host emits the matching `session_compact`, `app/steps/persist.ts` commits
+reusable state and success telemetry. Aborted/unconfirmed candidates write
+neither, and the UI reports `Applied` only after that correlated commit.
 
 | Concern | Where | Notes |
 | --- | --- | --- |
@@ -452,7 +461,7 @@ All external-world interaction.
 
 | File | Responsibility |
 | --- | --- |
-| `ui/overlays.ts` | model/mode pickers, progress, result, dashboard screens |
+| `ui/overlays.ts` | progressive preflight, semantic phase progress, approval review, and dashboard screens |
 | `ui/dashboard-format.ts` | shared pure formatters for metrics surfaces |
 | `ui/dashboard-insights.ts` | Data Confidence, quality/provider drilldowns, and canary trust views |
 | `ui/metrics-report.ts` | text report + local HTML metrics dashboard |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 No changes yet.
 
+## [8.0.4] - 2026-08-07
+
+### Added
+
+- Manual `/smart-compact` now opens one keyboard-first preflight screen driven by the same calibrated planner used for execution. It shows estimated before/after window pressure, projected net savings, live-tail and summary budgets, soft boundaries that will be summarized, hard safeguards, and an explainable mode recommendation. `D` progressively reveals estimator and boundary details; `M` changes the summary route and recalculates the plan.
+- Semantic progress feedback reports Extract, optional Explore, Synthesize, Verify, and Apply without per-batch toast noise. Final feedback compares the plan with the applied estimate and appears only after Pi confirms the matching `session_compact` run ID.
+- Privacy-safe metrics/details now distinguish projected and applied estimates, yield, retention target, summary budget, relaxed soft-boundary kinds, and hard-boundary adjustment. Post-summary yield rejection has its own content-free failure kind.
+
+### Changed
+
+- Context reduction is now the binding success contract. Recent user turns, pi-toolkit checkpoints, and topical grouping are soft fidelity preferences retained only when they fit the mode budget; complete tool-call/result pairs and zero-gap verification remain hard.
+- Every plan must project at least 10% net savings before any LLM call. After synthesis and continuity repair, the measured summary must still meet the planned target and 10% floor or the run fails closed before staging/apply.
+- `requireApproval: false` no longer shows a redundant second result modal after the user approves the preflight. `requireApproval: true` retains the final verified-summary Apply/Cancel review.
+
+### Fixed
+
+- A long pair of user turns can no longer override an explicit manual tail target and turn a high-yield plan into a misleading low-yield success. The captured 174,797-token production replay now plans 144,588 tokens for compaction and about 30,209 for the live tail instead of retaining 167,352 tokens and saving only 5,764.
+- The configured summary route, not the active context model, is the default hidden-behind-Advanced model in manual preflight. Preview and execution share the same config snapshot, adaptive profile, calibration, and active branch.
+- Mode descriptions, narrow-terminal wrapping, active-versus-summary labels, and success timing now match actual behavior; `Applied` is never reported from an unconfirmed native callback.
+
 ## [8.0.3] - 2026-08-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pi install git:github.com/alpertarhan/pi-smart-compact
 ## Quick start
 
 ```bash
-/smart-compact                                         # interactive model + mode picker
+/smart-compact                                         # explainable single-screen preflight
 /smart-compact auto                                    # adaptive default
 /smart-compact anthropic/claude-sonnet-4 fast         # direct model + mode
 /smart-compact balanced --focus=auth                   # preserve extra auth detail
@@ -63,7 +63,7 @@ The design principle is simple:
 
 > **Facts first. Synthesis second. Verification before apply.**
 
-Any unresolved verification gap rejects the custom summary before staging or apply. A zero-gap deterministic fallback is preferred over unverifiable model output; only failure of that fallback rejects the run. Automatic failures leave Pi free to use its native compactor, while manual failures leave the conversation unchanged.
+Any unresolved verification gap rejects the custom summary before staging or apply. A zero-gap deterministic fallback is preferred over unverifiable model output; only failure of that fallback rejects the run. A successful compaction must also meet its mode target and at least 10% estimated net savings both before synthesis and after the final summary is measured. Automatic failures leave Pi free to use its native compactor, while manual failures leave the conversation unchanged.
 
 ## EESV pipeline
 
@@ -121,10 +121,32 @@ Set `contextGraphEnabled` to `false` to disable indexing and both tools.
 
 | Surface | Behavior |
 | --- | --- |
-| `/smart-compact` | Explicit manual run. Supports picker UI, direct args, dry-run, focus, and budgets. |
+| `/smart-compact` | Explicit manual run. Opens a target-first preflight or accepts direct args, dry-run, focus, and budgets. |
 | `session_before_compact` | Auto path. Returns/stages a verification-scored summary under pressure; durable state waits for matching `session_compact`. |
 | `smart_compact` tool | Agent path. Produces a pending summary for Pi's next natural compact; does not compact mid-turn. |
 | `/smart-compact loops` | Project-level open-loop manager: resolve/reopen, priority, pin/unpin. |
+
+### Manual preflight
+
+The interactive command uses the configured summary route and the exact
+execution planner before spending LLM tokens. The primary screen shows the
+recommended fidelity preset, why it fits the current pressure/session shape,
+estimated context before and after, projected savings, live-tail and summary
+budgets, soft boundaries that will be summarized, and the hard tool-pair plus
+zero-gap-verification guarantees.
+
+- `↑` / `↓` changes `Thorough`, `Balanced`, or `Fast` and recalculates the plan.
+- `Enter` runs only a viable plan; `Esc` cancels without mutation.
+- `D` toggles calibrated estimator, target, boundary, and route details.
+- `M` opens Advanced model selection and replans with that route's calibration.
+
+Values remain estimates until the next provider turn reports usage. Smart
+Compact therefore uses `~`/`≤` language, measures the completed summary again
+before staging, and reports final success only after Pi confirms the matching
+`session_compact` run ID. A single long user turn may be split at a safe message
+boundary: its older prefix is verified into the summary while the budgeted
+working tail stays raw. Tool exchanges are summarized or retained as complete
+call/result pairs, never split.
 
 ### Focus and budgets
 
@@ -155,7 +177,7 @@ The tool exposes equivalent `focus`, `max_calls`, `max_input_tokens`, and
 | `fast` | 3 | 100K | 20K | Favors larger single-pass windows and minimum waiting |
 | `thorough` (`slow` alias) | 8 | 300K | 80K | Maximum fidelity; enables Explore and one optional LLM repair |
 
-Fast and aggressive modes use a zero-call deterministic summary when extraction confidence is high; otherwise they keep the bounded LLM path. Auto planning also raises fidelity when scoped continuity or prior damage indicates risk. Recent-tail retention scales with model context while preserving the two newest user turns when enough history exists.
+Fast and aggressive modes use a zero-call deterministic summary when extraction confidence is high; otherwise they keep the bounded LLM path. Auto planning also raises fidelity when scoped continuity or prior damage indicates risk. The mode token target is binding: recent user turns, pi-toolkit checkpoints, and topical grouping remain raw only when they fit the planned tail; otherwise the verified summary carries them forward.
 
 Output caps stop subsequent calls after observed usage reaches the threshold.
 The ChatGPT Codex subscription endpoint rejects `max_output_tokens`,
@@ -257,10 +279,12 @@ handling or a dedicated DLP system**. See the
 
 ### Approval and feedback
 
-- `requireApproval: true` adds a fail-closed manual **Apply / Cancel** decision
-  after the provenance review screen. Every path stages first; fingerprint,
-  continuity state, context graph, and success telemetry commit only after the
-  host confirms the matching native `session_compact` event.
+- The manual preflight is the default decision point. `requireApproval: true`
+  additionally shows a fail-closed verified-summary **Apply / Cancel** review;
+  `false` avoids a redundant second modal. Fingerprint, continuity state,
+  context graph, and success telemetry commit only after the host confirms the
+  matching native `session_compact` event, and only then does the UI report
+  `Applied`.
 - Online damage monitoring observes the first post-compaction messages and
   records re-read files or repeated context. Observations join the originating
   compaction by a local run id; missing evidence lowers coverage rather than
@@ -346,16 +370,16 @@ Automatic and tool-triggered runs operate on Pi's current active context, not
 the append-only session history. A same-session staged summary is reused, the
 exploration loop is limited to three rounds, provider and outer retries are
 disabled, and every mode has finite call plus aggregate prompt-token budgets.
-If anchor/tool-call protection leaves too much live context to get below the
-configured trigger, automatic/tool runs normally spend no LLM tokens and let
-Pi's native compactor handle it. Overflow is the safety exception: if reported
-usage already exceeds the active model window, EESV summarizes through soft
-anchor/recent-turn protection while retaining complete tool-call pairs rather
-than resending an oversized one-shot prompt to native compaction. Manual
-`/smart-compact` is an explicit force path: it keeps the absolute adaptive
-safety tail rather than a percentage of the model window. Below-threshold,
-low-yield, or repeated manual runs warn but continue whenever a safe prefix
-exists. This makes 100K–200K sessions compactable even on 1M-token models.
+Complete tool-call/result pairs are the hard window boundary. Recent user
+turns, pi-toolkit checkpoints, and topical grouping are soft and may expand the
+raw tail only while remaining inside the selected budget. Automatic/tool runs
+normally return to Pi's native compactor without an LLM call when a hard
+boundary cannot meet the target. Overflow is the safety exception: EESV keeps
+chunked recovery rather than resending an oversized one-shot prompt to native
+compaction. Manual `/smart-compact` uses an absolute adaptive tail rather than
+a percentage of a large model window. A plan below 10% projected savings never
+starts; if the measured final summary misses the same yield/target contract,
+the run fails closed before staging or apply.
 
 <details>
 <summary><strong>All configuration keys</strong></summary>

--- a/docs/MIGRATING_TO_V8.md
+++ b/docs/MIGRATING_TO_V8.md
@@ -1,6 +1,6 @@
 # Migrating from v7 to v8
 
-This guide applies to the stable `8.0.3` release.
+This guide applies to the stable `8.0.4` release.
 
 ## Compatibility
 
@@ -31,7 +31,9 @@ rewritten during migration. v8.0.1+ filters legacy RC state that misclassified
 `npm error`/`npm notice` diagnostics as constraints, and v8.0.2 also removes legacy
 source-search output persisted as unresolved work; the next confirmed save persists
 the sanitized state. v8.0.3 keeps the same graph file and transparently opens it
-with `node:sqlite` under Pi or `bun:sqlite` in Bun tooling.
+with `node:sqlite` under Pi or `bun:sqlite` in Bun tooling. v8.0.4 changes only
+compaction planning, UX, and privacy-safe operational metrics; it requires no
+state or database migration.
 
 Facts remain conservative: absence from a new window is not deletion. A fact is
 removed only by an explicit resolved/superseded override.
@@ -85,7 +87,7 @@ See the README configuration table for budgets and monitoring options.
 ## Recommended rollout
 
 1. Back up `~/.pi/agent/settings.json` and the Smart Compact cache directory.
-2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.3`.
+2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.4`.
 3. Leave all model routes null initially.
 4. Keep `telemetryChannel: "stable"` unless intentionally running a separate
    canary cohort.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "engines": {

--- a/src/app/preflight.ts
+++ b/src/app/preflight.ts
@@ -1,0 +1,121 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { PROFILES } from "../constants.ts";
+import type { CompactConfig, EffectiveCompactionMode, LlmMessage, ProfileConfig, SessionMessageEntry } from "../types.ts";
+import { deriveProjectIdFromCwd } from "../utils/fingerprint.ts";
+import { computeToolCharPercentage } from "../utils/helpers.ts";
+import { readRecentDamageScores } from "../utils/damage.ts";
+import { makeTokenEstimator, type TokenCalibrationStore, type TokenEstimator } from "../utils/tokens.ts";
+import { MODE_POLICIES } from "./mode-policy.ts";
+import type { CompactionWindowPlan } from "./run-context.ts";
+import { planCompactionWindow } from "./steps/window.ts";
+
+export function preflightDamageMedian(cwd: string, config: CompactConfig): number {
+  if (!config.adaptiveDamageFeedback) return 0;
+  const recent = readRecentDamageScores(deriveProjectIdFromCwd(cwd), 5).slice(-3).sort((a, b) => a - b);
+  return recent.length ? recent[Math.floor(recent.length / 2)] : 0;
+}
+
+export interface PreparedPreflightProfile {
+  profileCfg: ProfileConfig;
+  estimator: TokenEstimator;
+  adapted: boolean;
+  damageMedian: number;
+}
+
+/** Shared deterministic preparation used by both the preview and the real run. */
+export function preparePreflightProfile(input: {
+  cwd: string;
+  summaryModel: Model<Api>;
+  mode: EffectiveCompactionMode;
+  tokenCalibration: TokenCalibrationStore;
+  config: CompactConfig;
+  damageMedian?: number;
+}): PreparedPreflightProfile {
+  const config = input.config;
+  const profile = MODE_POLICIES[input.mode].profile;
+  let profileCfg = { ...PROFILES[profile], ...(config.profiles?.[profile] ?? {}) };
+  const damageMedian = input.damageMedian ?? preflightDamageMedian(input.cwd, config);
+  if (damageMedian >= 25) {
+    profileCfg = {
+      ...profileCfg,
+      keepRecentTokens: Math.round(profileCfg.keepRecentTokens * (damageMedian >= 50 ? 1.5 : 1.25)),
+      summaryBudgetTokens: Math.round(profileCfg.summaryBudgetTokens * (damageMedian >= 50 ? 1.3 : 1.2)),
+    };
+  }
+  return {
+    profileCfg,
+    estimator: makeTokenEstimator(input.summaryModel.provider, input.summaryModel.id, input.tokenCalibration),
+    adapted: damageMedian >= 25,
+    damageMedian,
+  };
+}
+
+export interface ManualPreflight {
+  mode: EffectiveCompactionMode;
+  plan: CompactionWindowPlan | null;
+  reason: CompactionWindowPlan["reason"] | "not-enough-messages";
+  profileCfg: ProfileConfig;
+  totalTokens: number;
+  rawEstimatedMessageTokens: number;
+  estimatorScale: number;
+  adapted: boolean;
+  damageMedian: number;
+  contextWindowTokens: number;
+  contextPercent: number;
+  toolPercent: number;
+  overflowedContext: boolean;
+}
+
+export function planManualPreflight(
+  ctx: ExtensionContext,
+  summaryModel: Model<Api>,
+  mode: EffectiveCompactionMode,
+  tokenCalibration: TokenCalibrationStore,
+  config: CompactConfig,
+  damageMedian?: number,
+): ManualPreflight {
+  const prepared = preparePreflightProfile({ cwd: ctx.cwd, summaryModel, mode, tokenCalibration, config, damageMedian });
+  const manager = ctx.sessionManager;
+  const branch = typeof manager.buildContextEntries === "function" ? manager.buildContextEntries() : manager.getBranch();
+  const msgs = branch.filter(
+    (entry: { type: string; message?: unknown }) => entry.type === "message" && entry.message != null,
+  ) as SessionMessageEntry[];
+  const totalTokens = ctx.getContextUsage()?.tokens ?? 0;
+  const contextWindowTokens = ctx.model?.contextWindow ?? 0;
+  const contextPercent = contextWindowTokens > 0 ? totalTokens / contextWindowTokens * 100 : 0;
+  const toolPercent = computeToolCharPercentage(branch);
+  const overflowedContext = contextWindowTokens > 0 && totalTokens > contextWindowTokens;
+  const messageTokens = msgs.map(entry => prepared.estimator.message(entry.message as LlmMessage));
+  const rawEstimatedMessageTokens = messageTokens.reduce((sum, tokens) => sum + tokens, 0);
+  if (msgs.length < 3) {
+    return { mode, plan: null, reason: "not-enough-messages", profileCfg: prepared.profileCfg, totalTokens, rawEstimatedMessageTokens, estimatorScale: 1, adapted: prepared.adapted, damageMedian: prepared.damageMedian, contextWindowTokens, contextPercent, toolPercent, overflowedContext };
+  }
+  const plan = planCompactionWindow({
+    msgs,
+    branch: branch as unknown[],
+    messageTokens,
+    totalTokens,
+    modelContextWindow: ctx.model?.contextWindow,
+    mode,
+    profileCfg: prepared.profileCfg,
+    force: true,
+    overflowedContext,
+  });
+  const normalizedMessages = plan.compactTokens + plan.retainedTokens;
+  return {
+    mode,
+    plan,
+    reason: plan.reason,
+    profileCfg: prepared.profileCfg,
+    totalTokens,
+    rawEstimatedMessageTokens,
+    estimatorScale: rawEstimatedMessageTokens > 0 ? normalizedMessages / rawEstimatedMessageTokens : 1,
+    adapted: prepared.adapted,
+    damageMedian: prepared.damageMedian,
+    contextWindowTokens,
+    contextPercent,
+    toolPercent,
+    overflowedContext,
+  };
+}

--- a/src/app/run-context.ts
+++ b/src/app/run-context.ts
@@ -99,6 +99,8 @@ export interface RcBase {
   // `session_before_compact` events feed this same orchestrator without a
   // cast — the type system enforces the "shared surface" invariant.
   ctx: ExtensionContext;
+  /** Optional caller snapshot; prepareRun loads config only when absent. */
+  config?: CompactConfig;
   notify: Notifier;
   vlog: (msg: string) => void;
   services: SmartCompactServices;
@@ -151,6 +153,32 @@ export type PreparedRc = RcBase & PreparedExt;
 // summarize. Returning null from that step means "conversation too short" —
 // callers must handle the null before treating an Rc as Windowed.
 
+export type RelaxedSoftBoundary = "recent-user-turn" | "anchor" | "topical";
+export type CompactionPlanReason =
+  | "viable"
+  | "no-eligible-prefix"
+  | "unsafe-tool-boundary"
+  | "retention-target-exceeded"
+  | "mode-target-not-met"
+  | "insufficient-projected-saving";
+
+export interface CompactionWindowPlan {
+  keepFrom: number;
+  compactTokens: number;
+  retainedTokens: number;
+  projectedAfterTokens: number;
+  projectedSavedTokens: number;
+  projectedYield: number;
+  fixedContextTokens: number;
+  retentionTargetTokens: number;
+  summaryBudgetTokens: number;
+  targetAfterTokens: number;
+  hardBoundaryAdjusted: boolean;
+  viable: boolean;
+  reason: CompactionPlanReason;
+  relaxedSoftBoundaries: RelaxedSoftBoundary[];
+}
+
 export interface WindowedExt extends PreparedExt {
   readonly _windowed: true;
   sessionId: string;
@@ -166,6 +194,8 @@ export interface WindowedExt extends PreparedExt {
   compactTokens: number;
   /** Estimated retained-tail tokens, normalized to Pi's measured context. */
   accTokens: number;
+  /** Content-free plan used to gate execution and, later, preview it in the UI. */
+  compactionPlan: CompactionWindowPlan;
 }
 export type WindowedRc = RcBase & WindowedExt;
 

--- a/src/app/run-smart-compact.ts
+++ b/src/app/run-smart-compact.ts
@@ -26,7 +26,7 @@ import { resolveSessionId } from "../infra/session-identity.ts";
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type { CompactionMode, CompressionProfile } from "../types.ts";
 import { MODE_POLICIES, modeFromLegacyProfile, resolveMode } from "./mode-policy.ts";
-import { showResultScreen } from "../ui/overlays.ts";
+import { clearCompactProgress, showProgressOverlay, showResultScreen } from "../ui/overlays.ts";
 import * as log from "../utils/logger.ts";
 
 import type {
@@ -73,6 +73,8 @@ export interface SmartCompactOptions {
    * need?" explicit at the type level.
    */
   ctx: ExtensionContext;
+  /** Reuse a caller-loaded snapshot when preview and execution must agree. */
+  config?: import("../types.ts").CompactConfig;
   summaryModel: Model<Api>;
   segModel: Model<Api>;
   /** Optional explicit verification/repair route; defaults to the summary model. */
@@ -116,6 +118,7 @@ export interface SmartCompactOptions {
 function makeBase(opts: SmartCompactOptions): RcBase {
   const ctrl = new AbortController();
   const notify: Notifier = (msg, type = "info") => {
+    if (opts.autoTriggered && (type === "info" || type === "success")) return;
     opts.ctx.ui.notify(msg, type === "success" ? "info" : type);
   };
   const vlog = (msg: string) => { if (opts.verbose) log.info(msg); };
@@ -127,6 +130,7 @@ function makeBase(opts: SmartCompactOptions): RcBase {
   return {
     runId: randomUUID(),
     ctx: opts.ctx,
+    config: opts.config,
     notify,
     vlog,
     services: createProductionServices(),
@@ -184,6 +188,7 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
   // metrics. We populate it as soon as buildState returns; until then it's
   // null and the failure path uses `base` only.
   let finalRc: StatedRc | null = null;
+  let keepApplyProgress = false;
   let failureSummaryFields: {
     sessionId?: string; tier?: string; contextPercent?: number; toolPercent?: number;
     totalTokens?: number; methodForMetrics?: string; profile: string; mode?: CompactionMode;
@@ -226,8 +231,6 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
     markPhase(windowed, "prepare");
 
     if (!windowed.flags.autoTriggered) {
-      // Lazy import to avoid an early UI dependency for headless tests.
-      const { showProgressOverlay } = await import("../ui/overlays.ts");
       showProgressOverlay(windowed.ctx, { phase: 1, phaseName: "Extract", detail: "Preparing...", model: windowed.modelLabel, profile: windowed.profile });
     }
 
@@ -254,11 +257,6 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
     const stated = buildState(verified);
     finalRc = stated;
 
-    stated.notify(
-      "Done: " + describePipeline(stated) +
-        " — saved " + stated.tokensSaved.toLocaleString() + "t (" + duration(stated) + ")",
-      "success",
-    );
     stated.vlog(
       "Pipeline complete — method=" + stated.method + " calls=" + stated.llmCalls +
         " chunks=" + stated.chunkCount + " tokensSaved=" + stated.tokensSaved,
@@ -286,31 +284,18 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
     markPhase(stated, "damage");
 
     const willApply = !stated.flags.skipCompact && !stated.flags.autoTriggered;
-    if (!stated.flags.autoTriggered) {
-      const approvalRequired = willApply && stated.config.requireApproval && stated.ctx.hasUI;
-      let decision: "apply" | "cancel" | "closed" = approvalRequired ? "cancel" : "closed";
+    if (!stated.flags.autoTriggered && willApply && stated.config.requireApproval) {
+      let decision: "apply" | "cancel" | "closed" = "cancel";
       try {
-        if (approvalRequired) {
-          // Approval is fail-closed and never races an auto-apply timer.
-          decision = await showResultScreen(stated.ctx, stated.details, stated.extraction, stated.services, { approval: true });
-        } else {
-          let resultTimer: ReturnType<typeof setTimeout> | undefined;
-          const timeoutPromise = new Promise<"closed">(resolve => { resultTimer = setTimeout(() => resolve("closed"), 5000); });
-          try {
-            decision = await Promise.race([
-              showResultScreen(stated.ctx, stated.details, stated.extraction, stated.services),
-              timeoutPromise,
-            ]);
-          } finally {
-            if (resultTimer) clearTimeout(resultTimer);
-          }
-        }
+        // Approval is fail-closed and never races an auto-apply timer.
+        decision = stated.ctx.hasUI
+          ? await showResultScreen(stated.ctx, stated.details, stated.extraction, stated.services, { approval: true })
+          : "cancel";
       } catch (err) {
-        log.warn("Result screen error", err);
-        stated.notify(approvalRequired ? "Approval UI failed — compaction cancelled" : "Result screen skipped", approvalRequired ? "warning" : "info");
-        decision = approvalRequired ? "cancel" : "closed";
+        log.warn("Approval UI error", err);
+        stated.notify("Approval UI failed — compaction cancelled", "warning");
       }
-      if (approvalRequired && decision !== "apply") {
+      if (decision !== "apply") {
         stated.pendingRef.clear(stated.sessionId);
         recordSuccessMetrics(stated, "cancelled");
         stated.notify("Compaction cancelled — current conversation unchanged", "info");
@@ -324,13 +309,19 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
     // Snapshot telemetry now, but append it only after session_compact proves
     // Pi applied this exact runId. This prevents failed native compactions
     // from being reported or persisted as successful.
+    if (willApply) {
+      showProgressOverlay(stated.ctx, { phase: 5, phaseName: "Apply", detail: "Awaiting Pi confirmation..." });
+    }
     stagePendingCompaction(stated, buildSuccessMetrics(stated, "success"));
     if (stated.cancellation.timedOut) {
       stated.pendingRef.clear(stated.sessionId);
       return;
     }
 
-    if (willApply) applyCompaction(stated);
+    if (willApply) {
+      applyCompaction(stated);
+      keepApplyProgress = true;
+    }
   } catch (err) {
     // The failure path may run before any step has populated stage data, so
     // we collect the few fields we need into a small bag. recordFailureMetrics
@@ -341,6 +332,7 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
     opts.abortSignal?.removeEventListener("abort", abortFromHost);
     if (base.cancellation.timeoutId) clearTimeout(base.cancellation.timeoutId);
     releaseRunLock(opts.isRunning, runSessionId);
+    if (!keepApplyProgress) clearCompactProgress(base.ctx);
     // If the timeout fired we always clear the pending summary so a stale
     // payload cannot be picked up by the next session_before_compact event.
     if (base.cancellation.timedOut) {
@@ -364,18 +356,4 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
       );
     }
   }
-}
-
-function describePipeline(rc: StatedRc): string {
-  if (rc.method === "eesv") {
-    return "EESV: Extract > Explore (" + rc.explorationRounds + "r) > Synthesize (" +
-      (rc.chunkCount || 1) + " chunks) > Verify (" +
-      (rc.verified ? "pass" : rc.verificationGaps.length + " gaps") + ")";
-  }
-  return rc.method + " (" + (rc.chunkCount || 1) + " chunks, " + rc.llmCalls + " calls)";
-}
-
-function duration(rc: StatedRc): string {
-  const pipelineMs = Date.now() - rc.pipelineStart;
-  return pipelineMs < 1000 ? pipelineMs + "ms" : (pipelineMs / 1000).toFixed(1) + "s";
 }

--- a/src/app/steps/metrics.ts
+++ b/src/app/steps/metrics.ts
@@ -47,6 +47,7 @@ export function buildSuccessMetrics(
   status: "success" | "dry-run" | "cancelled",
 ): MetricsSnapshot {
   const ecs = getExtractionCacheStats(rc.services);
+  const details = rc.details ?? {} as StatedRc["details"];
   return {
     ...getMetricsSummary(rc.services),
     runId: rc.runId,
@@ -59,6 +60,18 @@ export function buildSuccessMetrics(
     toolPercent: rc.toolPercent,
     tokensBefore: rc.totalTokens,
     tokensSaved: rc.tokensSaved,
+    plannedAfterTokens: details.plannedAfterTokens,
+    plannedSavedTokens: details.plannedSavedTokens,
+    plannedYield: details.plannedYield,
+    estimatedAfterTokens: details.estimatedAfterTokens,
+    estimatedSavedTokens: details.estimatedSavedTokens,
+    estimatedYield: details.estimatedYield,
+    retainedTailTokens: details.retainedTailTokens,
+    summaryTokens: details.summaryTokens,
+    summaryBudgetTokens: details.summaryBudgetTokens,
+    targetAfterTokens: details.targetAfterTokens,
+    relaxedSoftBoundaries: details.relaxedSoftBoundaries,
+    hardBoundaryAdjusted: details.hardBoundaryAdjusted,
     pruneSavedTokens: rc.pruning?.prunedTokenSaving,
     chunkCount: rc.chunkCount || 1,
     verificationScore: rc.verificationScore,
@@ -129,8 +142,19 @@ export function recordFailureMetrics(
     ?? loadConfig().telemetryChannel;
   const failureKind = classifyTelemetryFailure(err, rc.cancellation.timedOut);
   const gate = err && typeof err === "object"
-    ? err as { score?: unknown; initialScore?: unknown; gapCount?: unknown; gapKinds?: unknown }
+    ? err as {
+      score?: unknown; initialScore?: unknown; gapCount?: unknown; gapKinds?: unknown;
+      plannedAfterTokens?: unknown; plannedSavedTokens?: unknown; plannedYield?: unknown;
+      estimatedAfterTokens?: unknown; estimatedSavedTokens?: unknown; estimatedYield?: unknown;
+      retainedTailTokens?: unknown; summaryTokens?: unknown; summaryBudgetTokens?: unknown;
+      targetAfterTokens?: unknown; relaxedSoftBoundaries?: unknown; hardBoundaryAdjusted?: unknown;
+    }
     : null;
+  const finite = (value: unknown) => typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  const softKinds = new Set(["recent-user-turn", "anchor", "topical"]);
+  const relaxedSoftBoundaries = Array.isArray(gate?.relaxedSoftBoundaries)
+    ? gate.relaxedSoftBoundaries.filter((kind): kind is "recent-user-turn" | "anchor" | "topical" => typeof kind === "string" && softKinds.has(kind))
+    : undefined;
   const knownGapKinds = new Set<VerificationGap["kind"]>([
     "missing-section", "missing-file", "missing-error", "missing-constraint", "missing-decision",
     "missing-goal", "fabricated-file", "inconsistency", "missing-open-loops",
@@ -154,6 +178,18 @@ export function recordFailureMetrics(
     contextPercent: fields.contextPercent != null ? Math.round(fields.contextPercent) : undefined,
     toolPercent: fields.toolPercent,
     tokensBefore: fields.totalTokens,
+    plannedAfterTokens: finite(gate?.plannedAfterTokens),
+    plannedSavedTokens: finite(gate?.plannedSavedTokens),
+    plannedYield: finite(gate?.plannedYield),
+    estimatedAfterTokens: finite(gate?.estimatedAfterTokens),
+    estimatedSavedTokens: finite(gate?.estimatedSavedTokens),
+    estimatedYield: finite(gate?.estimatedYield),
+    retainedTailTokens: finite(gate?.retainedTailTokens),
+    summaryTokens: finite(gate?.summaryTokens),
+    summaryBudgetTokens: finite(gate?.summaryBudgetTokens),
+    targetAfterTokens: finite(gate?.targetAfterTokens),
+    relaxedSoftBoundaries,
+    hardBoundaryAdjusted: typeof gate?.hardBoundaryAdjusted === "boolean" ? gate.hardBoundaryAdjusted : undefined,
     method: fields.methodForMetrics,
     model: rc.modelLabel,
     provider: rc.summaryModel.provider,

--- a/src/app/steps/persist.ts
+++ b/src/app/steps/persist.ts
@@ -32,6 +32,7 @@ import { recordFailureMetrics } from "./metrics.ts";
 import type { StatedRc } from "../run-context.ts";
 import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { asBranchMessage } from "../../infra/ai-messages.ts";
+import { clearCompactProgress } from "../../ui/overlays.ts";
 
 import * as log from "../../utils/logger.ts";
 
@@ -144,10 +145,9 @@ export function applyCompaction(rc: StatedRc): void {
   if (rc.flags.skipCompact || rc.flags.autoTriggered) return;
   rc.ctx.compact({
     customInstructions: "Use pre-computed smart summary from /smart-compact",
-    onComplete: () => {
-      rc.ctx.ui.notify("Applied \u2713", "info");
-    },
+    onComplete: () => { /* session_compact owns correlated success feedback */ },
     onError: e => {
+      clearCompactProgress(rc.ctx);
       rc.pendingRef.clear(rc.sessionId);
       const handled = rc.onNativeApplyError?.(rc.runId, e) ?? false;
       if (!handled) {

--- a/src/app/steps/prepare.ts
+++ b/src/app/steps/prepare.ts
@@ -11,33 +11,25 @@
 import type { RcBase, PreparedRc, ResolvedAuth } from "../run-context.ts";
 import { advance } from "../run-context.ts";
 import { effectiveBudget, MODE_POLICIES } from "../mode-policy.ts";
-import { DEFAULT_CONFIG, PROFILES } from "../../constants.ts";
-import { getProviderCaps, makeTokenEstimator } from "../../utils/tokens.ts";
+import { DEFAULT_CONFIG } from "../../constants.ts";
+import { getProviderCaps } from "../../utils/tokens.ts";
 import { loadConfig } from "../../utils/helpers.ts";
+import { preparePreflightProfile } from "../preflight.ts";
 import * as log from "../../utils/logger.ts";
 import { SecretScrubber } from "../../domain/scrub.ts";
 import { BudgetGuard } from "../../infra/services.ts";
-import { deriveProjectIdFromCwd } from "../../utils/fingerprint.ts";
-import { readRecentDamageScores } from "../../utils/damage.ts";
 
 export async function prepareRun(rc: RcBase): Promise<PreparedRc | null> {
-  const config = loadConfig();
-  let profileCfg = { ...PROFILES[rc.profile], ...(config.profiles?.[rc.profile] ?? {}) };
-  let adapted = false;
-  if (config.adaptiveDamageFeedback) {
-    const scores = readRecentDamageScores(deriveProjectIdFromCwd(rc.ctx.cwd), 5);
-    const recent = scores.slice(-3).sort((a, b) => a - b);
-    const median = recent.length ? recent[Math.floor(recent.length / 2)] : 0;
-    if (median >= 25) {
-      const multiplier = median >= 50 ? 1.5 : 1.25;
-      profileCfg = {
-        ...profileCfg,
-        keepRecentTokens: Math.round(profileCfg.keepRecentTokens * multiplier),
-        summaryBudgetTokens: Math.round(profileCfg.summaryBudgetTokens * (median >= 50 ? 1.3 : 1.2)),
-      };
-      adapted = true;
-      rc.notify("Adaptive damage policy: median " + median + "/100 — preserving more recent context", "warning");
-    }
+  const config = rc.config ?? loadConfig();
+  const { profileCfg, estimator, adapted, damageMedian } = preparePreflightProfile({
+    cwd: rc.ctx.cwd,
+    summaryModel: rc.summaryModel,
+    mode: rc.mode,
+    tokenCalibration: rc.services.tokenCalibration,
+    config,
+  });
+  if (adapted) {
+    rc.notify("Adaptive damage policy: median " + damageMedian + "/100 — preserving more recent context", "info");
   }
   const providerCaps = getProviderCaps(rc.summaryModel.provider);
   rc.services.thinkingLevels = {
@@ -53,7 +45,6 @@ export async function prepareRun(rc: RcBase): Promise<PreparedRc | null> {
   const callBudget = rc.maxLlmCalls ?? effectiveBudget(config.maxLlmCalls, policy.maxLlmCalls);
   const inputBudget = rc.maxLlmInputTokens ?? effectiveBudget(config.maxLlmInputTokens, policy.maxInputTokens);
   rc.services.budget = new BudgetGuard(callBudget, rc.timeoutMs, rc.services.clock, inputBudget, policy.maxOutputTokens);
-  const estimator = makeTokenEstimator(rc.summaryModel.provider, rc.summaryModel.id, rc.services.tokenCalibration);
 
   if (rc.timeoutMs > 0) {
     rc.cancellation.timeoutId = setTimeout(() => {

--- a/src/app/steps/state.ts
+++ b/src/app/steps/state.ts
@@ -24,6 +24,7 @@ import { VERSION } from "../../constants.ts";
 import {
   verifySummary, repairSummaryDeterministically, formatVerificationGap, verificationFailureMessage, VerificationGateError,
 } from "../../phases/verify.ts";
+import { verifyCompactionYield } from "../../domain/yield-gate.ts";
 
 export function buildState(rc: VerifiedRc): StatedRc {
   const extraction = rc.extraction;
@@ -127,10 +128,8 @@ export function buildState(rc: VerifiedRc): StatedRc {
 
   const detModified = extraction.modifiedFiles.map(f => f.path);
   const detRead = extraction.readFiles;
-  // Compare the replaced prefix with its replacement summary. Subtracting an
-  // estimated retained tail from Pi's measured total mixes token scales when
-  // another context hook truncates tool output, producing false 0% savings.
-  const tokensSaved = Math.max(0, Math.min(rc.totalTokens, rc.compactTokens - rc.estimator.text(summary)));
+  const yieldEstimate = verifyCompactionYield(rc.totalTokens, rc.estimator.text(summary), rc.compactionPlan);
+  const tokensSaved = yieldEstimate.estimatedSavedTokens;
 
   const details: SmartCompactDetails = {
     runId: rc.runId,
@@ -152,6 +151,7 @@ export function buildState(rc: VerifiedRc): StatedRc {
     releaseChannel: rc.config?.telemetryChannel ?? "stable",
     qualityScore: rc.verificationScore,
     tokensBefore: rc.totalTokens,
+    ...yieldEstimate,
     provenance: rc.verificationProvenance,
     compactionState, openLoops,
     redactions: rc.services.scrubber.count(),

--- a/src/app/steps/synthesize.ts
+++ b/src/app/steps/synthesize.ts
@@ -144,7 +144,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
   } else if (rc.convTokens < singlePassMaxTokens) {
     if (!rc.flags.autoTriggered) {
       showProgressOverlay(rc.ctx, {
-        phase: 2, phaseName: "Explore",
+        phase: 3, phaseName: "Synthesize",
         detail: "Single-pass (" + rc.convTokens.toLocaleString() + "t)",
         model: rc.modelLabel, profile: rc.profile, extraction,
       });
@@ -246,7 +246,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
     if (!rc.flags.autoTriggered) {
       showProgressOverlay(rc.ctx, {
         phase: 3, phaseName: "Synthesize", detail: "0/" + totalBatches + " batches",
-        model: rc.modelLabel, profile: rc.profile, extraction, totalBatches,
+        model: rc.modelLabel, profile: rc.profile, extraction, explorationRounds, totalBatches,
       });
     }
 
@@ -310,7 +310,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
             showProgressOverlay(rc.ctx, {
               phase: 3, phaseName: "Synthesize",
               detail: completed + "/" + totalBatches + " batches",
-              model: rc.modelLabel, profile: rc.profile, extraction,
+              model: rc.modelLabel, profile: rc.profile, extraction, explorationRounds,
               totalBatches, currentBatch: completed,
             });
           }
@@ -324,7 +324,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
     if (!rc.flags.autoTriggered) {
       showProgressOverlay(rc.ctx, {
         phase: 3, phaseName: "Synthesize", detail: "Assembling...",
-        model: rc.modelLabel, profile: rc.profile, extraction, totalBatches: batches.length,
+        model: rc.modelLabel, profile: rc.profile, extraction, explorationRounds, totalBatches: batches.length,
       });
     }
     try {

--- a/src/app/steps/window.ts
+++ b/src/app/steps/window.ts
@@ -1,200 +1,204 @@
-/**
- * Step 2: pick the compaction window.
- *
- * Stage: `PreparedRc` → `WindowedRc | null`.
- *
- * The window is the prefix of active-context messages we will summarize. Walks back
- * from the tail accumulating tokens up to `keepRecentTokens`, then anchors:
- *
- *  - `smartKeepBoundary` respects the latest on-branch anchor and avoids
- *    splitting topical groups.
- *  - `guardToolCallBoundary` rejects boundaries that would orphan a
- *    `toolResult` from its `toolCall`.
- *
- * Returns `null` when the conversation is too small to compact.
- */
+/** Step 2: select and validate the active-context prefix to summarize. */
 
-import type { PreparedRc, WindowedRc } from "../run-context.ts";
+import type {
+  CompactionPlanReason, CompactionWindowPlan, PreparedRc, RelaxedSoftBoundary, WindowedRc,
+} from "../run-context.ts";
 import { advance } from "../run-context.ts";
-import type { LlmMessage, SessionMessageEntry } from "../../types.ts";
+import type { EffectiveCompactionMode, LlmMessage, ProfileConfig, SessionMessageEntry } from "../../types.ts";
 import { MODE_POLICIES, modeFromLegacyProfile } from "../mode-policy.ts";
-import { smartKeepBoundary, guardToolCallBoundary } from "../../utils/helpers.ts";
+import { advancePastToolCallBoundary, guardToolCallBoundary, smartKeepBoundaryCandidates } from "../../utils/helpers.ts";
 import { resolveSessionId } from "../../infra/session-identity.ts";
-import { MIN_TOKEN_THRESHOLD } from "../../constants.ts";
+import { MIN_COMPACTION_SAVING_RATIO } from "../../constants.ts";
+
+export type { CompactionWindowPlan } from "../run-context.ts";
+
+export interface CompactionWindowPlanInput {
+  msgs: SessionMessageEntry[];
+  branch: unknown[];
+  messageTokens: number[];
+  totalTokens: number;
+  modelContextWindow?: number;
+  mode: EffectiveCompactionMode;
+  profileCfg: ProfileConfig;
+  force: boolean;
+  overflowedContext: boolean;
+}
+
+/** Pure, content-free result suitable for both execution and a later UI preview. */
+export function planCompactionWindow(input: CompactionWindowPlanInput): CompactionWindowPlan {
+  const {
+    msgs, branch, messageTokens, totalTokens, modelContextWindow, mode, profileCfg, force, overflowedContext,
+  } = input;
+  const allMessageTokens = messageTokens.reduce((sum, tokens) => sum + tokens, 0);
+  const messageScale = totalTokens > 0 && allMessageTokens > 0 && (allMessageTokens > totalTokens || overflowedContext)
+    ? totalTokens / allMessageTokens
+    : 1;
+  const fixedContextTokens = overflowedContext ? 0 : Math.max(0, totalTokens - allMessageTokens);
+  const adaptiveKeepTokens = modelContextWindow
+    ? Math.min(profileCfg.keepRecentTokens * 2, Math.max(profileCfg.keepRecentTokens, modelContextWindow * 0.04))
+    : profileCfg.keepRecentTokens;
+  const targetPercent = MODE_POLICIES[mode].targetContextPercent;
+  const targetRetainedTokens = modelContextWindow
+    ? Math.max(0, modelContextWindow * targetPercent / 100 - fixedContextTokens - profileCfg.summaryBudgetTokens)
+    : adaptiveKeepTokens;
+  const retentionCeiling = force ? adaptiveKeepTokens : Math.max(adaptiveKeepTokens, targetRetainedTokens);
+  const rawMinimumTail = adaptiveKeepTokens / messageScale;
+  const rawRetentionCeiling = retentionCeiling / messageScale;
+
+  let rawRetained = 0;
+  let keepFrom = msgs.length - 1;
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const next = messageTokens[i];
+    if (rawRetained >= rawMinimumTail && rawRetained + next > rawRetentionCeiling) {
+      keepFrom = i + 1;
+      break;
+    }
+    rawRetained += next;
+    keepFrom = i;
+  }
+
+  const relaxedSoftBoundaries: RelaxedSoftBoundary[] = [];
+  const retainedAt = (from: number) => Math.round(messageTokens.slice(from).reduce((sum, tokens) => sum + tokens, 0) * messageScale);
+  // Message boundaries can overshoot the token ceiling by one message; that
+  // baseline is the tightest plan this pipeline can represent.
+  const effectiveRetentionCeiling = Math.max(retentionCeiling, retainedAt(keepFrom));
+  let hardBoundaryAdjusted = false;
+  const trySoftBoundary = (kind: RelaxedSoftBoundary, candidate: number | undefined) => {
+    if (candidate === undefined || candidate >= keepFrom) return;
+    const guarded = guardToolCallBoundary(msgs, candidate);
+    if (retainedAt(guarded) <= effectiveRetentionCeiling) {
+      keepFrom = guarded;
+      hardBoundaryAdjusted ||= guarded !== candidate;
+    } else relaxedSoftBoundaries.push(kind);
+  };
+
+  const users = msgs
+    .map((entry, index) => ({ index, role: (entry.message as { role?: string })?.role }))
+    .filter(entry => entry.role === "user");
+  const protectedUser = users.at(users.length >= 2 ? -2 : -1);
+  trySoftBoundary("recent-user-turn", protectedUser?.index);
+
+  const anchor = smartKeepBoundaryCandidates(msgs, keepFrom, branch).find(candidate => candidate.kind === "anchor");
+  trySoftBoundary("anchor", anchor?.keepFrom);
+  const topical = smartKeepBoundaryCandidates(msgs, keepFrom).find(candidate => candidate.kind === "topical");
+  trySoftBoundary("topical", topical?.keepFrom);
+
+  const boundaryBeforeHardGuard = keepFrom;
+  const backwardBoundary = guardToolCallBoundary(msgs, keepFrom);
+  const forwardBoundary = retainedAt(backwardBoundary) > effectiveRetentionCeiling
+    ? advancePastToolCallBoundary(msgs, keepFrom)
+    : keepFrom;
+  keepFrom = forwardBoundary > keepFrom && forwardBoundary < msgs.length && retainedAt(forwardBoundary) <= effectiveRetentionCeiling
+    ? forwardBoundary
+    : backwardBoundary;
+  hardBoundaryAdjusted ||= keepFrom !== boundaryBeforeHardGuard;
+  const compactTokens = Math.round(messageTokens.slice(0, keepFrom).reduce((sum, tokens) => sum + tokens, 0) * messageScale);
+  const retainedTokens = retainedAt(keepFrom);
+  const projectedAfterTokens = fixedContextTokens + retainedTokens + profileCfg.summaryBudgetTokens;
+  const projectedSavedTokens = Math.max(0, totalTokens - projectedAfterTokens);
+  const projectedYield = totalTokens > 0 ? projectedSavedTokens / totalTokens : 0;
+  const targetAfterTokens = !force && modelContextWindow
+    ? modelContextWindow * targetPercent / 100
+    : fixedContextTokens + effectiveRetentionCeiling + profileCfg.summaryBudgetTokens;
+
+  let reason: CompactionPlanReason = "viable";
+  if ((msgs[keepFrom]?.message as { role?: string } | undefined)?.role === "toolResult") reason = "unsafe-tool-boundary";
+  else if (keepFrom <= 0) reason = "no-eligible-prefix";
+  else if (retainedTokens > effectiveRetentionCeiling) reason = "retention-target-exceeded";
+  else if (!force && modelContextWindow && projectedAfterTokens > targetAfterTokens) reason = "mode-target-not-met";
+  else if (projectedYield < MIN_COMPACTION_SAVING_RATIO) reason = "insufficient-projected-saving";
+
+  return {
+    keepFrom,
+    compactTokens,
+    retainedTokens,
+    projectedAfterTokens,
+    projectedSavedTokens,
+    projectedYield,
+    fixedContextTokens,
+    retentionTargetTokens: effectiveRetentionCeiling,
+    summaryBudgetTokens: profileCfg.summaryBudgetTokens,
+    targetAfterTokens,
+    hardBoundaryAdjusted,
+    viable: reason === "viable",
+    reason,
+    relaxedSoftBoundaries,
+  };
+}
 
 export function resolveCompactionWindow(rc: PreparedRc): WindowedRc | null {
-  const usage = rc.ctx.getContextUsage();
-  const totalTokens = usage?.tokens ?? 0;
-
-  // getBranch() is append-only history and still contains messages already
-  // replaced by earlier compactions. Only buildContextEntries() represents
-  // what the model currently sees; summarizing full history caused repeated
-  // compactions to process the same six-figure prefix again.
+  const totalTokens = rc.ctx.getContextUsage()?.tokens ?? 0;
   const manager = rc.ctx.sessionManager;
-  const branch = typeof manager.buildContextEntries === "function"
-    ? manager.buildContextEntries()
-    : manager.getBranch();
+  const branch = typeof manager.buildContextEntries === "function" ? manager.buildContextEntries() : manager.getBranch();
   const msgs = branch.filter(
-    (e: { type: string; id?: string; message?: unknown }) => e.type === "message" && e.message != null,
+    (entry: { type: string; message?: unknown }) => entry.type === "message" && entry.message != null,
   ) as SessionMessageEntry[];
   if (msgs.length < 3) {
     if (rc.flags.force) rc.notify("Manual compaction skipped: fewer than 3 active messages are available.", "warning");
     return null;
   }
 
-  const adaptiveKeepTokens = rc.ctx.model
-    ? Math.min(rc.profileCfg.keepRecentTokens * 2, Math.max(rc.profileCfg.keepRecentTokens, rc.ctx.model.contextWindow * 0.04))
-    : rc.profileCfg.keepRecentTokens;
   const mode = rc.mode ?? (rc.profile ? modeFromLegacyProfile(rc.profile) : "balanced");
-  const targetPercent = MODE_POLICIES[mode].targetContextPercent;
-  const messageTokens = msgs.map(entry => rc.estimator.message(entry.message as LlmMessage));
-  const allMessageTokens = messageTokens.reduce((sum, tokens) => sum + tokens, 0);
   const overflowedContext = !!rc.flags.overflowRecovery || (!!rc.ctx.model && totalTokens > rc.ctx.model.contextWindow);
-  // A model switch or a stale provider usage sample can report more context
-  // than the active model accepts while the locally visible messages estimate
-  // much lower. In that recovery state, treating the entire delta as an
-  // uncompactable system prompt makes every EESV window look non-viable and
-  // delegates the already-oversized request to native's single LLM call. Map
-  // measured usage back across active messages instead; over-compacting is the
-  // only fail-safe direction when the current model cannot accept the context.
-  const messageScale = totalTokens > 0 && allMessageTokens > 0 && (allMessageTokens > totalTokens || overflowedContext)
-    ? totalTokens / allMessageTokens
-    : 1;
-  const fixedContextTokens = overflowedContext ? 0 : Math.max(0, totalTokens - allMessageTokens);
-  const targetRetainedTokens = rc.ctx.model
-    ? Math.max(0, rc.ctx.model.contextWindow * targetPercent / 100 - fixedContextTokens - rc.profileCfg.summaryBudgetTokens)
-    : adaptiveKeepTokens;
-  // Automatic/tool runs retain up to the model-relative target. An explicit
-  // manual command is the user's decision to compact now, so preserve the
-  // absolute adaptive safety tail instead of letting a 1M window turn 40–50%
-  // into a 400–500K no-op budget.
-  const retentionBudget = rc.flags.force
-    ? adaptiveKeepTokens
-    : Math.max(adaptiveKeepTokens, targetRetainedTokens);
-  // Selection uses raw per-message estimates, while both budgets above are in
-  // Pi-measured tokens. Scale the thresholds into the estimator's units before
-  // walking so an overestimating provider calibration cannot halve the safety
-  // tail or make only aggressive mode cross the boundary.
-  const rawAdaptiveKeepTokens = adaptiveKeepTokens / messageScale;
-  const rawRetentionBudget = retentionBudget / messageScale;
-  let accTokens = 0;
-  let keepFrom = msgs.length - 1;
-  for (let i = msgs.length - 1; i >= 0; i--) {
-    const next = messageTokens[i];
-    if (accTokens >= rawAdaptiveKeepTokens && accTokens + next > rawRetentionBudget) {
-      keepFrom = i + 1;
-      break;
-    }
-    accTokens += next;
-    keepFrom = i;
-  }
-  const plannedKeepFrom = keepFrom;
-  const recentUsers = msgs
-    .map((entry, index) => ({ index, role: (entry.message as { role?: string })?.role }))
-    .filter(entry => entry.role === "user");
-  if (recentUsers.length) {
-    const protectedUser = recentUsers[recentUsers.length >= 2 ? recentUsers.length - 2 : recentUsers.length - 1];
-    keepFrom = Math.min(keepFrom, protectedUser.index);
-  }
-  keepFrom = smartKeepBoundary(msgs, keepFrom, branch);
-  keepFrom = guardToolCallBoundary(msgs, keepFrom);
-
-  // Anchor/recent-turn protection is a fidelity preference; intact tool-call
-  // pairs are the hard boundary. If the soft protections retain far more than
-  // the selected budget, summarize through them with EESV rather than handing
-  // an oversized one-shot prompt to native compaction.
-  const recount = (from: number) => ({
-    compact: Math.round(messageTokens.slice(0, from).reduce((sum, tokens) => sum + tokens, 0) * messageScale),
-    retained: Math.round(messageTokens.slice(from).reduce((sum, tokens) => sum + tokens, 0) * messageScale),
+  const plan = planCompactionWindow({
+    msgs,
+    branch: branch as unknown[],
+    messageTokens: msgs.map(entry => rc.estimator.message(entry.message as LlmMessage)),
+    totalTokens,
+    modelContextWindow: rc.ctx.model?.contextWindow,
+    mode,
+    profileCfg: rc.profileCfg,
+    force: rc.flags.force,
+    overflowedContext,
   });
-  let counts = recount(keepFrom);
-  const softProtectionBudget = rc.flags.force
-    ? Math.max(retentionBudget, adaptiveKeepTokens * 2)
-    : retentionBudget;
-  const protectionCeiling = fixedContextTokens + softProtectionBudget + rc.profileCfg.summaryBudgetTokens;
-  if (overflowedContext && keepFrom < plannedKeepFrom && fixedContextTokens + counts.retained + rc.profileCfg.summaryBudgetTokens > protectionCeiling) {
-    keepFrom = guardToolCallBoundary(msgs, plannedKeepFrom);
-    counts = recount(keepFrom);
+
+  if (!plan.viable) {
+    if (rc.flags.force) {
+      const detail = plan.reason === "insufficient-projected-saving"
+        ? "projected saving is below 10%."
+        : plan.reason === "unsafe-tool-boundary"
+          ? "no safe tool-call boundary is available."
+          : plan.reason === "no-eligible-prefix"
+            ? "no eligible prefix remains."
+            : plan.reason === "retention-target-exceeded"
+              ? "a complete tool pair exceeds the retention target."
+              : "the projected context remains above the mode target.";
+      rc.notify("Manual compaction skipped: " + detail, "warning");
+    } else {
+      rc.notify("Smart compact skipped: the safe plan cannot meet its target; using native compaction instead.", "warning");
+    }
+    return null;
+  }
+
+  if (overflowedContext && plan.relaxedSoftBoundaries.length) {
     rc.notify(
       "Context exceeds the active model window. EESV will summarize through soft recent-turn/checkpoint protections while preserving complete tool-call pairs; native fallback would resend the oversized context.",
       "warning",
     );
   }
-  const compactTokens = counts.compact;
-  accTokens = counts.retained;
 
-  if ((msgs[keepFrom]?.message as Record<string, unknown> | undefined)?.role === "toolResult") {
-    if (rc.flags.force) rc.notify("Manual compaction skipped: no safe boundary can separate the retained tool result from its tool call.", "warning");
-    return null;
+  const contextPercent = rc.ctx.model && totalTokens ? totalTokens / rc.ctx.model.contextWindow * 100 : 0;
+  if (rc.flags.force && rc.config.minContextPercent > 0 && contextPercent < rc.config.minContextPercent) {
+    rc.notify(
+      "Manual compaction override at " + Math.round(contextPercent) + "% (" + totalTokens.toLocaleString() +
+        "t): compacting about " + plan.compactTokens.toLocaleString() + "t while preserving " +
+        plan.retainedTokens.toLocaleString() + "t of recent context. Early compaction is lossy; verification remains fail-closed.",
+      "warning",
+    );
   }
 
-  const toCompact = msgs.slice(0, keepFrom);
-  if (!toCompact.length) {
-    if (rc.flags.force) {
-      rc.notify(
-        "Manual compaction skipped: no eligible prefix remains after protecting recent user turns and tool-call boundaries. It may have been run again too soon.",
-        "warning",
-      );
-    }
-    return null;
-  }
-
-  const contextPercent = rc.ctx.model && totalTokens ? (totalTokens / rc.ctx.model.contextWindow) * 100 : 0;
-  if (rc.flags.force) {
-    const lowYield = compactTokens <= rc.profileCfg.summaryBudgetTokens + MIN_TOKEN_THRESHOLD
-      || (totalTokens > 0 && compactTokens / totalTokens < 0.1);
-    if (lowYield) {
-      rc.notify(
-        "Low-yield manual compaction: only " + compactTokens.toLocaleString() +
-          "t are eligible after preserving " + accTokens.toLocaleString() +
-          "t of recent context. Continuing because you requested it; repeated compaction may lose nuance.",
-        "warning",
-      );
-    } else if (rc.config.minContextPercent > 0 && contextPercent < rc.config.minContextPercent) {
-      rc.notify(
-        "Manual compaction override at " + Math.round(contextPercent) + "% (" +
-          totalTokens.toLocaleString() + "t): compacting about " + compactTokens.toLocaleString() +
-          "t while preserving " + accTokens.toLocaleString() +
-          "t of recent context. Early compaction is lossy; verification remains fail-closed.",
-        "warning",
-      );
-    }
-  }
-  if (!rc.flags.force && !overflowedContext && rc.ctx.model && totalTokens > 0 && rc.config.minContextPercent > 0) {
-    const projectedTokens = fixedContextTokens + accTokens + rc.profileCfg.summaryBudgetTokens;
-    const targetTokens = rc.ctx.model.contextWindow * targetPercent / 100;
-    if (projectedTokens > targetTokens) {
-      rc.notify(
-        "Smart compact skipped: protected recent context would remain above " +
-        targetPercent + "% after compaction; using native compaction instead.",
-        "warning",
-      );
-      return null;
-    }
-  }
-  const firstKeptId = msgs[keepFrom].id as string;
-  // Use the shared helper instead of a local sentinel. A literal fallback
-  // (e.g. "unknown") would compare equal across unrelated sessions and
-  // defeat the cross-session leak guard in `consumePending`.
-  const sessionId = resolveSessionId(rc.ctx);
-
-  const out = rc as PreparedRc & {
-    _windowed: true;
-    sessionId: string; branch: unknown[]; msgs: SessionMessageEntry[];
-    totalTokens: number; contextPercent: number; toolPercent: number;
-    keepFrom: number; toCompact: SessionMessageEntry[]; firstKeptId: string;
-    compactTokens: number; accTokens: number;
-  };
-  out.sessionId = sessionId;
+  const out = rc as PreparedRc & WindowedRc;
+  out.sessionId = resolveSessionId(rc.ctx);
   out.branch = branch as unknown[];
   out.msgs = msgs;
   out.totalTokens = totalTokens;
   out.contextPercent = contextPercent;
-  out.toolPercent = 0; // populated by selectTier
-  out.keepFrom = keepFrom;
-  out.toCompact = toCompact;
-  out.firstKeptId = firstKeptId;
-  out.compactTokens = compactTokens;
-  out.accTokens = accTokens;
+  out.toolPercent = 0;
+  out.keepFrom = plan.keepFrom;
+  out.toCompact = msgs.slice(0, plan.keepFrom);
+  out.firstKeptId = msgs[plan.keepFrom].id as string;
+  out.compactTokens = plan.compactTokens;
+  out.accTokens = plan.retainedTokens;
+  out.compactionPlan = plan;
   return advance<PreparedRc, WindowedRc>(out, "_windowed");
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,8 +10,10 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "8.0.3";
+export const VERSION = "8.0.4";
 export const CHARS_PER_TOKEN = 3.8;
+export const MIN_COMPACTION_SAVING_RATIO = 0.10;
+export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;
 
 export const COMPACT_SYSTEM_PREFIX =
   "You are an expert conversation summarizer for a coding agent. " +

--- a/src/domain/telemetry.ts
+++ b/src/domain/telemetry.ts
@@ -82,6 +82,7 @@ export function classifyTelemetryFailure(error: unknown, timedOut = false): Tele
   const text = (fields.name + " " + fields.code + " " + fields.message).toLowerCase();
   if (timedOut || /timeout|timed out|watchdog|deadline/.test(text)) return "timeout";
   if (fields.name.toLowerCase() === "verificationgateerror") return "verification";
+  if (fields.name.toLowerCase() === "yieldgateerror") return "yield";
   if (/budgetexceeded|token budget|call budget|latency budget/.test(text)) return "budget";
   if (fields.status === 429 || /rate.?limit|too many requests|quota/.test(text)) return "rate-limit";
   if (fields.status === 401 || fields.status === 403 || /unauthori[sz]ed|authentication|api.?key|credential/.test(text)) return "authentication";
@@ -243,7 +244,7 @@ function safeMetricLabel(value: unknown, fallback: string): string {
 
 const FAILURE_KINDS = new Set<TelemetryFailureKind>([
   "cancelled", "timeout", "rate-limit", "authentication", "budget",
-  "output-limit", "provider", "persistence", "validation", "verification", "internal",
+  "output-limit", "provider", "persistence", "validation", "verification", "yield", "internal",
 ]);
 
 export function buildPrivacySafeTelemetry(

--- a/src/domain/yield-gate.ts
+++ b/src/domain/yield-gate.ts
@@ -1,0 +1,73 @@
+import { ESTIMATOR_ROUNDING_TOLERANCE_TOKENS, MIN_COMPACTION_SAVING_RATIO } from "../constants.ts";
+import type { CompactionWindowPlan } from "../app/run-context.ts";
+
+export interface CompactionYieldEstimate {
+  plannedAfterTokens: number;
+  plannedSavedTokens: number;
+  plannedYield: number;
+  estimatedAfterTokens: number;
+  estimatedSavedTokens: number;
+  estimatedYield: number;
+  retainedTailTokens: number;
+  summaryTokens: number;
+  summaryBudgetTokens: number;
+  targetAfterTokens: number;
+  relaxedSoftBoundaries: CompactionWindowPlan["relaxedSoftBoundaries"];
+  hardBoundaryAdjusted: boolean;
+}
+
+/** Content-free failure raised before any compaction side effect. */
+export class YieldGateError extends Error implements CompactionYieldEstimate {
+  readonly name = "YieldGateError";
+
+  constructor(public readonly reason: "target-miss" | "insufficient-saving", estimate: CompactionYieldEstimate) {
+    super(reason === "target-miss"
+      ? "Final summary estimate misses the planned compaction target"
+      : "Final summary estimate does not meet the minimum saving policy");
+    Object.assign(this, estimate);
+  }
+
+  plannedAfterTokens!: number;
+  plannedSavedTokens!: number;
+  plannedYield!: number;
+  estimatedAfterTokens!: number;
+  estimatedSavedTokens!: number;
+  estimatedYield!: number;
+  retainedTailTokens!: number;
+  summaryTokens!: number;
+  summaryBudgetTokens!: number;
+  targetAfterTokens!: number;
+  relaxedSoftBoundaries!: CompactionWindowPlan["relaxedSoftBoundaries"];
+  hardBoundaryAdjusted!: boolean;
+}
+
+export function verifyCompactionYield(
+  totalTokens: number,
+  summaryTokens: number,
+  plan: CompactionWindowPlan,
+): CompactionYieldEstimate {
+  const estimatedAfterTokens = plan.fixedContextTokens + plan.retainedTokens + summaryTokens;
+  const estimatedSavedTokens = Math.max(0, totalTokens - estimatedAfterTokens);
+  const estimatedYield = totalTokens > 0 ? estimatedSavedTokens / totalTokens : 0;
+  const estimate: CompactionYieldEstimate = {
+    plannedAfterTokens: plan.projectedAfterTokens,
+    plannedSavedTokens: plan.projectedSavedTokens,
+    plannedYield: plan.projectedYield,
+    estimatedAfterTokens,
+    estimatedSavedTokens,
+    estimatedYield,
+    retainedTailTokens: plan.retainedTokens,
+    summaryTokens,
+    summaryBudgetTokens: plan.summaryBudgetTokens,
+    targetAfterTokens: plan.targetAfterTokens,
+    relaxedSoftBoundaries: plan.relaxedSoftBoundaries,
+    hardBoundaryAdjusted: plan.hardBoundaryAdjusted,
+  };
+  if (estimatedAfterTokens > plan.targetAfterTokens + ESTIMATOR_ROUNDING_TOLERANCE_TOKENS) {
+    throw new YieldGateError("target-miss", estimate);
+  }
+  if (estimatedYield < MIN_COMPACTION_SAVING_RATIO) {
+    throw new YieldGateError("insufficient-saving", estimate);
+  }
+  return estimate;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { getProviderCaps } from "./utils/tokens.ts";
 import { appendMetricsSnapshot, readMetricsLog } from "./utils/cache.ts";
 import { buildLocalDashboardInsights, buildMetricsReport, writeMetricsDashboard } from "./ui/metrics-report.ts";
 import { runSmartCompact } from "./app/run-smart-compact.ts";
-import { showCompactUI, showMetricsDashboardUI, showRestorePicker, showBackupViewer, showRestoreAction, showOpenLoopsUI } from "./ui/overlays.ts";
+import { clearCompactProgress, notifyAppliedCompaction, showCompactUI, showMetricsDashboardUI, showRestorePicker, showBackupViewer, showRestoreAction, showOpenLoopsUI } from "./ui/overlays.ts";
 import { resolveSessionId, isUnresolvedSessionId } from "./infra/session-identity.ts";
 import { createPendingSlot, type PendingSlot, type ConsumeResult } from "./app/pending-slot.ts";
 import { createSessionRunLock } from "./app/session-run-lock.ts";
@@ -393,21 +393,22 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
           const usage = ctx.getContextUsage();
           const totalTokens = usage?.tokens ?? 0;
           const pct = ctx.model && totalTokens ? Math.round((totalTokens / ctx.model.contextWindow) * 100) : 0;
-          if (!totalTokens || totalTokens < MIN_TOKEN_THRESHOLD) {
-            ctx.ui.notify(
-              "Context usage is low or unknown (" + totalTokens.toLocaleString() + "t). Manual compaction may save little and can lose nuance; continuing because you requested it.",
-              "warning",
-            );
-          }
           const cur = ctx.model;
-          const avail = ctx.modelRegistry.getAvailable();
-          const opts = avail.map(m => ({ value: m.provider + "/" + m.id, label: m.provider + "/" + m.id + (m.contextWindow >= 200000 ? " (" + Math.round(m.contextWindow / 1000) + "K)" : ""), model: m }));
-          const defIdx = cur ? opts.findIndex(o => o.value === cur.provider + "/" + cur.id) : 0;
-          const selected = await showCompactUI(ctx, { contextTokens: totalTokens, contextPercent: pct, currentModel: cur ? cur.provider + "/" + cur.id : "?", defaultModelIndex: defIdx >= 0 ? defIdx : 0 });
+          const initialRoutes = resolveModels(ctx, cur, config);
+          if (!initialRoutes.sumModel) { ctx.ui.notify("Could not resolve model", "error"); return; }
+          const available = ctx.modelRegistry.getAvailable();
+          const defIdx = available.findIndex(model => model.provider === initialRoutes.sumModel!.provider && model.id === initialRoutes.sumModel!.id);
+          const selected = await showCompactUI(ctx, {
+            contextTokens: totalTokens,
+            contextPercent: pct,
+            activeModelLabel: cur ? cur.provider + "/" + cur.id : "?",
+            defaultModelIndex: defIdx >= 0 ? defIdx : 0,
+            config,
+          });
           if (!selected) { ctx.ui.notify("Cancelled", "info"); return; }
-          const { segModel, sumModel, verifyModel } = resolveModels(ctx, selected.model.model, loadConfig(), true);
+          const { segModel, sumModel, verifyModel } = resolveModels(ctx, selected.model.model, config, true);
           if (!sumModel) { ctx.ui.notify("Could not resolve model", "error"); return; }
-          await runSmartCompact({ ctx, summaryModel: sumModel, segModel: segModel ?? sumModel, verifyModel: verifyModel ?? sumModel, mode: selected.mode, pendingRef, isRunning, onNativeApplyError, force: true });
+          await runSmartCompact({ ctx, config, summaryModel: sumModel, segModel: segModel ?? sumModel, verifyModel: verifyModel ?? sumModel, mode: selected.mode, pendingRef, isRunning, onNativeApplyError, force: true });
           return;
         }
 
@@ -519,11 +520,19 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
       if (!runId) return; // another compaction extension
       const candidate = commitCandidates.take(runId, sessionId);
       if (!candidate) {
+        clearCompactProgress(ctx);
         log.warn("Applied smart compaction had no matching staged candidate: " + runId);
         return;
       }
-      commitAppliedCompaction(candidate);
-      activateOnlineDamage(candidate);
+      try {
+        commitAppliedCompaction(candidate);
+        clearCompactProgress(ctx);
+        notifyAppliedCompaction(ctx, candidate.details, candidate.metricsSnapshot?.runType !== "manual");
+        activateOnlineDamage(candidate);
+      } catch (error) {
+        clearCompactProgress(ctx);
+        log.warn("Failed to commit applied smart compaction", error);
+      }
       return;
     }
     if (isUnresolvedSessionId(sessionId)) return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,7 @@ export interface PipelinePhaseTiming {
 export type TelemetryFailureKind =
   | "cancelled" | "timeout" | "rate-limit" | "authentication"
   | "budget" | "output-limit" | "provider" | "persistence"
-  | "validation" | "verification" | "internal";
+  | "validation" | "verification" | "yield" | "internal";
 
 export interface CompactMetricsEntry {
   ts: string;
@@ -143,6 +143,18 @@ export interface CompactMetricsEntry {
   toolPercent?: number;
   tokensBefore?: number;
   tokensSaved?: number;
+  plannedAfterTokens?: number;
+  plannedSavedTokens?: number;
+  plannedYield?: number;
+  estimatedAfterTokens?: number;
+  estimatedSavedTokens?: number;
+  estimatedYield?: number;
+  retainedTailTokens?: number;
+  summaryTokens?: number;
+  summaryBudgetTokens?: number;
+  targetAfterTokens?: number;
+  relaxedSoftBoundaries?: Array<"recent-user-turn" | "anchor" | "topical">;
+  hardBoundaryAdjusted?: boolean;
   pruneSavedTokens?: number;
   chunkCount?: number;
   fallbackReason?: string;
@@ -205,6 +217,19 @@ export interface SmartCompactDetails {
   releaseChannel?: "stable" | "canary";
   qualityScore: number;
   tokensBefore: number;
+  /** Content-free planner versus verified-summary estimator evidence. */
+  plannedAfterTokens?: number;
+  plannedSavedTokens?: number;
+  plannedYield?: number;
+  estimatedAfterTokens?: number;
+  estimatedSavedTokens?: number;
+  estimatedYield?: number;
+  retainedTailTokens?: number;
+  summaryTokens?: number;
+  summaryBudgetTokens?: number;
+  targetAfterTokens?: number;
+  relaxedSoftBoundaries?: Array<"recent-user-turn" | "anchor" | "topical">;
+  hardBoundaryAdjusted?: boolean;
   provenance?: VerificationProvenance;
   redactions?: number;
   compactionState?: CompactionState;

--- a/src/ui/dashboard-format.ts
+++ b/src/ui/dashboard-format.ts
@@ -57,6 +57,7 @@ export function formatRunDetails(entry: CompactMetricsEntry | undefined, title: 
     "Method: " + (entry.method ?? "?") + " | duration: " + metricMs(totalDuration),
     "Quality: " + metricScore(entry) + " | initial: " + metricNum(entry.initialVerificationScore) + " | gaps: " + metricNum(entry.remainingVerificationGaps ?? entry.verificationGaps),
     "Tokens: before " + metricNum(entry.tokensBefore) + "t | saved " + metricNum(entry.tokensSaved) + "t | prune saved " + metricNum(entry.pruneSavedTokens) + "t",
+    "Estimate: planned after " + metricNum(entry.plannedAfterTokens) + "t | applied estimate " + metricNum(entry.estimatedAfterTokens) + "t | yield " + metricPct(entry.estimatedYield),
     "LLM: " + metricNum(entry.totalCalls) + " calls | prompt " + metricNum(entry.totalInput + entry.totalCacheHit + (entry.totalCacheWrite ?? 0)) + "t | output " + metricNum(entry.totalOutput) + "t | provider cache " + metricPct(entry.cacheHitRate),
     "Extraction cache: " + metricNum(entry.extractionCacheHits) + " hit / " + metricNum(entry.extractionCacheMisses) + " miss | rate " + metricPct(entry.extractionCacheHitRate),
     "Context: " + metricNum(entry.contextPercent) + "% | tool share: " + metricNum(entry.toolPercent) + "% | chunks: " + metricNum(entry.chunkCount),

--- a/src/ui/overlays.ts
+++ b/src/ui/overlays.ts
@@ -4,18 +4,19 @@
 
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { DynamicBorder, Theme } from "@earendil-works/pi-coding-agent";
-import { PROFILES, TRUNC } from "../constants.ts";
-import { Container, Key, matchesKey, type SelectItem, SelectList, Text, truncateToWidth } from "@earendil-works/pi-tui";
+import { TRUNC } from "../constants.ts";
+import { Container, Key, matchesKey, type SelectItem, SelectList, Text, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type {
-  CompactMetricsEntry, CompactionMode, ModelOption, ProgressState,
+  CompactConfig, CompactMetricsEntry, CompactionMode, ModelOption, ProgressState,
   SmartCompactDetails, StructuredExtraction, OpenLoop, LoopOverride,
 } from "../types.ts";
 import type { BackupEntry } from "../utils/helpers.ts";
-import type { SmartCompactServices } from "../infra/services.ts";
+import { createProductionServices, type SmartCompactServices } from "../infra/services.ts";
 import { effectivePromptInputTokens, getExtractionCacheStats, getMetricsSummary } from "../utils/cache.ts";
 import { getProviderCaps } from "../utils/tokens.ts";
-import { MODE_POLICIES, resolveMode } from "../app/mode-policy.ts";
+import { planManualPreflight, preflightDamageMedian, type ManualPreflight } from "../app/preflight.ts";
+import type { EffectiveCompactionMode } from "../types.ts";
 import {
   DASHBOARD_PAGE_SIZE,
   formatCurrentSession,
@@ -55,7 +56,7 @@ export function renderTokenBar(theme: Theme, before: number, after: number, labe
 
 export async function selectModel(
   ctx: ExtensionCommandContext,
-  opts: { contextTokens: number; contextPercent: number; currentModel: string; defaultModelIndex: number },
+  opts: { contextTokens: number; contextPercent: number; activeModelLabel: string; defaultModelIndex: number },
 ): Promise<ModelOption | null> {
   const available = ctx.modelRegistry.getAvailable();
   const options: ModelOption[] = available.map(m => {
@@ -73,16 +74,17 @@ export async function selectModel(
   const items: SelectItem[] = options.map((o, i) => ({
     value: "model:" + i,
     label: o.label,
-    description: i === opts.defaultModelIndex ? "\u2190 session model" : undefined,
+    description: i === opts.defaultModelIndex ? "← selected summary route" : o.value === opts.activeModelLabel ? "active context model" : undefined,
   }));
   const result = await ctx.ui.custom<string | null>((tui, theme, _kb, done) => {
     const c = new Container();
     c.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
-    c.addChild(new Text(theme.fg("accent", theme.bold("  \uD83D\uDD0D Smart Compact \u2014 Step 1/2")), 1, 0));
+    c.addChild(new Text(theme.fg("accent", theme.bold("  Smart Compact — Advanced model")), 1, 0));
     c.addChild(new Text(theme.fg("dim", "  Architecture: EESV (Extract \u2192 Explore \u2192 Synthesize \u2192 Verify)"), 0, 0));
     c.addChild(new Text("", 0, 0));
     c.addChild(new Text(renderContextBar(theme, opts.contextPercent, opts.contextTokens), 0, 0));
-    c.addChild(new Text(theme.fg("dim", "  Session: " + opts.currentModel), 0, 0));
+    c.addChild(new Text(theme.fg("dim", "  Active context: " + opts.activeModelLabel), 0, 0));
+    c.addChild(new Text(theme.fg("dim", "  Selected summary route: " + (options[opts.defaultModelIndex]?.value ?? "?")), 0, 0));
     c.addChild(new Text("", 0, 0));
     c.addChild(new Text(theme.fg("text", "  Select model for compaction:"), 1, 0));
     c.addChild(new Text("", 0, 0));
@@ -110,71 +112,145 @@ export async function selectModel(
   return options[parseInt(result.slice(6), 10)] ?? null;
 }
 
-export async function selectMode(
-  ctx: ExtensionCommandContext,
-  selectedModel: ModelOption,
-  opts: { contextTokens: number; contextPercent: number },
-): Promise<CompactionMode | null> {
-  const estAfter = (budget: number, keep: number) => budget + Math.min(opts.contextTokens, keep);
-  const modes: Array<{ value: CompactionMode; label: string; desc: string }> = [
-    { value: "auto", label: "Auto", desc: "Adapts from pressure and session risk" },
-    { value: "balanced", label: "Balanced", desc: "Token and continuity balance" },
-    { value: "aggressive", label: "Aggressive", desc: "Maximum context recovery" },
-    { value: "fast", label: "Fast", desc: "Minimum waiting and LLM calls" },
-    { value: "thorough", label: "Thorough (Slow)", desc: "Maximum context fidelity" },
-  ];
-  const items: SelectItem[] = modes.map(item => {
-    const effective = item.value === "auto" ? resolveMode("auto", opts.contextPercent) : item.value;
-    const policy = MODE_POLICIES[effective];
-    const profile = PROFILES[policy.profile];
-    const after = estAfter(profile.summaryBudgetTokens, profile.keepRecentTokens);
-    const pct = opts.contextTokens > 0 ? Math.max(0, Math.round((1 - after / opts.contextTokens) * 100)) : 0;
-    return { value: item.value, label: item.label, description: item.desc + " \u2014 \u2264" + policy.maxLlmCalls + " calls / \u2264" + Math.round(policy.maxInputTokens / 1000) + "K prompt \u00b7 ~" + Math.round(policy.softLatencyMs / 1000) + "s soft target \u00b7 save ~" + pct + "%" };
-  });
-  const result = await ctx.ui.custom<string | null>((tui, theme, _kb, done) => {
-    const c = new Container();
-    c.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
-    c.addChild(new Text(theme.fg("accent", theme.bold("  \uD83D\uDD0D Smart Compact \u2014 Step 2/2")), 1, 0));
-    c.addChild(new Text("", 0, 0));
-    c.addChild(new Text(theme.fg("dim", "  Model: " + selectedModel.label), 0, 0));
-    c.addChild(new Text(renderContextBar(theme, opts.contextPercent, opts.contextTokens), 0, 0));
-    c.addChild(new Text("", 0, 0));
-    c.addChild(new Text(theme.fg("text", "  Select optimization mode:"), 1, 0));
-    c.addChild(new Text("", 0, 0));
-    const sel = new SelectList(items, 5, {
-      selectedPrefix: t => theme.fg("accent", t),
-      selectedText: t => theme.fg("accent", t),
-      description: t => theme.fg("muted", t),
-      scrollInfo: t => theme.fg("dim", t),
-      noMatch: t => theme.fg("warning", t),
-    });
-    sel.setSelectedIndex(0);
-    sel.onSelect = item => done(item.value);
-    sel.onCancel = () => done(null);
-    c.addChild(sel);
-    c.addChild(new Text("", 0, 0));
-    c.addChild(new Text(theme.fg("dim", "  \u2191\u2193 navigate \u2022 enter select \u2022 esc cancel"), 0, 0));
-    c.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
-    return {
-      render: (w: number) => c.render(w),
-      invalidate: () => c.invalidate(),
-      handleInput: (d: string) => { sel.handleInput(d); tui.requestRender(); },
-    };
-  });
-  if (!result) return null;
-  return modes.find(mode => mode.value === result)?.value ?? null;
+const PRIMARY_MODES: EffectiveCompactionMode[] = ["thorough", "balanced", "fast"];
+const MODE_LABELS: Record<EffectiveCompactionMode, string> = {
+  thorough: "Thorough", balanced: "Balanced", fast: "Fast", aggressive: "Aggressive",
+};
+const MODE_COPY: Record<EffectiveCompactionMode, string> = {
+  thorough: "richer summary · 30K base recent tail",
+  balanced: "default balance · 20K base recent tail",
+  fast: "faster run · 20K base recent tail · 6K base summary",
+  aggressive: "maximum recovery · 10K base recent tail",
+};
+
+export function explainPreflightReason(reason: ManualPreflight["reason"]): string {
+  switch (reason) {
+    case "viable": return "safe window and useful estimated saving";
+    case "not-enough-messages": return "fewer than 3 active messages";
+    case "no-eligible-prefix": return "no older prefix is available";
+    case "unsafe-tool-boundary": return "no complete tool-call boundary is available";
+    case "retention-target-exceeded": return "a complete tool pair exceeds the tail target";
+    case "mode-target-not-met": return "the estimated result misses this preset's target";
+    case "insufficient-projected-saving": return "estimated saving is below 10%";
+  }
 }
 
-// `ExtensionContext` is the narrower base type used by the pipeline so that
-// both interactive command runs and `session_before_compact` event runs can
-// emit progress without a cast. The function only touches `ctx.ui.notify`,
-// which is part of the shared surface.
+function recommendationEvidence(preflight: ManualPreflight): string {
+  const yieldPercent = Math.round((preflight.plan?.projectedYield ?? 0) * 100);
+  const tail = preflight.plan?.retainedTokens ?? 0;
+  return "~" + Math.round(preflight.contextPercent) + "% window pressure, ~" + yieldPercent + "% projected saving, ~" + tokenCount(tail) + " recent tail" +
+    (preflight.toolPercent >= 70 ? "; tool-heavy shape (~" + preflight.toolPercent + "% tool-result text)" : "");
+}
+
+export function recommendPreflight(plans: ReadonlyMap<EffectiveCompactionMode, ManualPreflight>): {
+  mode: EffectiveCompactionMode; reason: string;
+} {
+  const thorough = plans.get("thorough");
+  const balanced = plans.get("balanced");
+  const fast = plans.get("fast");
+  if (thorough?.adapted && thorough.plan?.viable) {
+    return { mode: "thorough", reason: "recent damage feedback favors richer retention; " + recommendationEvidence(thorough) };
+  }
+  if ((fast?.overflowedContext || (fast?.contextPercent ?? 0) >= 90) && fast?.plan?.viable) {
+    return { mode: "fast", reason: "severe context pressure favors faster recovery; " + recommendationEvidence(fast) };
+  }
+  if (balanced?.plan?.viable) {
+    return { mode: "balanced", reason: "normal pressure favors the default balance; " + recommendationEvidence(balanced) };
+  }
+  const fallback = (["thorough", "fast"] as const).find(mode => plans.get(mode)?.plan?.viable);
+  if (fallback) {
+    const chosen = plans.get(fallback)!;
+    return {
+      mode: fallback,
+      reason: "Balanced is unavailable because " + explainPreflightReason(balanced?.reason ?? "not-enough-messages") + "; " + recommendationEvidence(chosen),
+    };
+  }
+  return { mode: "balanced", reason: "no preset currently has a safe, useful window" };
+}
+
+function tokenCount(value: number): string { return Math.round(value).toLocaleString() + "t"; }
+function percent(value: number): string { return Math.round(value).toLocaleString() + "%"; }
+function windowPercent(tokens: number, window: number): string { return window > 0 ? percent(tokens / window * 100) : "unknown %"; }
+
+const SOFT_BOUNDARY_COPY: Record<string, string> = {
+  "recent-user-turn": "older user turn",
+  anchor: "latest checkpoint",
+  topical: "adjacent topic",
+  "context-anchor": "latest checkpoint",
+  "topical-group": "adjacent topic",
+};
+
+/** Pure copy generation; styling and terminal truncation stay in the component. */
+export function formatPreflightSummary(preflight: ManualPreflight, modelLabel: string, details = false): string[] {
+  const plan = preflight.plan;
+  if (!plan) {
+    const lines = [
+      "Before: ~" + tokenCount(preflight.totalTokens) + " (~" + percent(preflight.contextPercent) + " of active window) · Expected after: unavailable",
+      "This preset cannot run: " + explainPreflightReason(preflight.reason) + ".",
+      "Hard safeguards: complete tool-call/result pairs and zero-gap verification before apply.",
+    ];
+    if (details) lines.push(
+      "Estimator: messages ~" + tokenCount(preflight.rawEstimatedMessageTokens) + " · fixed/scaled normalization unavailable",
+      "Summary route: " + modelLabel + " · viability: " + preflight.reason,
+    );
+    return lines;
+  }
+  const soft = plan.relaxedSoftBoundaries.length
+    ? "Soft boundaries included in summary: " + plan.relaxedSoftBoundaries.map(kind => SOFT_BOUNDARY_COPY[kind] ?? kind).join(", ")
+    : "Soft boundaries kept when they fit: older user turn, latest checkpoint, adjacent topic";
+  const lines = [
+    "Before ~" + tokenCount(preflight.totalTokens) + " (~" + percent(preflight.contextPercent) + " window) → expected after ~" + tokenCount(plan.projectedAfterTokens) + " (~" + windowPercent(plan.projectedAfterTokens, preflight.contextWindowTokens) + " window)",
+    "Projected net saving ~" + tokenCount(plan.projectedSavedTokens) + " (~" + percent(plan.projectedYield * 100) + ", estimator-based)",
+    "Recent raw tail ~" + tokenCount(plan.retainedTokens) + " + summary budget ≤" + tokenCount(plan.summaryBudgetTokens),
+    soft,
+    "Hard safeguards: complete tool-call/result pairs and zero-gap verification before apply; " + (plan.hardBoundaryAdjusted ? "boundary adjusted to keep a pair intact" : "no hard-boundary adjustment needed"),
+  ];
+  if (!plan.viable) lines.push("Cannot run this preset: " + explainPreflightReason(plan.reason) + ". Choose a viable preset.");
+  if (details) lines.push(
+    "Estimator: messages ~" + tokenCount(preflight.rawEstimatedMessageTokens) + " · normalized ×" + preflight.estimatorScale.toFixed(2) + " · fixed ~" + tokenCount(plan.fixedContextTokens),
+    "Target ≤" + tokenCount(plan.targetAfterTokens) + " · tail target ≤" + tokenCount(plan.retentionTargetTokens),
+    "Hard-boundary adjustment: " + (plan.hardBoundaryAdjusted ? "yes" : "no") + " · viability: " + plan.reason,
+    "Internal soft boundaries: " + (plan.relaxedSoftBoundaries.join(", ") || "none"),
+    "Summary route: " + modelLabel + (preflight.adapted ? " · damage feedback " + preflight.damageMedian + "/100 applied" : ""),
+  );
+  return lines;
+}
+
+const PROGRESS_KEY = "smart-compact-progress";
+const PROGRESS_PHASES = ["Extract", "Explore", "Synthesize", "Verify", "Apply"];
+
 export function showProgressOverlay(ctx: ExtensionContext, state: ProgressState): void {
-  const phaseNames = ["Extract", "Explore", "Synthesize", "Verify"];
-  const progress = Math.round((state.phase / 4) * 100);
-  const name = phaseNames[state.phase - 1] ?? "?";
-  const detail = state.detail ? " (" + state.detail + ")" : "";
-  ctx.ui.notify("EESV [" + progress + "%] Phase " + state.phase + "/4: " + name + detail, state.phase >= 4 ? "info" : "info");
+  if (ctx.hasUI === false) return;
+  const name = PROGRESS_PHASES[state.phase - 1] ?? state.phaseName;
+  const story = PROGRESS_PHASES.map((phase, index) => index === 1 && state.phase > 2 && !state.explorationRounds
+    ? "– Explore"
+    : index < state.phase - 1 ? "✓ " + phase : index === state.phase - 1 ? "● " + phase : "○ " + phase).join("  ");
+  const detail = state.detail ? name + " · " + state.detail : name;
+  try {
+    ctx.ui.setStatus?.(PROGRESS_KEY, "Smart Compact · " + detail);
+    ctx.ui.setWidget?.(PROGRESS_KEY, (_tui, theme) => ({
+      render: (width: number) => [truncateToWidth(theme.fg("dim", story), width)],
+      invalidate: () => {},
+    }), { placement: "belowEditor" });
+  } catch { /* non-interactive UI adapters may not implement persistent UI */ }
+}
+
+export function clearCompactProgress(ctx: ExtensionContext): void {
+  try {
+    ctx.ui.setStatus?.(PROGRESS_KEY, undefined);
+    ctx.ui.setWidget?.(PROGRESS_KEY, undefined);
+  } catch { /* non-interactive UI adapter */ }
+}
+
+export function notifyAppliedCompaction(ctx: ExtensionContext, details: SmartCompactDetails, concise: boolean): void {
+  const before = details.tokensBefore ?? 0;
+  const after = details.estimatedAfterTokens ?? Math.max(0, before - details.tokensSaved);
+  const saving = Math.round((details.estimatedYield ?? (before ? details.tokensSaved / before : 0)) * 100);
+  const quality = details.qualityScore ?? 0;
+  const planned = details.plannedAfterTokens ?? after;
+  ctx.ui.notify(concise
+    ? "Smart compact applied ✓ · " + before.toLocaleString() + "t → ~" + after.toLocaleString() + "t estimate (plan ~" + planned.toLocaleString() + "t) · " + saving + "% saved · quality " + quality + " · 0 gaps"
+    : "Smart compact applied ✓ — " + before.toLocaleString() + "t → planned ~" + planned.toLocaleString() + "t / ~" + after.toLocaleString() + "t applied estimate · saved " + saving + "% · quality " + quality + "/100 · 0 gaps", "info");
 }
 
 // Same narrowing rationale as showProgressOverlay: only ctx.ui.custom is
@@ -192,7 +268,7 @@ export async function showResultScreen(
     c.addChild(new Text(theme.fg("accent", theme.bold(opts.approval ? "  \uD83D\uDD0E Smart Compact Review" : "  \u2705 Smart Compact Complete")), 1, 0));
     c.addChild(new Text("", 0, 0));
 
-    const estimatedAfter = (details.tokensBefore ?? 0) - (details.tokensSaved ?? 0);
+    const estimatedAfter = details.estimatedAfterTokens ?? (details.tokensBefore ?? 0) - (details.tokensSaved ?? 0);
     c.addChild(new Text(renderTokenBar(theme, details.tokensBefore, estimatedAfter, "Result  "), 0, 0));
     c.addChild(new Text(theme.fg("dim", "  Before: " + (details.tokensBefore ?? 0).toLocaleString() + "t \u2192 After: ~" + estimatedAfter.toLocaleString() + "t \u2192 Saved: " + (details.tokensSaved ?? 0).toLocaleString() + "t"), 0, 0));
     c.addChild(new Text("", 0, 0));
@@ -480,13 +556,82 @@ export async function showMetricsDashboardUI(
 
 export async function showCompactUI(
   ctx: ExtensionCommandContext,
-  opts: { contextTokens: number; contextPercent: number; currentModel: string; defaultModelIndex: number },
+  opts: { contextTokens: number; contextPercent: number; activeModelLabel: string; defaultModelIndex: number; config: CompactConfig },
 ): Promise<{ model: ModelOption; mode: CompactionMode } | null> {
-  const selectedModel = await selectModel(ctx, opts);
-  if (!selectedModel) return null;
-  const selectedMode = await selectMode(ctx, selectedModel, { contextTokens: opts.contextTokens, contextPercent: opts.contextPercent });
-  if (!selectedMode) return null;
-  return { model: selectedModel, mode: selectedMode };
+  const available = ctx.modelRegistry.getAvailable();
+  const asOption = (model: Model<Api>): ModelOption => ({
+    value: model.provider + "/" + model.id,
+    label: model.provider + "/" + model.id,
+    model,
+    supportsTools: getProviderCaps(model.provider).supportsTools,
+  });
+  const initialModel = available[opts.defaultModelIndex] ?? available[0];
+  if (!initialModel) return null;
+  let selectedModel = asOption(initialModel);
+  const calibration = createProductionServices().tokenCalibration;
+  const damageMedian = preflightDamageMedian(ctx.cwd, opts.config);
+
+  while (true) {
+    const plans = new Map(PRIMARY_MODES.map(mode => [mode, planManualPreflight(ctx, selectedModel.model, mode, calibration, opts.config, damageMedian)]));
+    const recommended = recommendPreflight(plans);
+    const action = await ctx.ui.custom<EffectiveCompactionMode | "model" | null>((tui, theme, keybindings, done) => {
+      let selected = Math.max(0, PRIMARY_MODES.indexOf(recommended.mode));
+      let details = false;
+      return {
+        render: (width: number) => {
+          const out = (text: string, color: import("@earendil-works/pi-coding-agent").ThemeColor = "text") =>
+            truncateToWidth(theme.fg(color, text), Math.max(0, width));
+          const wrapped = (text: string, color: import("@earendil-works/pi-coding-agent").ThemeColor = "text") =>
+            wrapTextWithAnsi(theme.fg(color, text), Math.max(1, width));
+          const lines = [
+            out("Smart Compact preflight", "accent"),
+            ...wrapped("Recommended: " + MODE_LABELS[recommended.mode] + " — " + recommended.reason, "text"),
+            out("Active context: " + opts.activeModelLabel + " · " + tokenCount(plans.get(recommended.mode)?.contextWindowTokens ?? 0) + " window", "dim"),
+            out("Summary model: " + selectedModel.label, "dim"),
+            out("─".repeat(Math.max(0, width)), "borderMuted"),
+          ];
+          for (let index = 0; index < PRIMARY_MODES.length; index++) {
+            const mode = PRIMARY_MODES[index];
+            const preview = plans.get(mode)!;
+            const viable = preview.plan?.viable ?? false;
+            lines.push(out(
+              (index === selected ? "> " : "  ") + MODE_LABELS[mode] +
+                (mode === recommended.mode ? " [recommended]" : "") +
+                (viable ? " [viable]" : " [unavailable: " + explainPreflightReason(preview.reason) + "]"),
+              index === selected ? "accent" : viable ? "text" : "muted",
+            ));
+            lines.push(out("    " + MODE_COPY[mode], "dim"));
+          }
+          lines.push(out("─".repeat(Math.max(0, width)), "borderMuted"));
+          const current = plans.get(PRIMARY_MODES[selected])!;
+          lines.push(...formatPreflightSummary(current, selectedModel.value, details).flatMap(line => wrapped(line, line.startsWith("Cannot") || line.startsWith("This preset") ? "warning" : "text")));
+          lines.push("", out("↑↓ mode · Enter compact · D details · M model · Esc cancel", "dim"));
+          return lines;
+        },
+        invalidate: () => {},
+        handleInput: (data: string) => {
+          if (keybindings.matches(data, "tui.select.cancel")) { done(null); return; }
+          if (keybindings.matches(data, "tui.select.up")) selected = Math.max(0, selected - 1);
+          else if (keybindings.matches(data, "tui.select.down")) selected = Math.min(PRIMARY_MODES.length - 1, selected + 1);
+          else if (keybindings.matches(data, "tui.select.confirm")) {
+            const mode = PRIMARY_MODES[selected];
+            if (plans.get(mode)?.plan?.viable) { done(mode); return; }
+          } else if (data.toLowerCase() === "d") details = !details;
+          else if (data.toLowerCase() === "m") { done("model"); return; }
+          tui.requestRender();
+        },
+      };
+    }, { overlay: true, overlayOptions: { width: "70%", minWidth: 36, anchor: "center", maxHeight: "85%" } });
+
+    if (!action) return null;
+    if (action === "model") {
+      const modelIndex = available.findIndex(model => model.provider === selectedModel.model.provider && model.id === selectedModel.model.id);
+      const next = await selectModel(ctx, { ...opts, defaultModelIndex: Math.max(0, modelIndex) });
+      if (next) selectedModel = next;
+      continue;
+    }
+    return { model: selectedModel, mode: action };
+  }
 }
 
 /** Picker for `/smart-compact restore` — list backups, return the chosen path. */

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -414,30 +414,26 @@ function branchIndexToMsgIndex(branchEntries: unknown[], branchIdx: number, msgs
   return Math.max(0, Math.min(msgCount - 1, msgs.length - 1));
 }
 
-export function smartKeepBoundary(
+export type SmartBoundaryKind = "anchor" | "topical";
+
+/** Return soft boundary candidates in application order. */
+export function smartKeepBoundaryCandidates(
   msgs: SessionMessageEntry[],
   keepFromIndex: number,
   branchEntries?: unknown[],
-): number {
-  let adjusted = keepFromIndex;
+): Array<{ kind: SmartBoundaryKind; keepFrom: number }> {
+  const candidates: Array<{ kind: SmartBoundaryKind; keepFrom: number }> = [];
 
-  // ── pi-toolkit anchor protection: never compact past the last on-branch anchor ──
-  if (branchEntries && branchEntries.length > 0) {
+  if (branchEntries?.length) {
     const lastAnchorBranchIdx = findLastAnchorIndex(branchEntries);
     if (lastAnchorBranchIdx >= 0) {
-      const lastAnchorMsgIdx = branchIndexToMsgIndex(branchEntries, lastAnchorBranchIdx, msgs);
-      if (adjusted > lastAnchorMsgIdx && lastAnchorMsgIdx >= 0) {
-        adjusted = lastAnchorMsgIdx;
-      }
+      const anchor = branchIndexToMsgIndex(branchEntries, lastAnchorBranchIdx, msgs);
+      if (keepFromIndex > anchor && anchor >= 0) candidates.push({ kind: "anchor", keepFrom: anchor });
     }
   }
 
-  if (adjusted <= 0 || adjusted >= msgs.length) return adjusted;
+  if (keepFromIndex <= 0 || keepFromIndex >= msgs.length) return candidates;
 
-  // Topical grouping: if the last compacted message and the first kept message
-  // touch the same file, pull the boundary back one so a file's work isn't split
-  // across the compaction seam. Files come from tool-call arguments — the earlier
-  // prose regex `path="..."` never matched real agent output, so this was a no-op.
   const touchedFiles = (msg: unknown): Set<string> => {
     const m = msg as Record<string, unknown>;
     const blocks = Array.isArray(m?.content) ? m.content : [];
@@ -450,12 +446,24 @@ export function smartKeepBoundary(
     }
     return files;
   };
-  const lastFiles = touchedFiles(msgs[adjusted - 1].message);
+  const lastFiles = touchedFiles(msgs[keepFromIndex - 1].message);
   if (lastFiles.size > 0) {
-    const keptFiles = touchedFiles(msgs[adjusted].message);
-    if ([...lastFiles].some(f => keptFiles.has(f))) return adjusted - 1;
+    const keptFiles = touchedFiles(msgs[keepFromIndex].message);
+    if ([...lastFiles].some(f => keptFiles.has(f))) {
+      candidates.push({ kind: "topical", keepFrom: keepFromIndex - 1 });
+    }
   }
-  return adjusted;
+  return candidates;
+}
+
+export function smartKeepBoundary(
+  msgs: SessionMessageEntry[],
+  keepFromIndex: number,
+  branchEntries?: unknown[],
+): number {
+  const anchor = smartKeepBoundaryCandidates(msgs, keepFromIndex, branchEntries).find(candidate => candidate.kind === "anchor");
+  const adjusted = anchor?.keepFrom ?? keepFromIndex;
+  return smartKeepBoundaryCandidates(msgs, adjusted).find(candidate => candidate.kind === "topical")?.keepFrom ?? adjusted;
 }
 
 /**
@@ -493,18 +501,21 @@ function collectToolCallIds(blocks: unknown[], msgIndex: number, out: Map<string
  * Also handles multi_tool_use.parallel wrappers where the actual tool call IDs are nested
  * inside arguments.tool_uses rather than on the wrapper block itself.
  */
-export function guardToolCallBoundary(msgs: SessionMessageEntry[], keepFrom: number): number {
-  if (keepFrom <= 0 || keepFrom >= msgs.length) return keepFrom;
-
-  // Map toolCallId -> assistant message index (including nested multi_tool_use.parallel)
-  const tcMap = new Map<string, number>();
+function toolCallIndexMap(msgs: SessionMessageEntry[]): Map<string, number> {
+  const map = new Map<string, number>();
   for (let i = 0; i < msgs.length; i++) {
     const m = msgs[i].message as Record<string, unknown>;
     if (m?.role !== "assistant") continue;
     const blocks = Array.isArray(m?.content) ? m.content : [];
-    collectToolCallIds(blocks, i, tcMap);
+    collectToolCallIds(blocks, i, map);
   }
+  return map;
+}
 
+export function guardToolCallBoundary(msgs: SessionMessageEntry[], keepFrom: number): number {
+  if (keepFrom <= 0 || keepFrom >= msgs.length) return keepFrom;
+
+  const tcMap = toolCallIndexMap(msgs);
   let adjusted = keepFrom;
   let changed = true;
   // Bound the transitive walk. Each iteration MUST shrink `adjusted` (we
@@ -537,6 +548,34 @@ export function guardToolCallBoundary(msgs: SessionMessageEntry[], keepFrom: num
   }
 
   return Math.max(0, Math.min(adjusted, msgs.length));
+}
+
+/**
+ * Prefer summarizing a complete tool exchange when pulling its call backward
+ * would exceed the retention target. Returns msgs.length when no later kept
+ * message exists; callers can then retain the pair or reject the plan.
+ */
+export function advancePastToolCallBoundary(msgs: SessionMessageEntry[], keepFrom: number): number {
+  if (keepFrom <= 0 || keepFrom >= msgs.length) return keepFrom;
+
+  const tcMap = toolCallIndexMap(msgs);
+  let adjusted = keepFrom;
+  for (let iter = 0; iter <= msgs.length; iter++) {
+    let next = adjusted;
+    for (let i = adjusted; i < msgs.length; i++) {
+      const m = msgs[i].message as Record<string, unknown>;
+      if (m?.role !== "toolResult") continue;
+      const tcIdx = typeof m.toolCallId === "string" ? tcMap.get(m.toolCallId) : undefined;
+      if ((i === adjusted && tcIdx === undefined) || (tcIdx !== undefined && tcIdx < adjusted)) {
+        next = i + 1;
+        break;
+      }
+    }
+    if (next === adjusted) return adjusted;
+    adjusted = next;
+    if (adjusted >= msgs.length) return msgs.length;
+  }
+  return msgs.length;
 }
 
 export function extractUserNote(args: string): string | undefined {

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -50,6 +50,17 @@ import type { SmartCompactDetails } from "../types.ts";
 const KNOWN_METHODS = new Set(["eesv", "single-pass", "heuristic"]);
 const KNOWN_PROFILES = new Set(["light", "balanced", "aggressive"]);
 const KNOWN_MODES = new Set(["balanced", "aggressive", "fast", "thorough"]);
+const NON_NEGATIVE_DETAIL_FIELDS = [
+  "chunkCount", "totalMessages", "totalTokensSummarized", "llmCalls", "tokensSaved",
+  "explorationRounds", "explorationBoundaries", "tokensBefore", "plannedAfterTokens",
+  "plannedSavedTokens", "estimatedAfterTokens", "estimatedSavedTokens", "retainedTailTokens",
+  "summaryTokens", "summaryBudgetTokens", "targetAfterTokens",
+] as const;
+const YIELD_DETAIL_FIELDS = ["plannedYield", "estimatedYield"] as const;
+
+function isNonNegativeFinite(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
 
 function isStringArray(v: unknown): v is string[] {
   return Array.isArray(v) && v.every(x => typeof x === "string");
@@ -74,7 +85,7 @@ export function isValidSmartCompactDetails(d: unknown): d is SmartCompactDetails
   // Required numeric fields with a sane lower bound. We coerce silently if
   // they're missing on legacy entries (handled in `sanitizeSmartCompactDetails`).
   if (typeof r.qualityScore !== "number" || !Number.isFinite(r.qualityScore)) return false;
-  if (typeof r.totalMessages !== "number" || !Number.isFinite(r.totalMessages)) return false;
+  if (!isNonNegativeFinite(r.totalMessages)) return false;
 
   // Optional but commonly accessed fields. We don't reject when missing
   // (legacy entries omit them) but we do reject if present-and-wrong-type.
@@ -85,6 +96,12 @@ export function isValidSmartCompactDetails(d: unknown): d is SmartCompactDetails
   if (r.runId !== undefined && (typeof r.runId !== "string" || r.runId.length < 8 || r.runId.length > 100)) return false;
   if (r.version !== undefined && typeof r.version !== "string") return false;
   if (r.releaseChannel !== undefined && r.releaseChannel !== "stable" && r.releaseChannel !== "canary") return false;
+  if (NON_NEGATIVE_DETAIL_FIELDS.some(key => r[key] !== undefined && !isNonNegativeFinite(r[key]))) return false;
+  if (YIELD_DETAIL_FIELDS.some(key => r[key] !== undefined
+    && (!isNonNegativeFinite(r[key]) || (r[key] as number) > 1))) return false;
+  if (r.hardBoundaryAdjusted !== undefined && typeof r.hardBoundaryAdjusted !== "boolean") return false;
+  if (r.relaxedSoftBoundaries !== undefined && (!Array.isArray(r.relaxedSoftBoundaries)
+    || r.relaxedSoftBoundaries.some(kind => !["recent-user-turn", "anchor", "topical"].includes(kind)))) return false;
   if (r.providerRoutes !== undefined) {
     if (!r.providerRoutes || typeof r.providerRoutes !== "object") return false;
     const routes = r.providerRoutes as Record<string, unknown>;
@@ -113,24 +130,34 @@ export function sanitizeSmartCompactDetails(d: unknown): SmartCompactDetails | n
 
   const repaired: SmartCompactDetails = {
     method: KNOWN_METHODS.has(r.method as string) ? (r.method as SmartCompactDetails["method"]) : "heuristic",
-    chunkCount: typeof r.chunkCount === "number" ? r.chunkCount : 0,
+    chunkCount: isNonNegativeFinite(r.chunkCount) ? r.chunkCount : 0,
     topics: r.topics,
     readFiles: r.readFiles,
     modifiedFiles: r.modifiedFiles,
-    totalMessages: typeof r.totalMessages === "number" ? r.totalMessages : 0,
-    totalTokensSummarized: typeof r.totalTokensSummarized === "number" ? r.totalTokensSummarized : 0,
-    llmCalls: typeof r.llmCalls === "number" ? r.llmCalls : 0,
+    totalMessages: isNonNegativeFinite(r.totalMessages) ? r.totalMessages : 0,
+    totalTokensSummarized: isNonNegativeFinite(r.totalTokensSummarized) ? r.totalTokensSummarized : 0,
+    llmCalls: isNonNegativeFinite(r.llmCalls) ? r.llmCalls : 0,
     profile: KNOWN_PROFILES.has(r.profile as string) ? (r.profile as SmartCompactDetails["profile"]) : "balanced",
     ...(KNOWN_MODES.has(r.mode as string) ? { mode: r.mode as SmartCompactDetails["mode"] } : {}),
     backupPath: typeof r.backupPath === "string" ? r.backupPath : null,
-    tokensSaved: typeof r.tokensSaved === "number" ? r.tokensSaved : 0,
+    tokensSaved: isNonNegativeFinite(r.tokensSaved) ? r.tokensSaved : 0,
     verified: typeof r.verified === "boolean" ? r.verified : false,
     gaps: isStringArray(r.gaps) ? r.gaps : [],
-    explorationRounds: typeof r.explorationRounds === "number" ? r.explorationRounds : 0,
-    explorationBoundaries: typeof r.explorationBoundaries === "number" ? r.explorationBoundaries : 0,
+    explorationRounds: isNonNegativeFinite(r.explorationRounds) ? r.explorationRounds : 0,
+    explorationBoundaries: isNonNegativeFinite(r.explorationBoundaries) ? r.explorationBoundaries : 0,
     model: typeof r.model === "string" ? r.model : "unknown",
     qualityScore: typeof r.qualityScore === "number" ? r.qualityScore : 0,
-    tokensBefore: typeof r.tokensBefore === "number" ? r.tokensBefore : 0,
+    tokensBefore: isNonNegativeFinite(r.tokensBefore) ? r.tokensBefore : 0,
+    ...Object.fromEntries(NON_NEGATIVE_DETAIL_FIELDS
+      .filter(key => !["chunkCount", "totalMessages", "totalTokensSummarized", "llmCalls", "tokensSaved", "explorationRounds", "explorationBoundaries", "tokensBefore"].includes(key)
+        && isNonNegativeFinite(r[key]))
+      .map(key => [key, r[key]])),
+    ...Object.fromEntries(YIELD_DETAIL_FIELDS
+      .filter(key => isNonNegativeFinite(r[key]) && (r[key] as number) <= 1)
+      .map(key => [key, r[key]])),
+    ...(Array.isArray(r.relaxedSoftBoundaries) && r.relaxedSoftBoundaries.every(kind => ["recent-user-turn", "anchor", "topical"].includes(kind))
+      ? { relaxedSoftBoundaries: r.relaxedSoftBoundaries as SmartCompactDetails["relaxedSoftBoundaries"] } : {}),
+    ...(typeof r.hardBoundaryAdjusted === "boolean" ? { hardBoundaryAdjusted: r.hardBoundaryAdjusted } : {}),
   };
   return isValidSmartCompactDetails(repaired) ? repaired : null;
 }

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -55,8 +55,18 @@ describe("metrics reporting", () => {
       profile: "balanced", mode: "balanced", tier: "full", contextPercent: 80,
       toolPercent: 50, totalTokens: 1_000, tokensSaved: 500, chunkCount: 1,
       methodForMetrics: "eesv", adapted: false,
+      details: {
+        plannedAfterTokens: 600, plannedSavedTokens: 400, plannedYield: 0.4,
+        estimatedAfterTokens: 500, estimatedSavedTokens: 500, estimatedYield: 0.5,
+        retainedTailTokens: 300, summaryTokens: 200, summaryBudgetTokens: 300,
+        targetAfterTokens: 600, relaxedSoftBoundaries: ["anchor"], hardBoundaryAdjusted: true,
+      },
     } as any, "success");
     expect(snapshot.runId).toBe("run-stage-quality");
+    expect(snapshot).toMatchObject({
+      tokensSaved: 500, estimatedSavedTokens: 500, estimatedAfterTokens: 500,
+      plannedAfterTokens: 600, retainedTailTokens: 300, relaxedSoftBoundaries: ["anchor"], hardBoundaryAdjusted: true,
+    });
     expect(snapshot.providerRoutes?.find(route => route.stage === "synthesize")).toMatchObject({
       qualityScore: 73, qualityBasis: "pre-repair-verification",
     });
@@ -103,6 +113,27 @@ describe("metrics reporting", () => {
       verificationGapKinds: ["inconsistency", "fabricated-file"],
     });
     expect(JSON.stringify(entry)).not.toContain("secret evidence");
+  });
+
+  it("persists content-free yield-gate diagnostics without summary text", () => {
+    const svc = services.createServices();
+    const error = Object.assign(new Error("Final summary estimate misses target"), {
+      name: "YieldGateError", plannedAfterTokens: 500, plannedSavedTokens: 500, plannedYield: 0.5,
+      estimatedAfterTokens: 700, estimatedSavedTokens: 300, estimatedYield: 0.3,
+      retainedTailTokens: 400, summaryTokens: 300, summaryBudgetTokens: 100,
+      targetAfterTokens: 600, relaxedSoftBoundaries: ["anchor"], hardBoundaryAdjusted: true,
+    });
+    recordFailureMetrics({
+      services: svc, cancellation: { timedOut: false }, flags: { autoTriggered: false },
+      summaryModel: { provider: "openai", id: "gpt" }, profile: "balanced", mode: "balanced",
+      modelLabel: "openai/gpt", pipelineStart: Date.now(),
+    } as any, error, { sessionId: "yield-failure", totalTokens: 1_000, profile: "balanced" });
+    const entry = cache.readMetricsLog().at(-1);
+    expect(entry).toMatchObject({
+      failureKind: "yield", estimatedAfterTokens: 700, estimatedSavedTokens: 300,
+      targetAfterTokens: 600, relaxedSoftBoundaries: ["anchor"], hardBoundaryAdjusted: true,
+    });
+    expect(JSON.stringify(entry)).not.toContain("Final summary estimate");
   });
 
   it("writes a local html dashboard", () => {

--- a/test/persist-lifecycle.test.ts
+++ b/test/persist-lifecycle.test.ts
@@ -70,9 +70,9 @@ function makeRC(behaviour: "complete" | "error"): RunContext {
     pipelineStart: Date.now(),
     extraction: undefined,
     compactionState: undefined,
-    // applyCompaction now records the run outcome from the native compact's
-    // callbacks (success on onComplete, error on onError), so the fake RC
-    // needs the metric fields those paths read.
+    // applyCompaction records only native apply errors. Correlated
+    // session_compact exclusively owns success metrics and feedback, while
+    // the error fallback still reads these metric fields.
     sessionId: "test-session",
     profile: "balanced",
     tier: "full",
@@ -118,6 +118,7 @@ describe("applyCompaction onError", () => {
     applyCompaction(rc);
     expect(rc.pendingRef.isPresent()).toBe(true);
     expect(readMetricsLog()).toHaveLength(before);
+    expect((rc as unknown as { _calls: string[] })._calls).not.toContain("notify:Applied ✓");
   });
 
   it("lets the lifecycle store own apply-error telemetry without duplication", () => {

--- a/test/preflight-ui.test.ts
+++ b/test/preflight-ui.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "bun:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { ManualPreflight } from "../src/app/preflight.ts";
+import { DEFAULT_CONFIG } from "../src/constants.ts";
+import type { CompactionWindowPlan } from "../src/app/run-context.ts";
+import { formatPreflightSummary, recommendPreflight, showCompactUI } from "../src/ui/overlays.ts";
+import { resolveModels } from "../src/index.ts";
+
+function preview(mode: ManualPreflight["mode"], viable: boolean, reason: ManualPreflight["reason"] = viable ? "viable" : "insufficient-projected-saving"): ManualPreflight {
+  const plan: CompactionWindowPlan = {
+    keepFrom: 2, compactTokens: 60_000, retainedTokens: 20_000,
+    projectedAfterTokens: 26_000, projectedSavedTokens: 64_000, projectedYield: 0.71,
+    fixedContextTokens: 0, retentionTargetTokens: 20_000, summaryBudgetTokens: 6_000,
+    targetAfterTokens: 26_000, hardBoundaryAdjusted: false, viable, reason: reason === "not-enough-messages" ? "no-eligible-prefix" : reason,
+    relaxedSoftBoundaries: ["recent-user-turn"],
+  };
+  return {
+    mode, plan, reason, totalTokens: 90_000,
+    profileCfg: { keepRecentTokens: 20_000, summaryBudgetTokens: 6_000, minChunkTokens: 500, maxChunkTokens: 8_000, singlePassMaxTokens: 30_000, batchMaxTokens: 24_000 },
+    rawEstimatedMessageTokens: 100_000, estimatorScale: 0.8, adapted: false, damageMedian: 0,
+    contextWindowTokens: 140_000, contextPercent: 64, toolPercent: 10, overflowedContext: false,
+  };
+}
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+  bg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
+const keybindings = {
+  matches: (data: string, binding: string) => ({
+    "tui.select.cancel": "esc", "tui.select.up": "up", "tui.select.down": "down", "tui.select.confirm": "enter",
+  } as Record<string, string>)[binding] === data,
+};
+
+const config = { ...DEFAULT_CONFIG, profiles: DEFAULT_CONFIG.profiles };
+const opts = { contextTokens: 90_000, contextPercent: 90, activeModelLabel: "openai/summary", defaultModelIndex: 0, config };
+
+function context(custom: (component: any, doneValue: { value?: unknown }) => void, totalTokens = 90_000, models?: Array<{ provider: string; id: string; contextWindow: number }>) {
+  const model = { provider: "openai", id: "summary", contextWindow: 100_000 };
+  const available = models ?? [model];
+  const branch = [
+    { type: "message", id: "old-user", message: { role: "user", content: [{ type: "text", text: "x".repeat(300_000) }] } },
+    { type: "message", id: "old-answer", message: { role: "assistant", content: [{ type: "text", text: "y".repeat(100_000) }] } },
+    { type: "message", id: "recent-user", message: { role: "user", content: [{ type: "text", text: "recent" }] } },
+    { type: "message", id: "recent-answer", message: { role: "assistant", content: [{ type: "text", text: "answer" }] } },
+  ];
+  return {
+    cwd: "/tmp/pi-smart-compact-preflight-test",
+    model,
+    modelRegistry: {
+      getAvailable: () => available,
+      find: (provider: string, id: string) => available.find(item => item.provider === provider && item.id === id),
+    },
+    getContextUsage: () => ({ tokens: totalTokens, contextWindow: model.contextWindow, percent: totalTokens / 1_000 }),
+    sessionManager: { buildContextEntries: () => branch, getBranch: () => branch },
+    ui: {
+      custom: async (factory: any) => {
+        const result: { value?: unknown } = {};
+        const component = factory({ requestRender: () => {} }, theme, keybindings, (value: unknown) => { result.value = value; });
+        custom(component, result);
+        return result.value;
+      },
+    },
+  } as any;
+}
+
+describe("smart compact preflight UI", () => {
+  it("recommends Balanced at normal pressure and explains a viable fallback", () => {
+    const plans = new Map([
+      ["thorough", preview("thorough", true)], ["balanced", preview("balanced", true)], ["fast", preview("fast", true)],
+    ] as const);
+    const normal = recommendPreflight(plans);
+    expect(normal.mode).toBe("balanced");
+    expect(normal.reason).toContain("~64% window pressure");
+    expect(normal.reason).toContain("~71% projected saving");
+    expect(normal.reason).toContain("~20,000t recent tail");
+
+    plans.set("balanced", preview("balanced", false));
+    const fallback = recommendPreflight(plans);
+    expect(fallback.mode).toBe("thorough");
+    expect(fallback.reason).toContain("estimated saving is below 10%");
+  });
+
+  it("recommends Fast under severe pressure and mentions tool-heavy shape", () => {
+    const plans = new Map(["thorough", "balanced", "fast"].map(mode => {
+      const item = preview(mode as ManualPreflight["mode"], true);
+      item.contextPercent = 96;
+      item.toolPercent = 78;
+      return [mode, item] as const;
+    }));
+    const recommendation = recommendPreflight(plans);
+    expect(recommendation.mode).toBe("fast");
+    expect(recommendation.reason).toContain("~96% window pressure");
+    expect(recommendation.reason).toContain("tool-heavy shape (~78%");
+  });
+
+  it("prioritizes Thorough when damage feedback adapted retention", () => {
+    const plans = new Map(["thorough", "balanced", "fast"].map(mode => {
+      const item = preview(mode as ManualPreflight["mode"], true);
+      item.adapted = true;
+      item.damageMedian = 40;
+      item.contextPercent = 96;
+      return [mode, item] as const;
+    }));
+    const recommendation = recommendPreflight(plans);
+    expect(recommendation.mode).toBe("thorough");
+    expect(recommendation.reason).toContain("recent damage feedback");
+  });
+
+  it("formats estimates, boundaries, safeguards, and technical disclosure honestly", () => {
+    const lines = formatPreflightSummary(preview("balanced", true), "openai/summary", true).join("\n");
+    expect(lines).toContain("Before ~90,000t (~64% window)");
+    expect(lines).toContain("expected after ~26,000t (~19% window)");
+    expect(lines).toContain("Projected net saving ~64,000t (~71%, estimator-based)");
+    expect(lines).toContain("summary budget ≤6,000t");
+    expect(lines).toContain("Soft boundaries included in summary: older user turn");
+    expect(lines).toContain("Internal soft boundaries: recent-user-turn");
+    expect(lines).toContain("complete tool-call/result pairs");
+    expect(lines).toContain("zero-gap verification before apply");
+    expect(lines).toContain("normalized ×0.80");
+    expect(lines).toContain("Summary route: openai/summary");
+  });
+
+  it("supports D disclosure and Enter on a viable preset without exceeding narrow width", async () => {
+    const result = await showCompactUI(context((component, done) => {
+      const narrowLines = component.render(36);
+      const narrow = narrowLines.join(" ");
+      expect(narrowLines.every((line: string) => visibleWidth(line) <= 36)).toBeTrue();
+      expect(narrow).toContain("severe context pressure");
+      expect(narrow).toContain("Before ~90,000t");
+      expect(narrow).toContain("expected after");
+      expect(narrow).toContain("Projected net saving");
+      expect(narrow).toContain("zero-gap verification before apply");
+      expect(component.render(100).join("\n")).toContain("faster run · 20K base recent tail · 6K base summary");
+      component.handleInput("d");
+      expect(component.render(80).join("\n")).toContain("Estimator:");
+      component.handleInput("enter");
+      expect(done.value).toBeDefined();
+    }), opts);
+    expect(result?.mode).toBeDefined();
+  });
+
+  it("uses the configured summary route as the initial preflight model", async () => {
+    const models = [
+      { provider: "openai", id: "summary", contextWindow: 100_000 },
+      { provider: "anthropic", id: "configured-summary", contextWindow: 200_000 },
+    ];
+    const configured = { ...config, summaryModel: "anthropic/configured-summary" };
+    const ctx = context((component) => {
+      expect(component.render(100).join("\n")).toContain("Summary model: anthropic/configured-summary");
+      component.handleInput("enter");
+    }, 90_000, models);
+    const initial = resolveModels(ctx, ctx.model, configured).sumModel!;
+    const defaultModelIndex = models.findIndex(model => model.provider === initial.provider && model.id === initial.id);
+    const result = await showCompactUI(ctx, { ...opts, config: configured, defaultModelIndex });
+    expect(result?.model.value).toBe("anthropic/configured-summary");
+  });
+
+  it("keeps the active model label and recalculates after M changes the summary route", async () => {
+    let screens = 0;
+    const models = [
+      { provider: "openai", id: "summary", contextWindow: 100_000 },
+      { provider: "anthropic", id: "advanced-summary", contextWindow: 200_000 },
+    ];
+    const result = await showCompactUI(context((component) => {
+      screens++;
+      if (screens === 1) component.handleInput("m");
+      else if (screens === 2) {
+        const picker = component.render(100).join("\n");
+        expect(picker).toContain("Active context: openai/summary");
+        component.handleInput("\x1b[B");
+        component.handleInput("\r");
+      } else {
+        expect(component.render(100).join("\n")).toContain("Summary model: anthropic/advanced-summary");
+        component.handleInput("esc");
+      }
+    }, 90_000, models), opts);
+    expect(screens).toBe(3);
+    expect(result).toBeNull();
+  });
+
+  it("blocks Enter for non-viable plans and lets Esc cancel", async () => {
+    const result = await showCompactUI(context((component, done) => {
+      component.handleInput("enter");
+      expect(done.value).toBeUndefined();
+      component.handleInput("esc");
+    }, 1_000), { ...opts, contextTokens: 1_000, contextPercent: 1 });
+    expect(result).toBeNull();
+  });
+});

--- a/test/progress-feedback.test.ts
+++ b/test/progress-feedback.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { clearCompactProgress, notifyAppliedCompaction, showProgressOverlay } from "../src/ui/overlays.ts";
+
+function context() {
+  const calls: string[] = [];
+  let widgetFactory: ((tui: unknown, theme: unknown) => { render(width: number): string[] }) | undefined;
+  const ctx = {
+    hasUI: true,
+    ui: {
+      setStatus: (_key: string, value: string | undefined) => calls.push("status:" + value),
+      setWidget: (_key: string, value: typeof widgetFactory) => {
+        widgetFactory = value;
+        calls.push("widget:" + (value == null ? "clear" : "set"));
+      },
+      notify: (message: string) => calls.push("notify:" + message),
+    },
+  } as any;
+  return { ctx, calls, widget: () => widgetFactory };
+}
+
+describe("semantic compact progress", () => {
+  it("renders completed/current/future phases and marks optional Explore skipped", () => {
+    const { ctx, calls, widget } = context();
+    showProgressOverlay(ctx, { phase: 3, phaseName: "Synthesize", detail: "2/4 batches" });
+    expect(calls).toEqual(["status:Smart Compact · Synthesize · 2/4 batches", "widget:set"]);
+    const component = widget()!({}, { fg: (_color: string, text: string) => text });
+    expect(component.render(120)).toEqual([
+      "✓ Extract  – Explore  ● Synthesize  ○ Verify  ○ Apply",
+    ]);
+    clearCompactProgress(ctx);
+    expect(calls.slice(-2)).toEqual(["status:undefined", "widget:clear"]);
+    expect(calls.some(call => call.startsWith("notify:"))).toBeFalse();
+  });
+
+  it("renders Explore completed when the optional phase ran", () => {
+    const { ctx, widget } = context();
+    showProgressOverlay(ctx, { phase: 4, phaseName: "Verify", detail: "Checking", explorationRounds: 2 });
+    const component = widget()!({}, { fg: (_color: string, text: string) => text });
+    expect(component.render(120)[0]).toBe("✓ Extract  ✓ Explore  ✓ Synthesize  ● Verify  ○ Apply");
+  });
+
+  it("reports only applied estimates, never actual context", () => {
+    const { ctx, calls } = context();
+    notifyAppliedCompaction(ctx, {
+      tokensBefore: 1_000, tokensSaved: 400, plannedAfterTokens: 550, estimatedAfterTokens: 600, estimatedYield: 0.4,
+      qualityScore: 100,
+    } as any, false);
+    expect(calls.at(-1)).toContain("1,000t → planned ~550t / ~600t applied estimate");
+    expect(calls.at(-1)).toContain("0 gaps");
+    expect(calls.at(-1)).not.toContain("actual");
+  });
+
+  it("suppresses headless progress", () => {
+    const { ctx, calls } = context();
+    ctx.hasUI = false;
+    showProgressOverlay(ctx, { phase: 1, phaseName: "Extract", detail: "Preparing" });
+    expect(calls).toEqual([]);
+  });
+});

--- a/test/provider-routing.test.ts
+++ b/test/provider-routing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { prepareRun } from "../src/app/steps/prepare.ts";
 import { createServices } from "../src/infra/services.ts";
 import { resolveStageAuth } from "../src/app/stage-auth.ts";
+import { DEFAULT_CONFIG } from "../src/constants.ts";
 
 describe("stage-aware provider routing", () => {
   it("resolves auth once per distinct route and keeps equivalent models deduplicated", async () => {
@@ -10,6 +11,10 @@ describe("stage-aware provider routing", () => {
     const equivalentSegmenter = { ...summary };
     const verifier = { provider: "anthropic", id: "verifier", contextWindow: 200_000 } as any;
     const controller = new AbortController();
+    const config = {
+      ...DEFAULT_CONFIG,
+      profiles: { ...DEFAULT_CONFIG.profiles, balanced: { ...DEFAULT_CONFIG.profiles.balanced, summaryBudgetTokens: 1_234 } },
+    };
     const prepared = await prepareRun({
       ctx: {
         cwd: process.cwd(),
@@ -19,6 +24,7 @@ describe("stage-aware provider routing", () => {
         } },
         ui: { notify: () => {} },
       },
+      config,
       summaryModel: summary,
       segModel: equivalentSegmenter,
       verifyModel: verifier,
@@ -34,6 +40,8 @@ describe("stage-aware provider routing", () => {
     } as any);
 
     expect(requested).toEqual([]);
+    expect(prepared?.config).toBe(config);
+    expect(prepared?.profileCfg.summaryBudgetTokens).toBe(1_234);
     expect(prepared?.summaryAuth).toBeUndefined();
     expect((await resolveStageAuth(prepared!, "summary")).apiKey).toBe("openai-key");
     expect((await resolveStageAuth(prepared!, "explore")).apiKey).toBe("openai-key");

--- a/test/state-step-continuity.test.ts
+++ b/test/state-step-continuity.test.ts
@@ -28,6 +28,12 @@ describe("buildState continuity integration", () => {
       estimator: makeTokenEstimator("openai", "test", services.tokenCalibration),
       profile: "balanced", mode: "balanced", method: "eesv", chunkCount: 1, summaries: [],
       toCompact: [{}, {}], convTokens: 1_000, totalTokens: 50_000, compactTokens: 20_000, accTokens: 10_000,
+      compactionPlan: {
+        keepFrom: 2, compactTokens: 20_000, retainedTokens: 10_000, projectedAfterTokens: 40_000,
+        projectedSavedTokens: 10_000, projectedYield: 0.2, fixedContextTokens: 20_000,
+        retentionTargetTokens: 10_000, summaryBudgetTokens: 10_000, targetAfterTokens: 40_000,
+        hardBoundaryAdjusted: false, viable: true, reason: "viable", relaxedSoftBoundaries: [],
+      },
       backupPath: null, verified: true, verificationGaps: [], verificationScore: 100,
       verificationProvenance: { initialScore: 100, deterministicPatched: [], llmPatched: false, finalScore: 100, remainingGaps: [] },
       explorationRounds: 0, modelLabel: "openai/test", notify: () => {},
@@ -66,9 +72,57 @@ describe("buildState continuity integration", () => {
       estimator: makeTokenEstimator("openai", "test", services.tokenCalibration),
       profile: "balanced", mode: "balanced", method: "eesv", chunkCount: 1, summaries: [],
       toCompact: [{}, {}], convTokens: 1_000, totalTokens: 50_000, compactTokens: 20_000, accTokens: 10_000,
+      compactionPlan: {
+        keepFrom: 2, compactTokens: 20_000, retainedTokens: 10_000, projectedAfterTokens: 40_000,
+        projectedSavedTokens: 10_000, projectedYield: 0.2, fixedContextTokens: 20_000,
+        retentionTargetTokens: 10_000, summaryBudgetTokens: 10_000, targetAfterTokens: 40_000,
+        hardBoundaryAdjusted: false, viable: true, reason: "viable", relaxedSoftBoundaries: [],
+      },
       backupPath: null, verified: true, verificationGaps: [], verificationScore: 100,
       verificationProvenance: { initialScore: 100, deterministicPatched: [], llmPatched: false, finalScore: 100, remainingGaps: [] },
       explorationRounds: 0, modelLabel: "openai/test", notify: () => {},
     } as any)).toThrow("Verification gate rejected summary");
+  });
+
+  it("rejects an oversized verified final state before details can exist", () => {
+    const services = createServices();
+    const extraction: StructuredExtraction = {
+      modifiedFiles: [], readFiles: [], deletedFiles: [], errors: [], decisions: [], constraints: [], topics: [], timeline: [],
+      mainGoal: null, lastUserMessages: [], lastErrors: [], messageCount: 2,
+    };
+    const rc: any = {
+      extraction,
+      finalSummary: "## Goal\nContinue safely\n\n## Progress\n" + "oversized-safe-text ".repeat(1_000),
+      projectId: "yield-state", continuityScope: { schemaVersion: 2, projectId: "yield-state", sessionId: "s" }, previousState: null,
+      llmMessages: [], explorationReport: null, config: { pinPaths: [] }, services,
+      estimator: makeTokenEstimator("openai", "test", services.tokenCalibration),
+      profile: "balanced", mode: "balanced", method: "eesv", chunkCount: 1, summaries: [],
+      toCompact: [{}, {}], convTokens: 1_000, totalTokens: 1_000, compactTokens: 900, accTokens: 100,
+      compactionPlan: {
+        keepFrom: 2, compactTokens: 900, retainedTokens: 100, projectedAfterTokens: 200,
+        projectedSavedTokens: 800, projectedYield: 0.8, fixedContextTokens: 0,
+        retentionTargetTokens: 100, summaryBudgetTokens: 100, targetAfterTokens: 200,
+        hardBoundaryAdjusted: true, viable: true, reason: "viable", relaxedSoftBoundaries: ["anchor"],
+      },
+      backupPath: null, verified: true, verificationGaps: [], verificationScore: 100,
+      verificationProvenance: { initialScore: 100, deterministicPatched: [], llmPatched: false, finalScore: 100, remainingGaps: [] },
+      explorationRounds: 0, modelLabel: "openai/test", notify: () => {},
+    };
+
+    try {
+      buildState(rc);
+      throw new Error("expected YieldGateError");
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: "YieldGateError", reason: "target-miss", plannedAfterTokens: 200,
+        retainedTailTokens: 100, summaryBudgetTokens: 100, targetAfterTokens: 200,
+        relaxedSoftBoundaries: ["anchor"], hardBoundaryAdjusted: true,
+      });
+      expect((error as { estimatedAfterTokens: number }).estimatedAfterTokens).toBeGreaterThan(200);
+      expect(JSON.stringify(error)).not.toContain("oversized-safe-text");
+      expect(rc.details).toBeUndefined();
+      expect(rc.compactionState).toBeUndefined();
+      expect(rc.openLoops).toBeUndefined();
+    }
   });
 });

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -35,6 +35,7 @@ describe("privacy-safe canary telemetry", () => {
     expect(classifyTelemetryFailure(new Error("native compaction write failed"))).toBe("persistence");
     expect(classifyTelemetryFailure(new Error("provider stream failed"))).toBe("provider");
     expect(classifyTelemetryFailure(Object.assign(new Error("Verification gate rejected summary"), { name: "VerificationGateError" }))).toBe("verification");
+    expect(classifyTelemetryFailure(Object.assign(new Error("estimate miss"), { name: "YieldGateError" }))).toBe("yield");
     expect(classifyTelemetryFailure(new Error("unexpected invariant"))).toBe("internal");
   });
 
@@ -148,12 +149,14 @@ describe("privacy-safe canary telemetry", () => {
   it("exports aggregates without session, project, prompt, path, or error text", () => {
     const report = buildPrivacySafeTelemetry([
       metric("stable", { failureKind: "authentication", status: "failure" }),
-      metric("canary"),
+      metric("canary", { estimatedAfterTokens: 600, estimatedSavedTokens: 400, relaxedSoftBoundaries: ["anchor"] }),
     ], [], { version: "8.0.0", minCanaryRuns: 5 });
     const serialized = JSON.stringify(report);
     expect(serialized).not.toContain("private-session");
     expect(serialized).not.toContain("run-");
     expect(serialized).not.toContain("projectId");
+    expect(serialized).not.toContain("estimatedAfterTokens");
+    expect(serialized).not.toContain("relaxedSoftBoundaries");
     expect(report.aggregates[0].model).toBe("m");
     expect(report.failures.authentication).toBe(1);
     expect(report.privacy).toContain("aggregate-only");

--- a/test/type-guards.test.ts
+++ b/test/type-guards.test.ts
@@ -165,9 +165,21 @@ describe("isValidSmartCompactDetails", () => {
     expect(isValidSmartCompactDetails(validDetails({ qualityScore: Infinity }))).toBe(false);
     expect(isValidSmartCompactDetails(validDetails({ qualityScore: "90" }))).toBe(false);
   });
-  it("rejects missing / non-finite totalMessages", () => {
+  it("rejects missing, non-finite, or negative token/count fields", () => {
     expect(isValidSmartCompactDetails(validDetails({ totalMessages: undefined }))).toBe(false);
     expect(isValidSmartCompactDetails(validDetails({ totalMessages: NaN }))).toBe(false);
+    for (const field of [
+      "chunkCount", "totalMessages", "totalTokensSummarized", "llmCalls", "tokensSaved",
+      "explorationRounds", "explorationBoundaries", "tokensBefore", "plannedAfterTokens",
+      "plannedSavedTokens", "estimatedAfterTokens", "estimatedSavedTokens", "retainedTailTokens",
+      "summaryTokens", "summaryBudgetTokens", "targetAfterTokens",
+    ]) expect(isValidSmartCompactDetails(validDetails({ [field]: -1 }))).toBe(false);
+  });
+  it("rejects yields outside [0,1]", () => {
+    expect(isValidSmartCompactDetails(validDetails({ plannedYield: -0.01 }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ plannedYield: 1.01 }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ estimatedYield: Infinity }))).toBe(false);
+    expect(isValidSmartCompactDetails(validDetails({ estimatedYield: 1 }))).toBe(true);
   });
 
   // Optional-but-typed fields: present-and-wrong-type must reject
@@ -267,6 +279,17 @@ describe("sanitizeSmartCompactDetails", () => {
     expect(repaired!.model).toBe("openai/gpt-x");
     expect(repaired!.verified).toBe(true);
     expect(repaired!.backupPath).toBe("/x.md");
+  });
+
+  it("drops malformed estimates and clamps malformed required counts to safe defaults", () => {
+    const repaired = sanitizeSmartCompactDetails(validDetails({
+      tokensSaved: -10, plannedAfterTokens: -1, estimatedYield: 1.5, chunkCount: -2,
+    }))!;
+    expect(repaired.tokensSaved).toBe(0);
+    expect(repaired.chunkCount).toBe(0);
+    expect(repaired.plannedAfterTokens).toBeUndefined();
+    expect(repaired.estimatedYield).toBeUndefined();
+    expect(isValidSmartCompactDetails(repaired)).toBe(true);
   });
 
   it("the repaired result always passes isValidSmartCompactDetails", () => {

--- a/test/window-boundary.test.ts
+++ b/test/window-boundary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { resolveCompactionWindow } from "../src/app/steps/window.ts";
+import { planCompactionWindow, resolveCompactionWindow } from "../src/app/steps/window.ts";
 import type { PreparedRc } from "../src/app/run-context.ts";
 import type { SessionMessageEntry } from "../src/types.ts";
 import { makeTokenEstimator, TokenCalibrationStore } from "../src/utils/tokens.ts";
@@ -97,7 +97,7 @@ describe("resolveCompactionWindow tool-result boundary", () => {
     rc.notify = message => { notices.push(message); };
 
     expect(resolveCompactionWindow(rc)).toBeNull();
-    expect(notices.join(" ")).toContain("run again too soon");
+    expect(notices.join(" ")).toContain("no eligible prefix remains");
   });
 
   it("backs up when the token window naturally starts at a toolResult", () => {
@@ -135,9 +135,40 @@ describe("resolveCompactionWindow tool-result boundary", () => {
     expect(result).toBeNull();
   });
 
+  it("summarizes a complete tool exchange when retaining it would exceed the target", () => {
+    const callId = "hard-adjust";
+    const branch = [
+      messageEntry("old-user", null, { role: "user", content: [{ type: "text", text: "old" }] }),
+      messageEntry("old-answer", "old-user", { role: "assistant", content: [{ type: "text", text: "old answer" }] }),
+      messageEntry("call", "old-answer", { role: "assistant", content: [{ type: "toolCall", id: callId, name: "read", arguments: { path: "x" } }] }),
+      messageEntry("result", "call", { role: "toolResult", toolCallId: callId, toolName: "read", content: [{ type: "text", text: "result" }] }),
+      messageEntry("tail", "result", { role: "assistant", content: [{ type: "text", text: "tail" }] }),
+    ];
+    const rc = makePreparedRc(branch, 350);
+    rc.profileCfg.summaryBudgetTokens = 10;
+
+    const plan = planCompactionWindow({
+      msgs: branch,
+      branch,
+      messageTokens: [1_000, 1_000, 100, 100, 300],
+      totalTokens: 2_500,
+      modelContextWindow: 10_000,
+      mode: "thorough",
+      profileCfg: rc.profileCfg,
+      force: true,
+      overflowedContext: false,
+    });
+
+    expect(plan.hardBoundaryAdjusted).toBeTrue();
+    expect(plan.keepFrom).toBe(4);
+    expect(plan.retentionTargetTokens).toBe(400);
+    expect(plan.retainedTokens).toBe(300);
+    expect(plan.reason).toBe("viable");
+  });
+
   it("counts large tool-call arguments in the recent-tail budget", () => {
     const branch: SessionMessageEntry[] = [];
-    for (let i = 0; i < 45; i++) {
+    for (let i = 0; i < 100; i++) {
       branch.push(messageEntry("a" + i, i ? "r" + (i - 1) : null, {
         role: "assistant",
         content: [{ type: "toolCall", id: "w" + i, name: "write", arguments: { path: "src/f" + i + ".ts", content: "x".repeat(2000) } }],
@@ -147,7 +178,11 @@ describe("resolveCompactionWindow tool-result boundary", () => {
       }));
     }
 
-    const result = resolveCompactionWindow(makePreparedRc(branch, 20_000));
+    const rc = makePreparedRc(branch, 20_000);
+    const estimated = branch.reduce((sum, entry) => sum + rc.estimator.message(entry.message as any), 0);
+    rc.ctx.model = { id: "tool-test", provider: "test", contextWindow: estimated * 2 } as any;
+    rc.ctx.getContextUsage = () => ({ tokens: estimated, contextWindow: estimated * 2, percent: 50 } as any);
+    const result = resolveCompactionWindow(rc);
 
     expect(result).not.toBeNull();
     expect(branch.length - result!.keepFrom).toBeGreaterThan(50);
@@ -191,28 +226,77 @@ describe("resolveCompactionWindow tool-result boundary", () => {
       messageEntry("active-6", "active-5", { role: "assistant", content: [{ type: "text", text: "latest answer" }] }),
     ];
     const rc = makePreparedRc([], 1);
+    const estimated = active.reduce((sum, entry) => sum + rc.estimator.message(entry.message as any), 0);
+    rc.ctx.getContextUsage = () => ({ tokens: estimated, contextWindow: 150_000, percent: estimated / 1_500 } as any);
+    rc.profileCfg.summaryBudgetTokens = 100;
     (rc.ctx.sessionManager as any).getBranch = () => { throw new Error("append-only history must not be read"); };
     (rc.ctx.sessionManager as any).buildContextEntries = () => active;
 
     const result = resolveCompactionWindow(rc);
 
     expect(result?.msgs.map(message => message.id)).toEqual(active.map(message => message.id));
-    expect(result?.toCompact.map(message => message.id)).toEqual(active.slice(0, 2).map(message => message.id));
+    expect(result?.toCompact.length).toBeGreaterThan(0);
   });
 
-  it("keeps the two most recent user turns when enough history exists", () => {
+  it("keeps the two most recent user turns when that soft boundary fits", () => {
     const branch = [
-      messageEntry("u1", null, { role: "user", content: [{ type: "text", text: "first" }] }),
-      messageEntry("a1", "u1", { role: "assistant", content: [{ type: "text", text: "first answer" }] }),
+      messageEntry("u1", null, { role: "user", content: [{ type: "text", text: "first " + "x".repeat(30_000) }] }),
+      messageEntry("a1", "u1", { role: "assistant", content: [{ type: "text", text: "first answer " + "x".repeat(30_000) }] }),
       messageEntry("u2", "a1", { role: "user", content: [{ type: "text", text: "second" }] }),
       messageEntry("a2", "u2", { role: "assistant", content: [{ type: "text", text: "second answer" }] }),
       messageEntry("u3", "a2", { role: "user", content: [{ type: "text", text: "third" }] }),
       messageEntry("a3", "u3", { role: "assistant", content: [{ type: "text", text: "third answer" }] }),
     ];
+    const rc = makePreparedRc(branch, 100);
+    const estimated = branch.reduce((sum, entry) => sum + rc.estimator.message(entry.message as any), 0);
+    rc.profileCfg.summaryBudgetTokens = 10;
+    rc.ctx.model = { id: "soft", provider: "test", contextWindow: estimated * 4 } as any;
+    rc.ctx.getContextUsage = () => ({ tokens: estimated, contextWindow: estimated * 4, percent: 25 } as any);
 
-    const result = resolveCompactionWindow(makePreparedRc(branch, 1));
+    const result = resolveCompactionWindow(rc)!;
+    expect(result.keepFrom).toBeLessThanOrEqual(branch.findIndex(entry => entry.id === "u2"));
+    expect(result.compactionPlan.relaxedSoftBoundaries).not.toContain("recent-user-turn");
+  });
 
-    expect(result?.firstKeptId).toBe("u2");
+  it("summarizes an old prefix of one long user turn when the full turn exceeds the tail budget", () => {
+    const branch: SessionMessageEntry[] = [
+      messageEntry("long-turn-user", null, {
+        role: "user",
+        content: [{ type: "text", text: "Implement the requested feature without losing the active constraints." }],
+      }),
+    ];
+    for (let index = 0; index < 45; index++) {
+      const parentId = branch.at(-1)!.id;
+      branch.push(messageEntry("long-turn-call-" + index, parentId, {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "long-call-" + index, name: "bash", arguments: { command: "echo " + index } }],
+      }));
+      branch.push(messageEntry("long-turn-result-" + index, "long-turn-call-" + index, {
+        role: "toolResult",
+        toolCallId: "long-call-" + index,
+        toolName: "bash",
+        content: [{ type: "text", text: "result " + index + " " + "x".repeat(8_000) }],
+        isError: false,
+      }));
+    }
+    branch.push(messageEntry("long-turn-tail", branch.at(-1)!.id, {
+      role: "assistant",
+      content: [{ type: "text", text: "Current implementation status and next action." }],
+    }));
+
+    const rc = makePreparedRc(branch, 10_000);
+    const estimated = branch.reduce((sum, entry) => sum + rc.estimator.message(entry.message as any), 0);
+    rc.profileCfg.summaryBudgetTokens = 3_000;
+    rc.ctx.model = { id: "long-turn", provider: "test", contextWindow: estimated * 2 } as any;
+    rc.ctx.getContextUsage = () => ({ tokens: estimated, contextWindow: estimated * 2, percent: 50 } as any);
+
+    const result = resolveCompactionWindow(rc)!;
+
+    expect(result.firstKeptId).not.toBe("long-turn-user");
+    expect(result.toCompact.some(entry => entry.id === "long-turn-user")).toBeTrue();
+    expect(result.compactionPlan.relaxedSoftBoundaries).toContain("recent-user-turn");
+    expect((result.msgs[result.keepFrom].message as any).role).not.toBe("toolResult");
+    expect(result.compactionPlan.projectedYield).toBeGreaterThanOrEqual(0.1);
   });
 
   it("manually compacts a 219K session on a 1M window without requiring aggressive mode", () => {
@@ -242,6 +326,35 @@ describe("resolveCompactionWindow tool-result boundary", () => {
     expect(notices.join(" ")).toContain("verification remains fail-closed");
   });
 
+  it("accepts a manual absolute-tail plan even when fixed context exceeds the relative mode target", () => {
+    const branch = Array.from({ length: 120 }, (_, index) => messageEntry(
+      "fixed-" + index,
+      index ? "fixed-" + (index - 1) : null,
+      {
+        role: index % 40 === 0 ? "user" : "assistant",
+        content: [{ type: "text", text: "message " + index + " " + "x".repeat(10_000) }],
+      },
+    ));
+    const rc = makePreparedRc(branch, 30_000);
+    rc.mode = "thorough";
+    rc.profile = "light";
+    rc.profileCfg.summaryBudgetTokens = 10_000;
+    rc.ctx.model = { id: "million-fixed", provider: "test", contextWindow: 1_000_000 } as any;
+    rc.ctx.getContextUsage = () => ({ tokens: 900_000, contextWindow: 1_000_000, percent: 90 } as any);
+
+    const result = resolveCompactionWindow(rc)!;
+    const plan = result.compactionPlan;
+
+    expect(plan.viable).toBeTrue();
+    expect(plan.projectedAfterTokens).toBeGreaterThan(500_000);
+    expect(plan.projectedYield).toBeGreaterThanOrEqual(0.1);
+    expect(plan.fixedContextTokens).toBeGreaterThan(500_000);
+    expect(plan.summaryBudgetTokens).toBe(10_000);
+    expect(plan.targetAfterTokens).toBe(plan.fixedContextTokens + plan.retentionTargetTokens + plan.summaryBudgetTokens);
+    expect(plan.projectedAfterTokens).toBeLessThanOrEqual(plan.targetAfterTokens);
+    expect(plan.hardBoundaryAdjusted).toBeFalse();
+  });
+
   it("retains context up to the mode target instead of stopping at the minimum tail", () => {
     const branch = Array.from({ length: 100 }, (_, index) => messageEntry(
       "m" + index,
@@ -252,9 +365,13 @@ describe("resolveCompactionWindow tool-result boundary", () => {
       },
     ));
     const rc = makePreparedRc(branch, 1);
+    const estimated = branch.reduce((sum, entry) => sum + rc.estimator.message(entry.message as any), 0);
+    rc.flags.force = false;
+    rc.ctx.model = { id: "target", provider: "test", contextWindow: estimated / 0.9 } as any;
+    rc.ctx.getContextUsage = () => ({ tokens: estimated, contextWindow: estimated / 0.9, percent: 90 } as any);
     const result = resolveCompactionWindow(rc)!;
-    expect(result.accTokens).toBeGreaterThan(6_000); // 4% adaptive minimum
-    expect(result.accTokens).toBeLessThan(30_000); // bounded near the 40% target
+    expect(result.accTokens).toBeGreaterThan(estimated * 0.25);
+    expect(result.accTokens).toBeLessThan(estimated * 0.5);
   });
 
   it("normalizes replaced and retained estimates to Pi's measured context", () => {
@@ -274,7 +391,7 @@ describe("resolveCompactionWindow tool-result boundary", () => {
   it("recounts the retained tail after anchor protection expands it", () => {
     const toolCallId = "anchor-call";
     const branch = [
-      messageEntry("old", null, { role: "user", content: [{ type: "text", text: "old " + "x".repeat(500) }] }),
+      messageEntry("old", null, { role: "user", content: [{ type: "text", text: "old " + "x".repeat(20_000) }] }),
       messageEntry("anchor-request", "old", { role: "assistant", content: [{ type: "toolCall", id: toolCallId, name: "context", arguments: { action: "anchor" } }] }),
       messageEntry("anchor", "anchor-request", { role: "toolResult", toolCallId, toolName: "context", details: { anchor: true }, content: [{ type: "text", text: "checkpoint" }] }),
       messageEntry("kept-1", "anchor", { role: "assistant", content: [{ type: "text", text: "kept " + "y".repeat(500) }] }),
@@ -282,12 +399,81 @@ describe("resolveCompactionWindow tool-result boundary", () => {
       messageEntry("a2", "u2", { role: "assistant", content: [{ type: "text", text: "second answer" }] }),
       messageEntry("u3", "a2", { role: "user", content: [{ type: "text", text: "tail" }] }),
     ];
-    const rc = makePreparedRc(branch, 1);
+    const rc = makePreparedRc(branch, 100);
+    const estimated = branch.reduce((sum, entry) => sum + rc.estimator.message(entry.message as any), 0);
+    rc.profileCfg.summaryBudgetTokens = 10;
+    rc.ctx.model = { id: "anchor", provider: "test", contextWindow: estimated * 4 } as any;
+    rc.ctx.getContextUsage = () => ({ tokens: estimated, contextWindow: estimated * 4, percent: 25 } as any);
 
     const result = resolveCompactionWindow(rc);
 
     expect(result?.firstKeptId).toBe("anchor-request");
     expect(result?.accTokens).toBe(branch.slice(1).reduce((sum, item) => sum + rc.estimator.message(item.message as any), 0));
+  });
+
+  it("prioritizes the 30K tail over two old user turns in a production-shaped session", () => {
+    const branch: SessionMessageEntry[] = [
+      messageEntry("old-user", null, { role: "user", content: [{ type: "text", text: "old constraint" }] }),
+    ];
+    for (let i = 0; i < 52; i++) {
+      const callId = "long-call-" + i;
+      branch.push(messageEntry("long-call-msg-" + i, branch.at(-1)!.id as string, {
+        role: "assistant",
+        content: [{ type: "toolCall", id: callId, name: "read", arguments: { path: "src/f" + i + ".ts" } }],
+      }));
+      branch.push(messageEntry("long-result-" + i, "long-call-msg-" + i, {
+        role: "toolResult",
+        toolCallId: callId,
+        toolName: "read",
+        content: [{ type: "text", text: "x".repeat(13_000) }],
+      }));
+    }
+    branch.push(messageEntry("second-user", branch.at(-1)!.id as string, {
+      role: "user", content: [{ type: "text", text: "older target that must be summarized" }],
+    }));
+    branch.push(messageEntry("tail", "second-user", {
+      role: "assistant", content: [{ type: "text", text: "z".repeat(145_000) }],
+    }));
+
+    const rc = makePreparedRc(branch, 30_000);
+    rc.mode = "thorough";
+    rc.profile = "light";
+    rc.profileCfg.summaryBudgetTokens = 10_000;
+    rc.ctx.model = { id: "gpt-5.6-sol", provider: "openai-codex", contextWindow: 272_000 } as any;
+    rc.ctx.getContextUsage = () => ({ tokens: 174_797, contextWindow: 272_000, percent: 64.3 } as any);
+
+    const result = resolveCompactionWindow(rc)!;
+
+    expect(result.compactTokens).toBeGreaterThan(130_000);
+    expect(result.accTokens).toBeGreaterThan(28_000);
+    expect(result.accTokens).toBeLessThan(35_000);
+    expect(result.compactionPlan.projectedYield).toBeGreaterThan(0.5);
+    expect(result.compactionPlan.fixedContextTokens).toBeGreaterThanOrEqual(0);
+    expect(result.compactionPlan.retentionTargetTokens).toBeGreaterThanOrEqual(result.accTokens);
+    expect(result.compactionPlan.summaryBudgetTokens).toBe(10_000);
+    expect(result.compactionPlan.targetAfterTokens).toBe(
+      result.compactionPlan.fixedContextTokens + result.compactionPlan.retentionTargetTokens + 10_000,
+    );
+    expect(result.compactionPlan.hardBoundaryAdjusted).toBeFalse();
+    expect(result.compactionPlan.relaxedSoftBoundaries).toContain("recent-user-turn");
+  });
+
+  it("stops a low-yield manual plan before LLM work", () => {
+    const notices: string[] = [];
+    const branch = [
+      messageEntry("old", null, { role: "user", content: [{ type: "text", text: "x".repeat(20_000) }] }),
+      messageEntry("recent", "old", { role: "user", content: [{ type: "text", text: "y".repeat(75_000) }] }),
+      messageEntry("tail", "recent", { role: "assistant", content: [{ type: "text", text: "z".repeat(75_000) }] }),
+    ];
+    const rc = makePreparedRc(branch, 30_000);
+    const estimated = branch.reduce((sum, entry) => sum + rc.estimator.message(entry.message as any), 0);
+    rc.profileCfg.summaryBudgetTokens = 6_000;
+    rc.ctx.model = { id: "manual", provider: "test", contextWindow: 100_000 } as any;
+    rc.ctx.getContextUsage = () => ({ tokens: estimated, contextWindow: 100_000, percent: estimated / 1_000 } as any);
+    rc.notify = message => { notices.push(message); };
+
+    expect(resolveCompactionWindow(rc)).toBeNull();
+    expect(notices.join(" ")).toContain("projected saving is below 10%");
   });
 
   it("recovers with EESV when reported usage exceeds the active model window", () => {

--- a/test/yield-gate.test.ts
+++ b/test/yield-gate.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { verifyCompactionYield, YieldGateError } from "../src/domain/yield-gate.ts";
+import type { CompactionWindowPlan } from "../src/app/run-context.ts";
+
+function plan(patch: Partial<CompactionWindowPlan> = {}): CompactionWindowPlan {
+  return {
+    keepFrom: 2, compactTokens: 700, retainedTokens: 200,
+    projectedAfterTokens: 300, projectedSavedTokens: 700, projectedYield: 0.7,
+    fixedContextTokens: 0, retentionTargetTokens: 200, summaryBudgetTokens: 100,
+    targetAfterTokens: 300, hardBoundaryAdjusted: false, viable: true, reason: "viable",
+    relaxedSoftBoundaries: [], ...patch,
+  };
+}
+
+describe("post-summary yield gate", () => {
+  it("fails closed when the verified summary misses the planned target", () => {
+    expect(() => verifyCompactionYield(1_000, 102, plan())).toThrow(YieldGateError);
+    try { verifyCompactionYield(1_000, 102, plan()); } catch (error) {
+      expect(error).toMatchObject({ name: "YieldGateError", reason: "target-miss", estimatedAfterTokens: 302 });
+      expect(JSON.stringify(error)).not.toContain("summary content");
+    }
+  });
+
+  it("fails closed below the 10% net-saving policy", () => {
+    const lowYield = plan({ fixedContextTokens: 700, retainedTokens: 100, targetAfterTokens: 1_000 });
+    expect(() => verifyCompactionYield(1_000, 101, lowYield)).toThrow(YieldGateError);
+    try { verifyCompactionYield(1_000, 101, lowYield); } catch (error) {
+      expect(error).toMatchObject({ reason: "insufficient-saving", estimatedSavedTokens: 99, estimatedYield: 0.099 });
+    }
+  });
+
+  it("passes the exact target and 10% saving boundary", () => {
+    const boundary = plan({ fixedContextTokens: 700, retainedTokens: 100, targetAfterTokens: 900 });
+    expect(verifyCompactionYield(1_000, 100, boundary)).toMatchObject({
+      estimatedAfterTokens: 900, estimatedSavedTokens: 100, estimatedYield: 0.1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- make meaningful context reduction a binding success contract instead of letting raw user-turn/checkpoint preferences override the token target
- replace the manual model→mode wizard with one explainable, keyboard-first preflight driven by the exact execution planner
- enforce the same target and >=10% net-yield policy again after the verified final summary is measured, before any staging/apply
- show semantic Extract/Synthesize/Verify/Apply progress and report success only after a run-id-correlated native `session_compact`

## Production regression fixed

The captured v8.0.3 manual run started at 174,797 tokens. Its correct 144,588 compact / 30,209 retained plan was moved from message 202 back to message 13 by the two-newest-user-turn preference, leaving only 7,445 tokens eligible. After the replacement summary it saved 5,764 tokens (3.3%).

v8.0.4 treats recent user turns, pi-toolkit checkpoints and topical grouping as soft: they stay raw only when they fit the mode budget. The same historical replay now projects:

- Thorough: ~40,209 after / ~134,588 saved (77%)
- Balanced (recommended): ~26,577 after / ~148,220 saved (85%)

A single long turn can be summarized through its older prefix. Tool exchanges remain indivisible: the planner either retains the complete pair within budget or summarizes the complete pair.

## UX

The manual preflight shows before→estimated-after window pressure, projected savings, raw tail, summary budget, soft boundaries being summarized, and hard safeguards. `D` progressively reveals estimator/target/route details; `M` changes the summary route and replans; arrows change fidelity; Enter accepts only a viable plan; Esc cancels.

Recommendations are content-free and explainable from pressure, tool density and recent damage feedback. Critical lines use ANSI-aware wrapping on narrow terminals. Provider usage remains estimated (`~`/`≤`) until a later turn reports it.

## Safety invariants

- complete `toolCall`/`toolResult` pairs remain a hard boundary
- zero-gap verification and continuity re-verification remain mandatory
- post-summary target/yield failure throws before `StatedRc`, pending staging or native apply
- unresolved/cancelled/unconfirmed runs leave the conversation unchanged
- persistence, graph updates and success telemetry still require matching `runId` + `session_compact`
- `Applied` is emitted only after that correlated commit

## Validation

- full suite: **740/740** tests across 68 files
- adversarial release gate: **273/273** tests across 26 suites
- source/script typechecks and multi-entry build: passed
- packed artifact/frozen install/CLI/Node SQLite audit: passed
- coverage: **85.10% functions / 86.83% lines**
- `bun audit`: no vulnerabilities
- production-shaped planner replay: passed

## Telemetry disclosure

The advisory telemetry gate remains **HOLD (Data Confidence 21%, 0 canary runs)**. This PR does **not** claim PROMOTE; it is a corrective patch for a captured production UX/yield failure. No provider-routing change is included because current route-quality evidence remains insufficient.
