### PR TITLE
fix: bound verification error feedback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -216,6 +216,9 @@ staging/apply. `session_before_compact` only stages a passing candidate; after
 the host emits the matching `session_compact`, `app/steps/persist.ts` commits
 reusable state and success telemetry. Aborted/unconfirmed candidates write
 neither, and the UI reports `Applied` only after that correlated commit.
+`ui/error-format.ts` converts verification/yield failures to one bounded,
+content-free diagnostic and collapses unknown multiline errors; full stacks are
+suppressed by default and emitted only under explicit `DEBUG=smart-compact`.
 
 | Concern | Where | Notes |
 | --- | --- | --- |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 No changes yet.
 
+## [8.0.5] - 2026-08-07
+
+### Fixed
+
+- Verify/continuity rejection no longer emits evidence-bearing findings and then repeats the exception with a full JavaScript stack in the manual UI. Verification and yield failures now render one bounded, content-free line with score/count/kinds or target estimates; full stacks are emitted only when `DEBUG=smart-compact` is explicitly enabled.
+- Unknown provider/native-apply errors collapse multiline text and cap the visible message, preventing the `EESV Verify: Checking` phase from being followed by pages of diagnostic output. Conversation-unchanged guidance remains explicit.
+
 ## [8.0.4] - 2026-08-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ before staging, and reports final success only after Pi confirms the matching
 `session_compact` run ID. A single long user turn may be split at a safe message
 boundary: its older prefix is verified into the summary while the budgeted
 working tail stays raw. Tool exchanges are summarized or retained as complete
-call/result pairs, never split.
+call/result pairs, never split. If Verify, yield, provider, or native apply
+fails, the UI shows one bounded actionable line without evidence text or a
+JavaScript stack. Stack diagnostics are opt-in with `DEBUG=smart-compact`.
 
 ### Focus and budgets
 

--- a/docs/MIGRATING_TO_V8.md
+++ b/docs/MIGRATING_TO_V8.md
@@ -1,6 +1,6 @@
 # Migrating from v7 to v8
 
-This guide applies to the stable `8.0.4` release.
+This guide applies to the stable `8.0.5` release.
 
 ## Compatibility
 
@@ -32,8 +32,8 @@ rewritten during migration. v8.0.1+ filters legacy RC state that misclassified
 source-search output persisted as unresolved work; the next confirmed save persists
 the sanitized state. v8.0.3 keeps the same graph file and transparently opens it
 with `node:sqlite` under Pi or `bun:sqlite` in Bun tooling. v8.0.4 changes only
-compaction planning, UX, and privacy-safe operational metrics; it requires no
-state or database migration.
+compaction planning, UX, and privacy-safe operational metrics; v8.0.5 bounds
+user-facing failure diagnostics. Neither requires a state or database migration.
 
 Facts remain conservative: absence from a new window is not deletion. A fact is
 removed only by an explicit resolved/superseded override.
@@ -87,7 +87,7 @@ See the README configuration table for budgets and monitoring options.
 ## Recommended rollout
 
 1. Back up `~/.pi/agent/settings.json` and the Smart Compact cache directory.
-2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.4`.
+2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.5`.
 3. Leave all model routes null initially.
 4. Keep `telemetryChannel: "stable"` unless intentionally running a separate
    canary cohort.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "engines": {

--- a/src/app/steps/persist.ts
+++ b/src/app/steps/persist.ts
@@ -33,6 +33,7 @@ import type { StatedRc } from "../run-context.ts";
 import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { asBranchMessage } from "../../infra/ai-messages.ts";
 import { clearCompactProgress } from "../../ui/overlays.ts";
+import { formatCompactErrorForUi } from "../../ui/error-format.ts";
 
 import * as log from "../../utils/logger.ts";
 
@@ -157,7 +158,8 @@ export function applyCompaction(rc: StatedRc): void {
           methodForMetrics: rc.method, profile: rc.profile, mode: rc.mode,
         });
       }
-      rc.ctx.ui.notify("Failed: " + e.message, "error");
+      log.debugError("Native compaction apply failed", e);
+      rc.ctx.ui.notify(formatCompactErrorForUi(e), "error");
     },
   });
 }

--- a/src/app/steps/state.ts
+++ b/src/app/steps/state.ts
@@ -121,10 +121,7 @@ export function buildState(rc: VerifiedRc): StatedRc {
     remainingGaps: postVerification.gaps,
   };
   const failure = verificationFailureMessage(postVerification);
-  if (failure) {
-    rc.notify(failure + " after continuity injection — current conversation left unchanged", "error");
-    throw new VerificationGateError(postVerification, postInitialScore);
-  }
+  if (failure) throw new VerificationGateError(postVerification, postInitialScore);
 
   const detModified = extraction.modifiedFiles.map(f => f.path);
   const detRead = extraction.readFiles;

--- a/src/app/steps/verify.ts
+++ b/src/app/steps/verify.ts
@@ -86,10 +86,7 @@ export async function verifyAndPatch(rc: SynthesizedRc): Promise<VerifiedRc> {
   }
 
   const failure = verificationFailureMessage(verification);
-  if (failure) {
-    rc.notify(failure + " — current conversation left unchanged", "error");
-    throw new VerificationGateError(verification, initialScore);
-  }
+  if (failure) throw new VerificationGateError(verification, initialScore);
 
   const out = rc as SynthesizedRc & {
     _verified: true;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "8.0.4";
+export const VERSION = "8.0.5";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.10;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { appendMetricsSnapshot, readMetricsLog } from "./utils/cache.ts";
 import { buildLocalDashboardInsights, buildMetricsReport, writeMetricsDashboard } from "./ui/metrics-report.ts";
 import { runSmartCompact } from "./app/run-smart-compact.ts";
 import { clearCompactProgress, notifyAppliedCompaction, showCompactUI, showMetricsDashboardUI, showRestorePicker, showBackupViewer, showRestoreAction, showOpenLoopsUI } from "./ui/overlays.ts";
+import { formatCompactErrorForUi } from "./ui/error-format.ts";
 import { resolveSessionId, isUnresolvedSessionId } from "./infra/session-identity.ts";
 import { createPendingSlot, type PendingSlot, type ConsumeResult } from "./app/pending-slot.ts";
 import { createSessionRunLock } from "./app/session-run-lock.ts";
@@ -429,8 +430,8 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
           timeoutMs: maxLatencyMs, force: true,
         });
       } catch (error) {
-        const msg = error instanceof Error ? error.message + "\n" + error.stack : String(error);
-        ctx.ui.notify("smart-compact error: " + msg, "error");
+        log.debugError("Manual smart compact failed", error);
+        ctx.ui.notify(formatCompactErrorForUi(error), "error");
       }
     },
   });
@@ -683,8 +684,8 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         }
         return { content: [{ type: "text", text: "Compaction finished (" + resolvedMode + ") but no summary was generated." }], details: undefined };
       } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        return { content: [{ type: "text", text: "Compaction error: " + msg }], details: undefined };
+        log.debugError("Smart compact tool failed", error);
+        return { content: [{ type: "text", text: formatCompactErrorForUi(error) }], details: undefined };
       }
     },
   });

--- a/src/ui/error-format.ts
+++ b/src/ui/error-format.ts
@@ -1,0 +1,26 @@
+import { VerificationGateError } from "../phases/verify.ts";
+import { YieldGateError } from "../domain/yield-gate.ts";
+
+const MAX_ERROR_TEXT = 240;
+const DEBUG_HINT = "Conversation unchanged. Set DEBUG=smart-compact for stack diagnostics.";
+
+function compactText(error: unknown): string {
+  const text = error instanceof Error ? error.message : String(error);
+  return text.replace(/\s+/g, " ").trim().slice(0, MAX_ERROR_TEXT) || "Unknown error";
+}
+
+/** One bounded, content-free UI line; full diagnostics belong in local logs. */
+export function formatCompactErrorForUi(error: unknown): string {
+  if (error instanceof VerificationGateError) {
+    const kinds = error.gapKinds.slice(0, 4).join(", ") || "unknown";
+    return "Verification stopped apply: " + error.score + "/100, " + error.gapCount +
+      " unresolved gap(s) [" + kinds + "]. " + DEBUG_HINT;
+  }
+  if (error instanceof YieldGateError) {
+    const reason = error.reason === "target-miss" ? "target missed" : "saving below 10%";
+    return "Yield check stopped apply: estimated " + error.estimatedAfterTokens.toLocaleString() +
+      "t after vs " + error.targetAfterTokens.toLocaleString() + "t target (" + reason +
+      "). " + DEBUG_HINT;
+  }
+  return "Smart compact failed: " + compactText(error) + ". " + DEBUG_HINT;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -24,3 +24,7 @@ export function info(msg: string, ...args: unknown[]): void {
 export function debug(msg: string, ...args: unknown[]): void {
   if (DEBUG) console.error(LOG_PREFIX + " [debug] " + msg, ...args);
 }
+
+export function debugError(msg: string, err?: unknown): void {
+  if (DEBUG) error(msg, err);
+}

--- a/test/error-format.test.ts
+++ b/test/error-format.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { VerificationGateError } from "../src/phases/verify.ts";
+import { YieldGateError } from "../src/domain/yield-gate.ts";
+import { formatCompactErrorForUi } from "../src/ui/error-format.ts";
+
+describe("bounded Smart Compact error UX", () => {
+  it("renders verification diagnostics without evidence text or stack lines", () => {
+    const error = new VerificationGateError({
+      ok: false,
+      score: 42,
+      gaps: [
+        { kind: "missing-error", message: "SECRET_EVIDENCE\n" + "x".repeat(2_000) },
+        { kind: "missing-file", path: "private/path.ts" },
+      ],
+    }, 18);
+
+    const text = formatCompactErrorForUi(error);
+
+    expect(text).toContain("42/100, 2 unresolved gap(s)");
+    expect(text).toContain("missing-error, missing-file");
+    expect(text).not.toContain("SECRET_EVIDENCE");
+    expect(text).not.toContain("private/path.ts");
+    expect(text).not.toContain("\n");
+  });
+
+  it("explains yield rejection in one content-free line", () => {
+    const error = new YieldGateError("target-miss", {
+      plannedAfterTokens: 40_000,
+      plannedSavedTokens: 60_000,
+      plannedYield: 0.6,
+      summaryTokens: 12_000,
+      estimatedAfterTokens: 42_000,
+      estimatedSavedTokens: 58_000,
+      estimatedYield: 0.58,
+      retainedTailTokens: 30_000,
+      summaryBudgetTokens: 10_000,
+      targetAfterTokens: 40_000,
+      relaxedSoftBoundaries: [],
+      hardBoundaryAdjusted: false,
+    });
+
+    expect(formatCompactErrorForUi(error)).toBe(
+      "Yield check stopped apply: estimated 42,000t after vs 40,000t target (target missed). " +
+      "Conversation unchanged. Set DEBUG=smart-compact for stack diagnostics.",
+    );
+  });
+
+  it("collapses and caps unknown multiline errors while retaining opt-in debug guidance", () => {
+    const text = formatCompactErrorForUi(new Error("first line\n" + "trace ".repeat(200)));
+
+    expect(text).not.toContain("\n");
+    expect(text.length).toBeLessThan(340);
+    expect(text).toEndWith("Conversation unchanged. Set DEBUG=smart-compact for stack diagnostics.");
+  });
+});

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -383,7 +383,8 @@ describe("verifyAndPatch", () => {
     expect(result.finalSummary).toContain("Continue work in README.md");
   });
 
-  it("fails closed when contradictory evidence cannot pass verification", async () => {
+  it("fails closed without emitting evidence text from the verification step", async () => {
+    const uiErrors: string[] = [];
     const extraction = makeExtraction({
       constraints: [{ index: 1, text: "Must publish stable now", category: "requirement", confidence: 1 }],
     });
@@ -401,9 +402,10 @@ describe("verifyAndPatch", () => {
       },
       mode: "aggressive",
       flags: { autoTriggered: true },
-      notify: () => {},
+      notify: (message: string, type: string) => { if (type === "error") uiErrors.push(message); },
       vlog: () => {},
     } as any)).rejects.toThrow("Verification gate rejected summary");
+    expect(uiErrors).toEqual([]);
   });
 
   it("repairs a patchable high-score gap instead of skipping it", async () => {


### PR DESCRIPTION
## Summary

- replace the remaining multiline Verify/Checking failure path with one bounded, content-free user-facing diagnostic
- suppress full stacks by default and emit them only under explicit `DEBUG=smart-compact`
- centralize the same formatter for manual command, agent tool and native apply errors
- preserve all v8.0.4 target-first planner, preflight, yield-gate and correlated-apply behavior

## Root cause

Phase 4 could emit its own evidence-bearing rejection, throw, and then the outer manual command handler displayed `error.message + error.stack`. The same failure therefore appeared twice and could fill the TUI with unrelated evidence and stack frames immediately after `EESV Verify: Checking`.

v8.0.3 fixed the false-positive sources themselves (multiline evidence injection, generic/numeric contradiction anchors, one-pass repair, unsafe fallback rejection). The captured v8.0.3 production run repaired 18 findings to 100/100 with 0 gaps. This patch closes the remaining presentation path: even a genuine unrecoverable failure cannot dump evidence or a stack into the TUI.

## New failure UX

- verification: score, gap count and content-free gap kinds
- yield: estimated-after, target and plain-language reason
- unknown provider/native errors: whitespace-collapsed and capped to 240 characters
- every line states that the conversation is unchanged and points to local logs

## Safety

- verification/yield gates and their typed errors are unchanged
- failure still occurs before staging/apply
- full stack diagnostics remain available through explicit `DEBUG=smart-compact`
- no evidence text, file path, prompt, summary or stack is rendered by the compact error formatter

## Validation

- full suite: **743/743** tests across 69 files
- adversarial release gate: **273/273** tests across 26 suites
- source/script typechecks and build: passed
- coverage: **85.41% functions / 87.08% lines**
- packed artifact audit: **143 files**, frozen install and CLI/Node smoke passed
- `bun audit`: no vulnerabilities

## Release note

v8.0.4 has a signed GitHub release but was not published to npm. npm should move directly from 8.0.3 to 8.0.5 so the target-first UX and bounded-error follow-up ship together.
