### PR TITLE
feat: streamline compact decision UX

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,13 +107,15 @@ assertions: the type system proves `buildState` has run.
 `runSmartCompact()`. Before any expensive work, the system checks context size
 against the threshold in `src/constants.ts`. Auto / tool runs are skipped while
 context is small; manual `/smart-compact` uses an absolute adaptive safety tail
-rather than a percentage of large model windows. Its single preflight is built
-from the same config snapshot, calibrated estimator, adaptive profile, active
-branch, and pure window planner as execution. A plan must meet the tail target
-and at least 10% projected net savings before any model call. A pending summary
-for the same session is reused instead of invoking the pipeline again. The
-selected `CompactionMode` resolves to a concrete policy before the first model
-call; `auto` uses context pressure and deterministic extraction risk.
+rather than a percentage of large model windows. Its decision-card preflight
+is built from the same config snapshot, calibrated estimator, adaptive profile,
+active branch, and pure window planner as execution. It compares exactly Fast,
+Balanced, and Thorough; `M` changes the summary route and replans all three,
+while `D` reveals technical estimator/boundary details. A plan must meet the
+tail target and at least 10% projected net savings before any model call. A
+pending summary for the same session is reused instead of invoking the pipeline
+again. `auto` is not a fourth policy: it selects one of the three from context
+pressure and deterministic extraction risk.
 
 Model routes are stage-specific but never inferred from mode. With no explicit
 configuration, Explore, Synthesize, and Verify all use the selected Pi model.
@@ -173,7 +175,7 @@ prefix uses short-lived prompt caching.
 
 Primary: [`src/phases/synthesize.ts`](./src/phases/synthesize.ts). Three paths:
 
-- **Deterministic zero-call** — high-confidence Fast/Aggressive extractions.
+- **Deterministic zero-call** — high-confidence Fast extractions.
 - **Single-pass** — when the compacted conversation fits under the configured threshold.
 - **Hierarchical** — for larger sessions: merge available boundaries → split oversized semantic chunks → batch by token budget → summarize batches → assemble.
 
@@ -195,7 +197,9 @@ open-loop coverage.
 idempotent) → (2) one LLM patch only in `thorough` mode if still insufficient
 → (3) replace lower-scoring output with the deterministic quality floor → (4)
 reject unless final verification has no gaps and meets the verified threshold.
-Final verification runs again after continuity injection.
+Final verification runs again after continuity injection. Unresolved-error
+source snippets and fallback-rendered evidence share `summaryEvidenceLine()`, so
+Markdown prefixes and multiline wrapping cannot create false missing-error gaps.
 
 ## EESV hardening and control surfaces
 
@@ -219,6 +223,12 @@ neither, and the UI reports `Applied` only after that correlated commit.
 `ui/error-format.ts` converts verification/yield failures to one bounded,
 content-free diagnostic and collapses unknown multiline errors; full stacks are
 suppressed by default and emitted only under explicit `DEBUG=smart-compact`.
+Manual execution uses a two-line widget: a colored EESV phase chain plus a
+phase-specific action brief. Before Apply it explicitly says the conversation
+is unchanged. Routine info toasts are hidden unless `verbose`; handled provider,
+watchdog, Explore, batch, and assembly failures switch to deterministic fallback
+without printing raw messages. Auto-trigger rejection logs are also debug-only,
+leaving one content-free safe-fallback notice in the UI.
 
 | Concern | Where | Notes |
 | --- | --- | --- |
@@ -392,7 +402,7 @@ The code is organized into six layers, each with a single responsibility.
 | --- | --- |
 | `app/run-smart-compact.ts` | top-level pipeline orchestrator |
 | `app/run-context.ts` | typed stage chain (`RcBase → … → StatedRc`) |
-| `app/mode-policy.ts` | Auto planner and finite Fast/Balanced/Aggressive/Thorough policies |
+| `app/mode-policy.ts` | Auto selector and finite Fast/Balanced/Thorough policies; legacy Aggressive maps to Fast |
 | `app/pending-slot.ts` | encapsulated pending-compaction state cell |
 | `app/explore-wrap.ts` | thin re-export shim isolating the explore import for headless tests |
 | `app/steps/prepare.ts` | resolve config, auth, provider caps |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 No changes yet.
 
+## [8.0.6] - 2026-08-07
+
+### Changed
+
+- Replaced the dense flat `/smart-compact` preflight with a bordered decision card: context pressure, prominent `[M] Change` summary-model route, and side-by-side after-size/saving estimates for exactly Fast, Balanced, and Thorough. The selected plan keeps only outcome, retention, and hard safety guarantees visible; `D` reveals estimator, target, boundary, and route internals.
+- Consolidated execution into three monotonic policies: Fast is the quickest/most compact 10K-tail policy, Balanced is the 20K-tail default, and Thorough is the 30K-tail high-fidelity policy with Explore and optional LLM repair. Legacy `aggressive` inputs map to Fast with a deprecation warning rather than appearing as a fourth mode.
+- Manual runs now show a two-line semantic live brief: the colored Extract → Explore → Synthesize → Verify → Apply chain plus meaningful actions such as topic mapping, batch compression, continuity assembly, deterministic repair, and correlated Apply. Before Apply it explicitly states that the conversation is unchanged.
+- Replaced routine phase toasts and per-batch provider/watchdog warnings with the live brief and content-free aggregated fallback status. Expected single-pass, Explore, batch, and assembly fallbacks no longer print raw provider messages or request IDs; auto-trigger verification failures emit one concise safe-fallback notice instead of evidence-bearing stderr lines. Full diagnostics remain opt-in through `DEBUG=smart-compact`.
+- Fixed deterministic verification of Markdown-prefixed multiline errors (`> npm…`, list/heading prefixes): verification now canonicalizes the source snippet with the same safe one-line transform used by fallback rendering. The captured 259,782-token session replay now plans ~26,267 tokens after, repairs the remaining fabricated-file finding, and reaches 100/100 with 0 gaps even when every synthesis batch uses deterministic fallback.
+
 ## [8.0.5] - 2026-08-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -128,14 +128,14 @@ Set `contextGraphEnabled` to `false` to disable indexing and both tools.
 
 ### Manual preflight
 
-The interactive command uses the configured summary route and the exact
-execution planner before spending LLM tokens. The primary screen shows the
-recommended fidelity preset, why it fits the current pressure/session shape,
-estimated context before and after, projected savings, live-tail and summary
-budgets, soft boundaries that will be summarized, and the hard tool-pair plus
-zero-gap-verification guarantees.
+The interactive command uses the configured summary route and exact execution
+planner before spending LLM tokens. Its compact decision card compares the
+three modes by estimated after-size and saving, highlights the recommendation,
+and keeps only the selected plan plus hard tool-pair/zero-gap guarantees in the
+primary view. Technical estimator, target, route, and boundary data stays under
+`D` instead of crowding the decision.
 
-- `↑` / `↓` changes `Thorough`, `Balanced`, or `Fast` and recalculates the plan.
+- `↑` / `↓` changes `Fast`, `Balanced`, or `Thorough` and recalculates the plan.
 - `Enter` runs only a viable plan; `Esc` cancels without mutation.
 - `D` toggles calibrated estimator, target, boundary, and route details.
 - `M` opens Advanced model selection and replans with that route's calibration.
@@ -149,12 +149,18 @@ working tail stays raw. Tool exchanges are summarized or retained as complete
 call/result pairs, never split. If Verify, yield, provider, or native apply
 fails, the UI shows one bounded actionable line without evidence text or a
 JavaScript stack. Stack diagnostics are opt-in with `DEBUG=smart-compact`.
+During execution a two-line live brief shows the EESV phase chain and the
+meaningful current action; it states that the conversation remains unchanged
+until verified Apply. Routine phase toasts and raw per-batch watchdog/provider
+errors are suppressed by default: handled fallbacks appear as one content-free
+brief. `verbose` restores routine phase notices; full stack diagnostics require
+`DEBUG=smart-compact`.
 
 ### Focus and budgets
 
 ```bash
-/smart-compact auto --focus=authentication
-/smart-compact aggressive --max-input-tokens=120000
+/smart-compact balanced --focus=authentication
+/smart-compact fast --max-input-tokens=120000
 /smart-compact fast --focus=src/auth.ts --max-calls=3
 /smart-compact thorough
 ```
@@ -173,13 +179,17 @@ The tool exposes equivalent `focus`, `max_calls`, `max_input_tokens`, and
 
 | Mode | Calls | Prompt cap | Output cap | Behavior |
 | --- | ---: | ---: | ---: | --- |
-| `auto` | adaptive | adaptive | adaptive | Default; selects from context pressure and deterministic session risk |
-| `balanced` | 6 | 200K | 40K | Token/continuity balance; deterministic boundaries and repair |
-| `aggressive` | 4 | 120K | 25K | Maximum context recovery with a 3K summary and 10K live tail |
-| `fast` | 3 | 100K | 20K | Favors larger single-pass windows and minimum waiting |
-| `thorough` (`slow` alias) | 8 | 300K | 80K | Maximum fidelity; enables Explore and one optional LLM repair |
+| `fast` | 3 | 100K | 20K | Quickest recovery; 3K summary, 10K recent tail, 30% context target |
+| `balanced` | 6 | 200K | 40K | Default quality/speed trade-off; 6K summary, 20K recent tail, 40% target |
+| `thorough` | 8 | 300K | 80K | Deepest analysis; 10K summary, 30K recent tail, 50% target, Explore and optional LLM repair |
 
-Fast and aggressive modes use a zero-call deterministic summary when extraction confidence is high; otherwise they keep the bounded LLM path. Auto planning also raises fidelity when scoped continuity or prior damage indicates risk. The mode token target is binding: recent user turns, pi-toolkit checkpoints, and topical grouping remain raw only when they fit the planned tail; otherwise the verified summary carries them forward.
+These are the only three execution modes. Automatic runs choose among them
+from context pressure and deterministic session risk; `auto` is a selector,
+not a fourth execution policy. Fast can use a zero-call deterministic summary
+when extraction confidence is high; otherwise it keeps the bounded LLM path.
+The mode token target is binding: recent user turns, pi-toolkit checkpoints,
+and topical grouping remain raw only when they fit the planned tail; otherwise
+the verified summary carries them forward.
 
 Output caps stop subsequent calls after observed usage reaches the threshold.
 The ChatGPT Codex subscription endpoint rejects `max_output_tokens`,
@@ -189,8 +199,10 @@ back deterministically on abort. Custom Codex endpoints receive
 `max_output_tokens` through Pi AI's payload hook.
 
 Legacy compression profiles remain as advanced/backwards-compatible policy:
-`light` maps to `thorough`; `balanced` and `aggressive` map to their same-named
-modes. The selected model never changes automatically.
+`light` maps to `thorough`, `balanced` maps to `balanced`, and `aggressive` maps
+to `fast` with a deprecation warning. The selected model never changes
+automatically; `M` changes the summary route inside preflight and recalculates
+all three plans.
 
 ### Stage-aware provider routing
 
@@ -388,7 +400,7 @@ the run fails closed before staging or apply.
 
 | Key | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `mode` | `auto \| balanced \| aggressive \| fast \| thorough` | `auto` | User-facing execution preset |
+| `mode` | `auto \| fast \| balanced \| thorough` | `auto` | Automatic selector or one of the three execution modes |
 | `profile` | `light \| balanced \| aggressive` | `balanced` | Legacy/advanced compression profile; used when mode is absent |
 | `summaryModel` | `string \| null` | `null` | Uses the active session model when null |
 | `segmentationModel` | `string \| null` | `null` | Optional explicit model for Explore |
@@ -410,7 +422,7 @@ the run fails closed before staging or apply.
 | `codexMaxCallMs` | integer `0` or `5000–300000` | `0` | ChatGPT Codex per-call watchdog; `0` derives 15–90s from requested output tokens |
 | `maxLatencyMs` | `0` or `5000–600000` | `0` | `0` means unlimited |
 | `focusWeighting` | `boolean` | `true` | Weight focused topics/paths higher |
-| `zeroCallEnabled` | `boolean` | `true` | Use deterministic synthesis for high-confidence fast/aggressive runs |
+| `zeroCallEnabled` | `boolean` | `true` | Use deterministic synthesis for high-confidence Fast runs |
 | `contextGraphEnabled` | `boolean` | `true` | Index verified state and enable project-scoped recall/save tools |
 | `telemetryChannel` | `stable \| canary` | `stable` | Tag local schema-v2 metrics for external canary comparison |
 | `onlineDamageMonitor` | `boolean` | `true` | Observe post-compaction regression signals |

--- a/docs/MIGRATING_TO_V8.md
+++ b/docs/MIGRATING_TO_V8.md
@@ -1,6 +1,6 @@
 # Migrating from v7 to v8
 
-This guide applies to the stable `8.0.5` release.
+This guide applies to the stable `8.0.6` release.
 
 ## Compatibility
 
@@ -33,7 +33,8 @@ source-search output persisted as unresolved work; the next confirmed save persi
 the sanitized state. v8.0.3 keeps the same graph file and transparently opens it
 with `node:sqlite` under Pi or `bun:sqlite` in Bun tooling. v8.0.4 changes only
 compaction planning, UX, and privacy-safe operational metrics; v8.0.5 bounds
-user-facing failure diagnostics. Neither requires a state or database migration.
+user-facing failure diagnostics; v8.0.6 streamlines the three-mode decision card
+and live progress brief. None requires a state or database migration.
 
 Facts remain conservative: absence from a new window is not deletion. A fact is
 removed only by an explicit resolved/superseded override.
@@ -75,7 +76,7 @@ All defaults preserve the selected model and require no migration edits.
 | Key | Default | Purpose |
 |---|---|---|
 | `mode` | `auto` | Pressure/risk-aware execution policy |
-| `zeroCallEnabled` | `true` | Deterministic Fast/Aggressive synthesis when confidence is high |
+| `zeroCallEnabled` | `true` | Deterministic Fast synthesis when confidence is high |
 | `contextGraphEnabled` | `true` | Local scoped graph and memory tools |
 | `telemetryChannel` | `stable` | Stable/canary metric tag |
 | `segmentationModel` | `null` | Explicit Explore route; selected model when null |
@@ -87,7 +88,7 @@ See the README configuration table for budgets and monitoring options.
 ## Recommended rollout
 
 1. Back up `~/.pi/agent/settings.json` and the Smart Compact cache directory.
-2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.5`.
+2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.6`.
 3. Leave all model routes null initially.
 4. Keep `telemetryChannel: "stable"` unless intentionally running a separate
    canary cohort.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "engines": {

--- a/src/app/mode-policy.ts
+++ b/src/app/mode-policy.ts
@@ -17,19 +17,14 @@ export interface ModePolicy {
 
 export const MODE_POLICIES: Readonly<Record<EffectiveCompactionMode, ModePolicy>> = {
   fast: {
-    profile: "balanced", maxLlmCalls: 3, maxInputTokens: 100_000, maxOutputTokens: 20_000,
+    profile: "aggressive", maxLlmCalls: 3, maxInputTokens: 100_000, maxOutputTokens: 20_000,
     explore: false, allowLlmPatch: false, singlePassMultiplier: 2,
-    batchOutput: { min: 800, perChunk: 160, max: 2_400 }, softLatencyMs: 30_000, targetContextPercent: 45,
+    batchOutput: { min: 800, perChunk: 160, max: 2_400 }, softLatencyMs: 30_000, targetContextPercent: 30,
   },
   balanced: {
     profile: "balanced", maxLlmCalls: 6, maxInputTokens: 200_000, maxOutputTokens: 40_000,
     explore: false, allowLlmPatch: false, singlePassMultiplier: 1.5,
     batchOutput: { min: 1_000, perChunk: 250, max: 4_096 }, softLatencyMs: 60_000, targetContextPercent: 40,
-  },
-  aggressive: {
-    profile: "aggressive", maxLlmCalls: 4, maxInputTokens: 120_000, maxOutputTokens: 25_000,
-    explore: false, allowLlmPatch: false, singlePassMultiplier: 2,
-    batchOutput: { min: 800, perChunk: 180, max: 2_400 }, softLatencyMs: 45_000, targetContextPercent: 30,
   },
   thorough: {
     profile: "light", maxLlmCalls: 8, maxInputTokens: 300_000, maxOutputTokens: 80_000,
@@ -39,7 +34,7 @@ export const MODE_POLICIES: Readonly<Record<EffectiveCompactionMode, ModePolicy>
 };
 
 export function modeFromLegacyProfile(profile: CompressionProfile): EffectiveCompactionMode {
-  return profile === "light" ? "thorough" : profile;
+  return profile === "light" ? "thorough" : profile === "aggressive" ? "fast" : "balanced";
 }
 
 /** Cheap preflight choice used before deterministic extraction is available. */
@@ -49,8 +44,8 @@ export function resolveMode(
   extraction?: StructuredExtraction,
   additionalRisk = 0,
 ): EffectiveCompactionMode {
-  if (requested !== "auto") return requested;
-  if (contextPercent >= 85) return "aggressive";
+  if (requested !== "auto") return requested === "aggressive" ? "fast" : requested;
+  if (contextPercent >= 85) return "fast";
   if (!extraction) return contextPercent < 70 ? "fast" : "balanced";
 
   const unresolved = extraction.errors.filter(error => !error.resolved).length;

--- a/src/app/run-smart-compact.ts
+++ b/src/app/run-smart-compact.ts
@@ -119,6 +119,7 @@ function makeBase(opts: SmartCompactOptions): RcBase {
   const ctrl = new AbortController();
   const notify: Notifier = (msg, type = "info") => {
     if (opts.autoTriggered && (type === "info" || type === "success")) return;
+    if (type === "info" && !opts.verbose) return; // live brief replaces routine toast spam
     opts.ctx.ui.notify(msg, type === "success" ? "info" : type);
   };
   const vlog = (msg: string) => { if (opts.verbose) log.info(msg); };
@@ -189,6 +190,7 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
   // null and the failure path uses `base` only.
   let finalRc: StatedRc | null = null;
   let keepApplyProgress = false;
+  let runFailed = false;
   let failureSummaryFields: {
     sessionId?: string; tier?: string; contextPercent?: number; toolPercent?: number;
     totalTokens?: number; methodForMetrics?: string; profile: string; mode?: CompactionMode;
@@ -215,7 +217,7 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
     if (!prepared) return;
 
     base.notify(
-      "EESV Compact (" + base.modelLabel + ", " + base.profile + ") — " +
+      "EESV Compact (" + base.modelLabel + ", " + base.mode + ") — " +
         ((base.ctx.getContextUsage()?.tokens ?? 0)).toLocaleString() + "t",
       "info",
     );
@@ -231,7 +233,11 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
     markPhase(windowed, "prepare");
 
     if (!windowed.flags.autoTriggered) {
-      showProgressOverlay(windowed.ctx, { phase: 1, phaseName: "Extract", detail: "Preparing...", model: windowed.modelLabel, profile: windowed.profile });
+      showProgressOverlay(windowed.ctx, {
+        phase: 1, phaseName: "Extract",
+        detail: "Indexing goals, files, decisions, errors, and open loops",
+        model: windowed.modelLabel, profile: windowed.profile,
+      });
     }
 
     const recovered = recoverSessionLog(windowed);
@@ -265,8 +271,8 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
 
     if (stated.flags.dryRun) {
       recordSuccessMetrics(stated, "dry-run");
-      stated.notify(
-        "DRY RUN (" + stated.method + ", " + stated.profile + ") — " +
+      stated.ctx.ui.notify(
+        "DRY RUN (" + stated.method + ", " + stated.mode + ") — " +
           stated.toCompact.length + " msgs, " + stated.llmCalls + " calls",
         "info",
       );
@@ -292,13 +298,13 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
           ? await showResultScreen(stated.ctx, stated.details, stated.extraction, stated.services, { approval: true })
           : "cancel";
       } catch (err) {
-        log.warn("Approval UI error", err);
+        log.debugError("Approval UI stopped", err);
         stated.notify("Approval UI failed — compaction cancelled", "warning");
       }
       if (decision !== "apply") {
         stated.pendingRef.clear(stated.sessionId);
         recordSuccessMetrics(stated, "cancelled");
-        stated.notify("Compaction cancelled — current conversation unchanged", "info");
+        stated.ctx.ui.notify("Compaction cancelled — current conversation unchanged", "info");
         return;
       }
     }
@@ -310,7 +316,10 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
     // Pi applied this exact runId. This prevents failed native compactions
     // from being reported or persisted as successful.
     if (willApply) {
-      showProgressOverlay(stated.ctx, { phase: 5, phaseName: "Apply", detail: "Awaiting Pi confirmation..." });
+      showProgressOverlay(stated.ctx, {
+        phase: 5, phaseName: "Apply",
+        detail: "Verified " + stated.verificationScore + "/100 · staging this run · awaiting Pi confirmation",
+      });
     }
     stagePendingCompaction(stated, buildSuccessMetrics(stated, "success"));
     if (stated.cancellation.timedOut) {
@@ -323,6 +332,7 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
       keepApplyProgress = true;
     }
   } catch (err) {
+    runFailed = true;
     // The failure path may run before any step has populated stage data, so
     // we collect the few fields we need into a small bag. recordFailureMetrics
     // takes either a StatedRc (best case) or the partial bag.
@@ -348,11 +358,13 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<void> 
       // when Pi confirms the compact).
       const dur = pipelineMs < 1000 ? pipelineMs + "ms" : (pipelineMs / 1000).toFixed(1) + "s";
       const hasPending = base.pendingRef.isPresent(runSessionId);
-      base.ctx.ui.notify(
+      if (hasPending || runFailed || finalRc) base.ctx.ui.notify(
         hasPending
           ? "Smart compact prepared in " + dur + " — awaiting native /compact"
-          : "Smart compact run finished in " + dur,
-        "info",
+          : runFailed
+            ? "Smart compact stopped safely in " + dur + " · no summary applied · Pi fallback continues"
+            : "Smart compact run finished in " + dur,
+        runFailed ? "warning" : "info",
       );
     }
   }

--- a/src/app/steps/persist.ts
+++ b/src/app/steps/persist.ts
@@ -104,7 +104,7 @@ export function runDamageDetection(rc: RunContext): void {
     if (damage.reReadFiles.length > 0) {
       writeRemediationHints(rc.projectId, damage.reReadFiles);
     }
-  } catch (err) { log.warn("Damage detection error", err); }
+  } catch (err) { log.debugError("Damage detection skipped", err); }
 }
 
 /**

--- a/src/app/steps/synthesize.ts
+++ b/src/app/steps/synthesize.ts
@@ -70,6 +70,9 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
   const cached = getCachedSynthesis(cacheKey);
   if (cached) {
     rc.notify("Synthesis cache hit — no LLM calls", "info");
+    if (!rc.flags.autoTriggered) showProgressOverlay(rc.ctx, {
+      phase: 3, phaseName: "Synthesize", detail: "Reusing the cached continuation summary · no LLM call",
+    });
     const hit = rc as ExtractedRc & {
       _synthesized: true; finalSummary: string; method: "eesv" | "single-pass" | "heuristic";
       methodForMetrics: string; llmCalls: number; summaries: ChunkSummary[];
@@ -88,13 +91,16 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
     return advance<ExtractedRc, SynthesizedRc>(hit, "_synthesized");
   }
   const zeroCall = rc.config.zeroCallEnabled !== false
-    && (rc.mode === "fast" || rc.mode === "aggressive")
+    && rc.mode === "fast"
     && !rc.focus && !rc.userNote
     && deterministicExtractionConfidence(extraction, {
       conversationTokens: rc.convTokens,
       toolPercent: rc.toolPercent,
     }) >= 0.85;
   if (zeroCall) {
+    if (!rc.flags.autoTriggered) showProgressOverlay(rc.ctx, {
+      phase: 3, phaseName: "Synthesize", detail: "Building a deterministic continuation summary · no LLM call",
+    });
     const finalSummary = assembleFallback([], extraction);
     setCachedSynthesis(cacheKey, {
       finalSummary, method: "heuristic", summaries: [], explorationReport: null,
@@ -135,17 +141,21 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
   try {
     summaryAuth = await resolveStageAuth(rc, "summary");
   } catch (error) {
-    rc.notify("Summary route unavailable; using deterministic fallback: " + (error instanceof Error ? error.message : String(error)), "warning");
+    log.debugError("Summary route unavailable", error);
+    rc.notify("Summary route unavailable · using deterministic fallback", "info");
   }
 
   if (!summaryAuth) {
+    if (!rc.flags.autoTriggered) showProgressOverlay(rc.ctx, {
+      phase: 3, phaseName: "Synthesize", detail: "Summary route unavailable · building a deterministic summary",
+    });
     finalSummary = assembleFallback([], extraction);
     method = "heuristic";
   } else if (rc.convTokens < singlePassMaxTokens) {
     if (!rc.flags.autoTriggered) {
       showProgressOverlay(rc.ctx, {
         phase: 3, phaseName: "Synthesize",
-        detail: "Single-pass (" + rc.convTokens.toLocaleString() + "t)",
+        detail: "Writing one continuation summary from " + rc.convTokens.toLocaleString() + " tokens",
         model: rc.modelLabel, profile: rc.profile, extraction,
       });
     }
@@ -157,7 +167,8 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
       );
       finalSummary = r.summary; method = "single-pass";
     } catch (err) {
-      rc.notify("Single-pass failed: " + (err instanceof Error ? err.message : String(err)), "warning");
+      log.debugError("Single-pass synthesis used deterministic fallback", err);
+      rc.notify("Single-pass generation stopped · using deterministic fallback", "info");
       finalSummary = assembleFallback([], extraction);
       method = "heuristic";
     }
@@ -167,7 +178,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
       const exploreStart = Date.now();
       if (!rc.flags.autoTriggered) {
         showProgressOverlay(rc.ctx, {
-          phase: 2, phaseName: "Explore", detail: "Exploring...",
+          phase: 2, phaseName: "Explore", detail: "Mapping topic shifts and continuity risks",
           model: rc.modelLabel, profile: rc.profile, extraction,
         });
       }
@@ -191,7 +202,8 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
         rc.vlog("Explore boundaries: " + explorationReport.boundaries
           .map(b => b.afterIndex + "(" + b.confidence.toFixed(2) + ")").join(", "));
       } catch (err) {
-        rc.notify("Phase 2 Explore: failed - " + (err instanceof Error ? err.message : String(err)), "warning");
+        log.debugError("Explore used deterministic topic boundaries", err);
+        rc.notify("Explore unavailable · using deterministic topic boundaries", "info");
       } finally {
         const exploreEnd = Date.now();
         markMeasuredPhase(rc, "explore", exploreStart, exploreEnd);
@@ -245,7 +257,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
     const totalBatches = batches.length;
     if (!rc.flags.autoTriggered) {
       showProgressOverlay(rc.ctx, {
-        phase: 3, phaseName: "Synthesize", detail: "0/" + totalBatches + " batches",
+        phase: 3, phaseName: "Synthesize", detail: "Compressing older history · batch 0/" + totalBatches,
         model: rc.modelLabel, profile: rc.profile, extraction, explorationRounds, totalBatches,
       });
     }
@@ -290,7 +302,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
           for (let index = wave; index < totalBatches; index++) {
             results[index] = batches[index].map(chunk => failedChunkSummary(chunk));
           }
-          rc.notify("Synthesis budget exhausted — remaining batches use deterministic fallback", "warning");
+          rc.notify("Synthesis budget reached · remaining batches use deterministic fallback", "info");
           break;
         }
         const waveBatches = batches.slice(wave, Math.min(wave + concurrency, batchCallLimit));
@@ -309,7 +321,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
           if (!rc.flags.autoTriggered) {
             showProgressOverlay(rc.ctx, {
               phase: 3, phaseName: "Synthesize",
-              detail: completed + "/" + totalBatches + " batches",
+              detail: "Compressing older history · batch " + completed + "/" + totalBatches,
               model: rc.modelLabel, profile: rc.profile, extraction, explorationRounds,
               totalBatches, currentBatch: completed,
             });
@@ -318,12 +330,24 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
         await Promise.all(wavePromises);
       }
       for (const r of results) if (r) summaries.push(...r);
-      for (let i = 0; i < errors.length; i++) if (errors[i]) rc.notify("Batch " + (i + 1) + " failed: " + errors[i]!.message, "warning");
+      const failedBatches = errors.filter(Boolean);
+      for (const error of failedBatches) log.debugError("Synthesis batch used deterministic fallback", error);
+      if (failedBatches.length) {
+        rc.notify(
+          failedBatches.length + " synthesis batch(es) stopped · deterministic evidence fallback preserved coverage",
+          "info",
+        );
+        if (!rc.flags.autoTriggered) showProgressOverlay(rc.ctx, {
+          phase: 3, phaseName: "Synthesize",
+          detail: failedBatches.length + " batch fallback(s) · preserving coverage from deterministic evidence",
+          explorationRounds,
+        });
+      }
     }
 
     if (!rc.flags.autoTriggered) {
       showProgressOverlay(rc.ctx, {
-        phase: 3, phaseName: "Synthesize", detail: "Assembling...",
+        phase: 3, phaseName: "Synthesize", detail: "Merging summaries with project continuity",
         model: rc.modelLabel, profile: rc.profile, extraction, explorationRounds, totalBatches: batches.length,
       });
     }
@@ -335,7 +359,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
       );
       if (r?.startsWith("##")) finalSummary = r; else throw new Error("bad");
     } catch (err) {
-      log.warn("Assembly failed", err);
+      log.debugError("Assembly used deterministic fallback", err);
       finalSummary = assembleFallback(summaries, extraction);
     }
     method = "eesv";

--- a/src/app/steps/verify.ts
+++ b/src/app/steps/verify.ts
@@ -24,7 +24,7 @@ export async function verifyAndPatch(rc: SynthesizedRc): Promise<VerifiedRc> {
 
   if (!rc.flags.autoTriggered) {
     showProgressOverlay(rc.ctx, {
-      phase: 4, phaseName: "Verify", detail: "Checking...",
+      phase: 4, phaseName: "Verify", detail: "Checking facts, files, constraints, errors, and open loops",
       model: rc.modelLabel, profile: rc.profile, extraction,
       explorationRounds: rc.explorationRounds,
     });
@@ -41,8 +41,12 @@ export async function verifyAndPatch(rc: SynthesizedRc): Promise<VerifiedRc> {
   if (initialPatchable.length > 0) {
     rc.notify(
       "Phase 4 Verify: " + initialPatchable.length + " deterministic gap(s), score=" + verification.score + ", applying repair",
-      "warning",
+      "info",
     );
+    if (!rc.flags.autoTriggered) showProgressOverlay(rc.ctx, {
+      phase: 4, phaseName: "Verify", detail: "Repairing " + initialPatchable.length + " deterministic finding(s)",
+      explorationRounds: rc.explorationRounds,
+    });
     const repaired = repairSummaryDeterministically(summary, verification, extraction, rc.previousState);
     summary = repaired.summary;
     verification = repaired.result;
@@ -51,12 +55,16 @@ export async function verifyAndPatch(rc: SynthesizedRc): Promise<VerifiedRc> {
 
   const mode = rc.mode ?? (rc.profile ? modeFromLegacyProfile(rc.profile) : "balanced");
   if (MODE_POLICIES[mode].allowLlmPatch && !verification.ok) {
-    rc.notify("Phase 4 Verify: deterministic repair insufficient (score=" + verification.score + "), requesting LLM patch", "warning");
+    rc.notify("Phase 4 Verify: deterministic repair insufficient (score=" + verification.score + "), requesting LLM patch", "info");
+    if (!rc.flags.autoTriggered) showProgressOverlay(rc.ctx, {
+      phase: 4, phaseName: "Verify", detail: "Requesting a semantic repair for unresolved findings",
+      explorationRounds: rc.explorationRounds,
+    });
     const beforePatch = summary;
     try {
       const verifyAuth = await resolveStageAuth(rc, "verify");
       summary = await patchSummary(summary, verification.gaps, rc.verifyModel ?? rc.summaryModel, verifyAuth, rc.cancellation.signal, rc.services);
-    } catch (error) { log.warn("LLM patch failed", error); }
+    } catch (error) { log.debugError("LLM verification patch used deterministic fallback", error); }
     if (summary !== beforePatch) {
       llmPatched = true;
       verification = verifySummary(summary, extraction, rc.previousState);
@@ -68,6 +76,10 @@ export async function verifyAndPatch(rc: SynthesizedRc): Promise<VerifiedRc> {
   }
 
   if (!verification.ok) {
+    if (!rc.flags.autoTriggered) showProgressOverlay(rc.ctx, {
+      phase: 4, phaseName: "Verify", detail: "Trying the deterministic safety summary",
+      explorationRounds: rc.explorationRounds,
+    });
     let deterministic = assembleFallback(rc.summaries, extraction);
     let deterministicVerification = verifySummary(deterministic, extraction, rc.previousState);
     const repaired = repairSummaryDeterministically(deterministic, deterministicVerification, extraction, rc.previousState);
@@ -81,12 +93,16 @@ export async function verifyAndPatch(rc: SynthesizedRc): Promise<VerifiedRc> {
       verification = deterministicVerification;
       deterministicPatched.push(...repaired.patched);
       qualityFloorUsed = true;
-      rc.notify("Quality floor replaced unsafe or unverifiable model output", "warning");
+      rc.notify("Quality floor replaced unsafe or unverifiable model output", "info");
     }
   }
 
   const failure = verificationFailureMessage(verification);
   if (failure) throw new VerificationGateError(verification, initialScore);
+  if (!rc.flags.autoTriggered) showProgressOverlay(rc.ctx, {
+    phase: 4, phaseName: "Verify", detail: "Passed " + verification.score + "/100 · 0 unresolved gaps",
+    explorationRounds: rc.explorationRounds,
+  });
 
   const out = rc as SynthesizedRc & {
     _verified: true;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "8.0.5";
+export const VERSION = "8.0.6";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.10;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,7 +254,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
   pi.registerCommand("smart-compact", {
     description: "EESV smart compaction v" + VERSION + ". Usage: /smart-compact [model] [mode] [flags] [--focus=topic] [--max-calls=N] [--max-input-tokens=N] [note]",
     getArgumentCompletions: (prefix: string) => {
-      const m = ["verbose", "debug", "dry-run", "metrics", "dashboard", "restore", "loops", "auto", "balanced", "aggressive", "fast", "thorough", "slow", "light", "--focus=", "--max-calls=", "--max-input-tokens=", "--max-latency="].filter(o => o.startsWith(prefix)).map(o => ({ value: o, label: o }));
+      const m = ["verbose", "debug", "dry-run", "metrics", "dashboard", "restore", "loops", "fast", "balanced", "thorough", "--focus=", "--max-calls=", "--max-input-tokens=", "--max-latency="].filter(o => o.startsWith(prefix)).map(o => ({ value: o, label: o }));
       return m.length ? m : null;
     },
     handler: async (args, ctx) => {
@@ -385,8 +385,9 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
           /^[a-z0-9_.-]+\/[a-z0-9_.:-]+$/i.test(t) &&
           (findModelById(ctx, t) || knownProviders.has(t.split("/")[0])));
         const config = loadConfig();
-        const rawMode = tokens.find(t => ["auto", "balanced", "aggressive", "fast", "thorough", "slow"].includes(t));
-        const modeArg = (rawMode === "slow" ? "thorough" : rawMode) as CompactionMode | undefined;
+        const rawMode = tokens.find(t => ["auto", "fast", "balanced", "thorough", "aggressive", "slow"].includes(t));
+        const modeArg = (rawMode === "slow" ? "thorough" : rawMode === "aggressive" ? "fast" : rawMode) as CompactionMode | undefined;
+        if (rawMode === "aggressive") ctx.ui.notify("Aggressive mode is now Fast; using Fast.", "warning");
         const profileArg = tokens.includes("light") ? "light" as CompressionProfile : undefined;
         const mode = modeArg ?? (profileArg ? modeFromLegacyProfile(profileArg) : config.mode);
 
@@ -497,7 +498,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
             cancellationOut,
           });
         } catch (err) {
-          log.warn("Smart compact auto-trigger threw", err);
+          log.debugError("Smart compact auto-trigger stopped", err);
         } finally {
           clearTimeout(timeoutId);
         }
@@ -510,7 +511,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
           return { compaction: { summary: fresh.summary, firstKeptEntryId: fresh.firstKeptEntryId, tokensBefore: fresh.tokensBefore, details: fresh.details } };
         }
       }
-    } catch (e) { log.warn("session_before_compact error", e); }
+    } catch (e) { log.debugError("session_before_compact stopped", e); }
   });
 
   pi.on("session_compact", async (event, ctx) => {
@@ -605,7 +606,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
     parameters: {
       type: "object",
       properties: {
-        mode: { type: "string", description: "auto, balanced, aggressive, fast, or thorough (slow alias). Default: auto." },
+        mode: { type: "string", description: "fast, balanced, thorough, or auto. Default: auto." },
         profile: { type: "string", description: "Deprecated alias: light, balanced, or aggressive." },
         verbose: { type: "boolean", description: "Show detailed pipeline output." },
         dry_run: { type: "boolean", description: "Run the pipeline but skip applying the compaction." },
@@ -621,7 +622,9 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
       const profile = (params.profile === "light" || params.profile === "balanced" || params.profile === "aggressive") ? params.profile : undefined;
       const mode = params.mode === "slow"
         ? "thorough"
-        : (["auto", "balanced", "aggressive", "fast", "thorough"] as const).find(value => value === params.mode);
+        : params.mode === "aggressive"
+          ? "fast"
+          : (["auto", "fast", "balanced", "thorough"] as const).find(value => value === params.mode);
       const verbose = !!params.verbose;
       const dryRun = !!params.dry_run;
       const focus = typeof params.focus === "string" ? params.focus.trim() || undefined : undefined;

--- a/src/phases/explore.ts
+++ b/src/phases/explore.ts
@@ -379,7 +379,7 @@ export async function exploreConversation(
             tools: EXPLORATION_TOOLS,
           }, { apiKey: auth.apiKey, headers: auth.headers, signal, maxTokens: Math.min(4096, model.maxTokens || 4096) }, svc);
         } catch (err) {
-          log.warn("Explore loop error", err);
+          log.debugError("Explore loop stopped", err);
           break;
         }
 

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -243,7 +243,7 @@ export function verifySummary(
   }
 
   for (const error of unresolvedEvidence) {
-    const snippet = error.message.trim().replace(/\s+/g, " ").slice(0, TRUNC.ERROR_SNIPPET).toLowerCase();
+    const snippet = summaryEvidenceLine(error.message, TRUNC.ERROR_SNIPPET).toLowerCase();
     if (snippet.length > 5 && !normalizedSummary.includes(snippet)) {
       gaps.push({ kind: "missing-error", message: error.message });
       score -= 5;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,8 +9,9 @@ import type { SectionKind } from "./domain/summary-schema.ts";
 export type SessionType = "implementation" | "review" | "debugging" | "discussion";
 
 export type CompressionProfile = "light" | "balanced" | "aggressive";
-export type CompactionMode = "auto" | "balanced" | "aggressive" | "fast" | "thorough";
-export type EffectiveCompactionMode = Exclude<CompactionMode, "auto">;
+export type EffectiveCompactionMode = "fast" | "balanced" | "thorough";
+/** `aggressive` is accepted only as a legacy input and resolves to Fast. */
+export type CompactionMode = "auto" | EffectiveCompactionMode | "aggressive";
 
 export interface ProfileConfig {
   summaryBudgetTokens: number;

--- a/src/ui/overlays.ts
+++ b/src/ui/overlays.ts
@@ -5,7 +5,7 @@
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { DynamicBorder, Theme } from "@earendil-works/pi-coding-agent";
 import { TRUNC } from "../constants.ts";
-import { Container, Key, matchesKey, type SelectItem, SelectList, Text, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { Container, Key, matchesKey, type SelectItem, SelectList, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type {
   CompactConfig, CompactMetricsEntry, CompactionMode, ModelOption, ProgressState,
@@ -112,15 +112,14 @@ export async function selectModel(
   return options[parseInt(result.slice(6), 10)] ?? null;
 }
 
-const PRIMARY_MODES: EffectiveCompactionMode[] = ["thorough", "balanced", "fast"];
+const PRIMARY_MODES: EffectiveCompactionMode[] = ["fast", "balanced", "thorough"];
 const MODE_LABELS: Record<EffectiveCompactionMode, string> = {
-  thorough: "Thorough", balanced: "Balanced", fast: "Fast", aggressive: "Aggressive",
+  fast: "Fast", balanced: "Balanced", thorough: "Thorough",
 };
 const MODE_COPY: Record<EffectiveCompactionMode, string> = {
-  thorough: "richer summary · 30K base recent tail",
-  balanced: "default balance · 20K base recent tail",
-  fast: "faster run · 20K base recent tail · 6K base summary",
-  aggressive: "maximum recovery · 10K base recent tail",
+  fast: "quickest · compact 10K recent tail · 3K summary",
+  balanced: "default quality/speed · 20K recent tail · 6K summary",
+  thorough: "deepest analysis · rich 30K recent tail · 10K summary",
 };
 
 export function explainPreflightReason(reason: ManualPreflight["reason"]): string {
@@ -157,7 +156,7 @@ export function recommendPreflight(plans: ReadonlyMap<EffectiveCompactionMode, M
   if (balanced?.plan?.viable) {
     return { mode: "balanced", reason: "normal pressure favors the default balance; " + recommendationEvidence(balanced) };
   }
-  const fallback = (["thorough", "fast"] as const).find(mode => plans.get(mode)?.plan?.viable);
+  const fallback = (["fast", "thorough"] as const).find(mode => plans.get(mode)?.plan?.viable);
   if (fallback) {
     const chosen = plans.get(fallback)!;
     return {
@@ -169,8 +168,12 @@ export function recommendPreflight(plans: ReadonlyMap<EffectiveCompactionMode, M
 }
 
 function tokenCount(value: number): string { return Math.round(value).toLocaleString() + "t"; }
+function compactTokenCount(value: number): string {
+  if (Math.abs(value) < 1_000) return Math.round(value) + "t";
+  const scaled = value / 1_000;
+  return scaled.toFixed(scaled >= 10 ? 1 : 2).replace(/\.0+$|(\.\d*[1-9])0+$/, "$1") + "K";
+}
 function percent(value: number): string { return Math.round(value).toLocaleString() + "%"; }
-function windowPercent(tokens: number, window: number): string { return window > 0 ? percent(tokens / window * 100) : "unknown %"; }
 
 const SOFT_BOUNDARY_COPY: Record<string, string> = {
   "recent-user-turn": "older user turn",
@@ -180,38 +183,31 @@ const SOFT_BOUNDARY_COPY: Record<string, string> = {
   "topical-group": "adjacent topic",
 };
 
-/** Pure copy generation; styling and terminal truncation stay in the component. */
+/** Compact decision copy; technical planner data stays behind D. */
 export function formatPreflightSummary(preflight: ManualPreflight, modelLabel: string, details = false): string[] {
   const plan = preflight.plan;
   if (!plan) {
     const lines = [
-      "Before: ~" + tokenCount(preflight.totalTokens) + " (~" + percent(preflight.contextPercent) + " of active window) · Expected after: unavailable",
-      "This preset cannot run: " + explainPreflightReason(preflight.reason) + ".",
-      "Hard safeguards: complete tool-call/result pairs and zero-gap verification before apply.",
+      "Plan unavailable · " + explainPreflightReason(preflight.reason),
+      "✓ Complete tool pairs · ✓ zero-gap verification before apply",
     ];
     if (details) lines.push(
-      "Estimator: messages ~" + tokenCount(preflight.rawEstimatedMessageTokens) + " · fixed/scaled normalization unavailable",
-      "Summary route: " + modelLabel + " · viability: " + preflight.reason,
+      "Estimator  messages ~" + tokenCount(preflight.rawEstimatedMessageTokens) + " · normalization unavailable",
+      "Route  " + modelLabel + " · viability " + preflight.reason,
     );
     return lines;
   }
-  const soft = plan.relaxedSoftBoundaries.length
-    ? "Soft boundaries included in summary: " + plan.relaxedSoftBoundaries.map(kind => SOFT_BOUNDARY_COPY[kind] ?? kind).join(", ")
-    : "Soft boundaries kept when they fit: older user turn, latest checkpoint, adjacent topic";
   const lines = [
-    "Before ~" + tokenCount(preflight.totalTokens) + " (~" + percent(preflight.contextPercent) + " window) → expected after ~" + tokenCount(plan.projectedAfterTokens) + " (~" + windowPercent(plan.projectedAfterTokens, preflight.contextWindowTokens) + " window)",
-    "Projected net saving ~" + tokenCount(plan.projectedSavedTokens) + " (~" + percent(plan.projectedYield * 100) + ", estimator-based)",
-    "Recent raw tail ~" + tokenCount(plan.retainedTokens) + " + summary budget ≤" + tokenCount(plan.summaryBudgetTokens),
-    soft,
-    "Hard safeguards: complete tool-call/result pairs and zero-gap verification before apply; " + (plan.hardBoundaryAdjusted ? "boundary adjusted to keep a pair intact" : "no hard-boundary adjustment needed"),
+    "Plan  " + compactTokenCount(preflight.totalTokens) + " → ~" + compactTokenCount(plan.projectedAfterTokens) + " · ~" + compactTokenCount(plan.projectedSavedTokens) + " saved (" + percent(plan.projectedYield * 100) + ")",
+    "Keep  ~" + compactTokenCount(plan.retainedTokens) + " recent · summary up to " + compactTokenCount(plan.summaryBudgetTokens),
+    "✓ Complete tool pairs · ✓ zero-gap verification before apply",
   ];
-  if (!plan.viable) lines.push("Cannot run this preset: " + explainPreflightReason(plan.reason) + ". Choose a viable preset.");
+  if (!plan.viable) lines.unshift("Unavailable · " + explainPreflightReason(plan.reason));
   if (details) lines.push(
-    "Estimator: messages ~" + tokenCount(preflight.rawEstimatedMessageTokens) + " · normalized ×" + preflight.estimatorScale.toFixed(2) + " · fixed ~" + tokenCount(plan.fixedContextTokens),
-    "Target ≤" + tokenCount(plan.targetAfterTokens) + " · tail target ≤" + tokenCount(plan.retentionTargetTokens),
-    "Hard-boundary adjustment: " + (plan.hardBoundaryAdjusted ? "yes" : "no") + " · viability: " + plan.reason,
-    "Internal soft boundaries: " + (plan.relaxedSoftBoundaries.join(", ") || "none"),
-    "Summary route: " + modelLabel + (preflight.adapted ? " · damage feedback " + preflight.damageMedian + "/100 applied" : ""),
+    "Target  ≤" + tokenCount(plan.targetAfterTokens) + " · tail ≤" + tokenCount(plan.retentionTargetTokens) + " · fixed ~" + tokenCount(plan.fixedContextTokens),
+    "Estimator  ~" + tokenCount(preflight.rawEstimatedMessageTokens) + " messages · normalized ×" + preflight.estimatorScale.toFixed(2),
+    "Boundary  " + (plan.hardBoundaryAdjusted ? "tool pair kept intact" : "no hard adjustment") + " · soft summarized: " + (plan.relaxedSoftBoundaries.map(kind => SOFT_BOUNDARY_COPY[kind] ?? kind).join(", ") || "none"),
+    "Route  " + modelLabel + (preflight.adapted ? " · damage feedback " + preflight.damageMedian + "/100" : ""),
   );
   return lines;
 }
@@ -222,14 +218,22 @@ const PROGRESS_PHASES = ["Extract", "Explore", "Synthesize", "Verify", "Apply"];
 export function showProgressOverlay(ctx: ExtensionContext, state: ProgressState): void {
   if (ctx.hasUI === false) return;
   const name = PROGRESS_PHASES[state.phase - 1] ?? state.phaseName;
-  const story = PROGRESS_PHASES.map((phase, index) => index === 1 && state.phase > 2 && !state.explorationRounds
-    ? "– Explore"
-    : index < state.phase - 1 ? "✓ " + phase : index === state.phase - 1 ? "● " + phase : "○ " + phase).join("  ");
-  const detail = state.detail ? name + " · " + state.detail : name;
   try {
-    ctx.ui.setStatus?.(PROGRESS_KEY, "Smart Compact · " + detail);
+    ctx.ui.setStatus?.(PROGRESS_KEY, "Smart Compact " + state.phase + "/5 · " + name);
     ctx.ui.setWidget?.(PROGRESS_KEY, (_tui, theme) => ({
-      render: (width: number) => [truncateToWidth(theme.fg("dim", story), width)],
+      render: (width: number) => {
+        const story = PROGRESS_PHASES.map((phase, index) => {
+          if (index === 1 && state.phase > 2 && !state.explorationRounds) return theme.fg("dim", "– Explore");
+          if (index < state.phase - 1) return theme.fg("success", "✓ " + phase);
+          if (index === state.phase - 1) return theme.fg("accent", theme.bold("● " + phase));
+          return theme.fg("dim", "○ " + phase);
+        }).join(theme.fg("dim", "  "));
+        const safety = state.phase < 5 ? " · conversation unchanged" : "";
+        return [
+          truncateToWidth(story, width),
+          truncateToWidth(theme.fg("muted", "↳ " + state.detail + safety), width),
+        ];
+      },
       invalidate: () => {},
     }), { placement: "belowEditor" });
   } catch { /* non-interactive UI adapters may not implement persistent UI */ }
@@ -579,40 +583,72 @@ export async function showCompactUI(
       let details = false;
       return {
         render: (width: number) => {
-          const out = (text: string, color: import("@earendil-works/pi-coding-agent").ThemeColor = "text") =>
-            truncateToWidth(theme.fg(color, text), Math.max(0, width));
-          const wrapped = (text: string, color: import("@earendil-works/pi-coding-agent").ThemeColor = "text") =>
-            wrapTextWithAnsi(theme.fg(color, text), Math.max(1, width));
+          const inner = Math.max(1, width - 2);
+          const border = (text: string) => theme.fg("borderMuted", text);
+          const fit = (text: string, max = inner) => truncateToWidth(text, Math.max(0, max), "");
+          const fill = (text: string) => {
+            const clipped = fit(text);
+            return clipped + " ".repeat(Math.max(0, inner - visibleWidth(clipped)));
+          };
+          const cell = (text = "") => border("│") + fill(text) + border("│");
+          const divider = border("├" + "─".repeat(inner) + "┤");
+          const title = fit(" Smart Compact ", Math.max(0, inner - 1));
+          const top = border("╭─") + theme.fg("accent", theme.bold(title)) +
+            border("─".repeat(Math.max(0, inner - 1 - visibleWidth(title))) + "╮");
+          const bottom = border("╰" + "─".repeat(inner) + "╯");
+          const selectedMode = PRIMARY_MODES[selected];
+          const current = plans.get(selectedMode)!;
+          const contextWindow = current.contextWindowTokens;
+          const contextPct = Math.round(current.contextPercent);
+          const barLength = width >= 72 ? 14 : 8;
+          const barFilled = Math.min(barLength, Math.round(Math.min(100, contextPct) / 100 * barLength));
+          const contextBar = theme.fg(contextPct >= 90 ? "error" : contextPct >= 70 ? "warning" : "success", "█".repeat(barFilled)) +
+            theme.fg("dim", "░".repeat(barLength - barFilled));
+          const modelPrefix = "  Summary model  ";
+          const modelAction = theme.fg("accent", "  [M] Change");
+          const modelWidth = Math.max(1, inner - visibleWidth(modelPrefix) - visibleWidth(modelAction));
           const lines = [
-            out("Smart Compact preflight", "accent"),
-            ...wrapped("Recommended: " + MODE_LABELS[recommended.mode] + " — " + recommended.reason, "text"),
-            out("Active context: " + opts.activeModelLabel + " · " + tokenCount(plans.get(recommended.mode)?.contextWindowTokens ?? 0) + " window", "dim"),
-            out("Summary model: " + selectedModel.label, "dim"),
-            out("─".repeat(Math.max(0, width)), "borderMuted"),
+            top,
+            cell("  Context  " + compactTokenCount(opts.contextTokens) + " / " + compactTokenCount(contextWindow) + "  " + contextBar + "  " + contextPct + "%"),
+            cell(theme.fg("dim", modelPrefix) + fit(selectedModel.label, modelWidth) + modelAction),
+            divider,
           ];
+
           for (let index = 0; index < PRIMARY_MODES.length; index++) {
             const mode = PRIMARY_MODES[index];
             const preview = plans.get(mode)!;
-            const viable = preview.plan?.viable ?? false;
-            lines.push(out(
-              (index === selected ? "> " : "  ") + MODE_LABELS[mode] +
-                (mode === recommended.mode ? " [recommended]" : "") +
-                (viable ? " [viable]" : " [unavailable: " + explainPreflightReason(preview.reason) + "]"),
-              index === selected ? "accent" : viable ? "text" : "muted",
-            ));
-            lines.push(out("    " + MODE_COPY[mode], "dim"));
+            const plan = preview.plan;
+            const viable = plan?.viable ?? false;
+            const marker = index === selected ? "› " : "  ";
+            const recommendedMark = mode === recommended.mode ? "  recommended" : "             ";
+            const trait = mode === "fast" ? "quickest" : mode === "balanced" ? "default" : "deepest";
+            const stats = (viable && plan
+              ? "~" + compactTokenCount(plan.projectedAfterTokens) + " after · " + percent(plan.projectedYield * 100) + " saved"
+              : "unavailable · " + explainPreflightReason(preview.reason)) + " · " + trait;
+            const line = " " + marker + MODE_LABELS[mode].padEnd(9) + recommendedMark + "  " + stats;
+            lines.push(cell(index === selected
+              ? theme.fg("accent", theme.bold(line))
+              : theme.fg(viable ? mode === recommended.mode ? "success" : "text" : "muted", line)));
           }
-          lines.push(out("─".repeat(Math.max(0, width)), "borderMuted"));
-          const current = plans.get(PRIMARY_MODES[selected])!;
-          lines.push(...formatPreflightSummary(current, selectedModel.value, details).flatMap(line => wrapped(line, line.startsWith("Cannot") || line.startsWith("This preset") ? "warning" : "text")));
-          lines.push("", out("↑↓ mode · Enter compact · D details · M model · Esc cancel", "dim"));
+
+          lines.push(divider);
+          for (const line of formatPreflightSummary(current, selectedModel.value, details)) {
+            const color = line.startsWith("Unavailable") || line.startsWith("Plan unavailable") ? "warning" : line.startsWith("✓") ? "success" : "text";
+            lines.push(cell("  " + theme.fg(color, line)));
+          }
+          if (details) lines.push(cell("  " + theme.fg("dim", MODE_LABELS[selectedMode] + " · " + MODE_COPY[selectedMode])));
+          lines.push(
+            divider,
+            cell(theme.fg("dim", "  ↑↓ choose · Enter run · D details · M model · Esc cancel")),
+            bottom,
+          );
           return lines;
         },
         invalidate: () => {},
         handleInput: (data: string) => {
           if (keybindings.matches(data, "tui.select.cancel")) { done(null); return; }
-          if (keybindings.matches(data, "tui.select.up")) selected = Math.max(0, selected - 1);
-          else if (keybindings.matches(data, "tui.select.down")) selected = Math.min(PRIMARY_MODES.length - 1, selected + 1);
+          if (keybindings.matches(data, "tui.select.up")) selected = (selected + PRIMARY_MODES.length - 1) % PRIMARY_MODES.length;
+          else if (keybindings.matches(data, "tui.select.down")) selected = (selected + 1) % PRIMARY_MODES.length;
           else if (keybindings.matches(data, "tui.select.confirm")) {
             const mode = PRIMARY_MODES[selected];
             if (plans.get(mode)?.plan?.viable) { done(mode); return; }
@@ -621,7 +657,7 @@ export async function showCompactUI(
           tui.requestRender();
         },
       };
-    }, { overlay: true, overlayOptions: { width: "70%", minWidth: 36, anchor: "center", maxHeight: "85%" } });
+    }, { overlay: true, overlayOptions: { width: "68%", minWidth: 52, anchor: "center", maxHeight: "85%" } });
 
     if (!action) return null;
     if (action === "model") {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -14,7 +14,7 @@ import { flattenToolCallBlock } from "./extraction.ts";
 import { extractToolPath } from "../domain/tool-semantics.ts";
 
 const VALID_PROFILES = ["light", "balanced", "aggressive"] as const;
-const VALID_MODES = ["auto", "balanced", "aggressive", "fast", "thorough"] as const;
+const VALID_MODES = ["auto", "fast", "balanced", "thorough"] as const;
 const VALID_THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const PROFILE_NUMERIC_KEYS = ["summaryBudgetTokens", "keepRecentTokens", "minChunkTokens", "maxChunkTokens", "singlePassMaxTokens", "batchMaxTokens"] as const;
 
@@ -26,8 +26,12 @@ const PROFILE_NUMERIC_KEYS = ["summaryBudgetTokens", "keepRecentTokens", "minChu
  * This prevents silent misconfiguration (e.g. profile: "super").
  */
 export function validateSmartCompactConfig(sc: Record<string, unknown>): void {
+  if (sc.mode === "aggressive") {
+    log.warn("smart-compact config: mode 'aggressive' is deprecated; using 'fast'.");
+    sc.mode = "fast";
+  }
   if ("mode" in sc && !(VALID_MODES as readonly string[]).includes(sc.mode as string)) {
-    log.warn("smart-compact config: invalid mode '" + sc.mode + "', expected auto|balanced|aggressive|fast|thorough. Using default 'auto'.");
+    log.warn("smart-compact config: invalid mode '" + sc.mode + "', expected auto|fast|balanced|thorough. Using default 'auto'.");
     delete sc.mode;
   }
   if ("telemetryChannel" in sc && sc.telemetryChannel !== "stable" && sc.telemetryChannel !== "canary") {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -16,10 +16,15 @@ describe("validateSmartCompactConfig", () => {
     expect(sc.profile).toBe("light");
   });
 
-  it("validates the optimization mode", () => {
-    const valid: Record<string, unknown> = { mode: "thorough" };
-    validateSmartCompactConfig(valid);
-    expect(valid.mode).toBe("thorough");
+  it("validates the three optimization modes and migrates legacy aggressive to Fast", () => {
+    for (const mode of ["fast", "balanced", "thorough"]) {
+      const valid: Record<string, unknown> = { mode };
+      validateSmartCompactConfig(valid);
+      expect(valid.mode).toBe(mode);
+    }
+    const legacy: Record<string, unknown> = { mode: "aggressive" };
+    validateSmartCompactConfig(legacy);
+    expect(legacy.mode).toBe("fast");
     const invalid: Record<string, unknown> = { mode: "turbo" };
     validateSmartCompactConfig(invalid);
     expect(invalid.mode).toBeUndefined();

--- a/test/index-tool.test.ts
+++ b/test/index-tool.test.ts
@@ -10,7 +10,8 @@ describe("smart_compact tool cancellation", () => {
       on: () => {},
     } as any);
 
-    expect(tool.parameters.properties.mode.description).toContain("auto");
+    expect(tool.parameters.properties.mode.description).toContain("fast, balanced, thorough");
+    expect(tool.parameters.properties.mode.description).not.toContain("aggressive");
     expect(tool.parameters.properties.max_input_tokens).toBeDefined();
   });
 

--- a/test/mode-policy.test.ts
+++ b/test/mode-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { batchOutputLimit, deterministicExtractionConfidence, MODE_POLICIES, resolveMode } from "../src/app/mode-policy.ts";
+import { batchOutputLimit, deterministicExtractionConfidence, modeFromLegacyProfile, MODE_POLICIES, resolveMode } from "../src/app/mode-policy.ts";
 import type { StructuredExtraction } from "../src/types.ts";
 
 const extraction = (partial: Partial<StructuredExtraction> = {}): StructuredExtraction => ({
@@ -9,7 +9,7 @@ const extraction = (partial: Partial<StructuredExtraction> = {}): StructuredExtr
 
 describe("compaction mode policy", () => {
   it("uses pressure first and deterministic risk second in auto mode", () => {
-    expect(resolveMode("auto", 90, extraction())).toBe("aggressive");
+    expect(resolveMode("auto", 90, extraction())).toBe("fast");
     expect(resolveMode("auto", 65, extraction())).toBe("fast");
     expect(resolveMode("auto", 75, extraction({
       errors: Array.from({ length: 3 }, (_, index) => ({ index, tool: "bash", message: "failed", retryAttempted: false, resolved: false })),
@@ -42,10 +42,16 @@ describe("compaction mode policy", () => {
     }))).toBeLessThan(0.5);
   });
 
-  it("keeps explicit modes stable", () => {
-    for (const mode of ["fast", "balanced", "aggressive", "thorough"] as const) {
+  it("exposes three stable modes and maps legacy aggressive behavior to Fast", () => {
+    for (const mode of ["fast", "balanced", "thorough"] as const) {
       expect(resolveMode(mode, 99, extraction())).toBe(mode);
     }
+    expect(resolveMode("aggressive", 99, extraction())).toBe("fast");
+    expect(modeFromLegacyProfile("aggressive")).toBe("fast");
+    expect(Object.keys(MODE_POLICIES)).toEqual(["fast", "balanced", "thorough"]);
+    expect(MODE_POLICIES.fast.profile).toBe("aggressive");
+    expect(MODE_POLICIES.fast.targetContextPercent).toBeLessThan(MODE_POLICIES.balanced.targetContextPercent);
+    expect(MODE_POLICIES.balanced.targetContextPercent).toBeLessThan(MODE_POLICIES.thorough.targetContextPercent);
   });
 
   it("gives every preset a finite token and call ceiling", () => {

--- a/test/pipeline-integration.test.ts
+++ b/test/pipeline-integration.test.ts
@@ -200,8 +200,8 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
       return makeSummaryResponse("## Goal\nUpdate auth\n## Progress\n### Done\n- none\n### In Progress\n- update auth\n### Blocked\n- none\n## Critical Context\n- preserve context");
     } });
     const tiered = makeTieredRc(messages);
-    tiered.mode = "aggressive";
-    tiered.requestedMode = "aggressive";
+    tiered.mode = "fast";
+    tiered.requestedMode = "fast";
     const extracted = extractWithCache(tiered);
     extracted.extraction.mainGoal = "Update auth";
     extracted.extraction.lastUserMessages = ["Update src/auth.ts"];
@@ -228,7 +228,9 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
     };
     setLlmClient(fakeClient);
 
+    const notices: string[] = [];
     const tiered = makeTieredRc(messages);
+    tiered.notify = (message: string) => { notices.push(message); };
     const extracted = extractWithCache(tiered);
     const synthesized = await summarizeConversation(extracted);
 
@@ -240,5 +242,7 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
     expect(synthesized.method).toBe("heuristic");
     expect(synthesized.finalSummary.length).toBeGreaterThan(0);
     expect(synthesized.llmCalls).toBe(1);
+    expect(notices).toContain("Single-pass generation stopped · using deterministic fallback");
+    expect(notices.join("\n")).not.toContain("simulated provider outage");
   });
 });

--- a/test/preflight-ui.test.ts
+++ b/test/preflight-ui.test.ts
@@ -78,7 +78,7 @@ describe("smart compact preflight UI", () => {
 
     plans.set("balanced", preview("balanced", false));
     const fallback = recommendPreflight(plans);
-    expect(fallback.mode).toBe("thorough");
+    expect(fallback.mode).toBe("fast");
     expect(fallback.reason).toContain("estimated saving is below 10%");
   });
 
@@ -108,37 +108,41 @@ describe("smart compact preflight UI", () => {
     expect(recommendation.reason).toContain("recent damage feedback");
   });
 
-  it("formats estimates, boundaries, safeguards, and technical disclosure honestly", () => {
-    const lines = formatPreflightSummary(preview("balanced", true), "openai/summary", true).join("\n");
-    expect(lines).toContain("Before ~90,000t (~64% window)");
-    expect(lines).toContain("expected after ~26,000t (~19% window)");
-    expect(lines).toContain("Projected net saving ~64,000t (~71%, estimator-based)");
-    expect(lines).toContain("summary budget ≤6,000t");
-    expect(lines).toContain("Soft boundaries included in summary: older user turn");
-    expect(lines).toContain("Internal soft boundaries: recent-user-turn");
-    expect(lines).toContain("complete tool-call/result pairs");
-    expect(lines).toContain("zero-gap verification before apply");
-    expect(lines).toContain("normalized ×0.80");
-    expect(lines).toContain("Summary route: openai/summary");
+  it("keeps the decision brief and places planner disclosure behind Details", () => {
+    const brief = formatPreflightSummary(preview("balanced", true), "openai/summary").join("\n");
+    expect(brief).toContain("Plan  90K → ~26K · ~64K saved (71%)");
+    expect(brief).toContain("Keep  ~20K recent · summary up to 6K");
+    expect(brief).toContain("Complete tool pairs · ✓ zero-gap verification before apply");
+    expect(brief).not.toContain("Estimator");
+
+    const details = formatPreflightSummary(preview("balanced", true), "openai/summary", true).join("\n");
+    expect(details).toContain("Estimator  ~100,000t messages · normalized ×0.80");
+    expect(details).toContain("Boundary  no hard adjustment · soft summarized: older user turn");
+    expect(details).toContain("Route  openai/summary");
   });
 
-  it("supports D disclosure and Enter on a viable preset without exceeding narrow width", async () => {
+  it("renders the three-mode decision card, supports D, and never exceeds width", async () => {
     const result = await showCompactUI(context((component, done) => {
       const narrowLines = component.render(36);
-      const narrow = narrowLines.join(" ");
       expect(narrowLines.every((line: string) => visibleWidth(line) <= 36)).toBeTrue();
-      expect(narrow).toContain("severe context pressure");
-      expect(narrow).toContain("Before ~90,000t");
-      expect(narrow).toContain("expected after");
-      expect(narrow).toContain("Projected net saving");
-      expect(narrow).toContain("zero-gap verification before apply");
-      expect(component.render(100).join("\n")).toContain("faster run · 20K base recent tail · 6K base summary");
+      const card = component.render(100).join("\n");
+      expect(card).toContain("Smart Compact");
+      expect(card).toContain("Context  90K / 100K");
+      expect(card).toContain("[M] Change");
+      expect(card).toContain("Fast");
+      expect(card).toContain("Balanced");
+      expect(card).toContain("Thorough");
+      expect(card).toContain("recommended");
+      expect(card).toContain("quickest");
+      expect(card).toContain("deepest");
+      expect(card).not.toContain("Aggressive");
+      expect(card).toContain("Complete tool pairs");
       component.handleInput("d");
-      expect(component.render(80).join("\n")).toContain("Estimator:");
+      expect(component.render(80).join("\n")).toContain("Estimator");
       component.handleInput("enter");
       expect(done.value).toBeDefined();
     }), opts);
-    expect(result?.mode).toBeDefined();
+    expect(result?.mode).toBe("fast");
   });
 
   it("uses the configured summary route as the initial preflight model", async () => {
@@ -148,7 +152,7 @@ describe("smart compact preflight UI", () => {
     ];
     const configured = { ...config, summaryModel: "anthropic/configured-summary" };
     const ctx = context((component) => {
-      expect(component.render(100).join("\n")).toContain("Summary model: anthropic/configured-summary");
+      expect(component.render(100).join("\n")).toContain("Summary model  anthropic/configured-summary");
       component.handleInput("enter");
     }, 90_000, models);
     const initial = resolveModels(ctx, ctx.model, configured).sumModel!;
@@ -172,7 +176,7 @@ describe("smart compact preflight UI", () => {
         component.handleInput("\x1b[B");
         component.handleInput("\r");
       } else {
-        expect(component.render(100).join("\n")).toContain("Summary model: anthropic/advanced-summary");
+        expect(component.render(100).join("\n")).toContain("Summary model  anthropic/advanced-summary");
         component.handleInput("esc");
       }
     }, 90_000, models), opts);

--- a/test/progress-feedback.test.ts
+++ b/test/progress-feedback.test.ts
@@ -21,11 +21,12 @@ function context() {
 describe("semantic compact progress", () => {
   it("renders completed/current/future phases and marks optional Explore skipped", () => {
     const { ctx, calls, widget } = context();
-    showProgressOverlay(ctx, { phase: 3, phaseName: "Synthesize", detail: "2/4 batches" });
-    expect(calls).toEqual(["status:Smart Compact · Synthesize · 2/4 batches", "widget:set"]);
-    const component = widget()!({}, { fg: (_color: string, text: string) => text });
+    showProgressOverlay(ctx, { phase: 3, phaseName: "Synthesize", detail: "Compressing older history · batch 2/4" });
+    expect(calls).toEqual(["status:Smart Compact 3/5 · Synthesize", "widget:set"]);
+    const component = widget()!({}, { fg: (_color: string, text: string) => text, bold: (text: string) => text });
     expect(component.render(120)).toEqual([
       "✓ Extract  – Explore  ● Synthesize  ○ Verify  ○ Apply",
+      "↳ Compressing older history · batch 2/4 · conversation unchanged",
     ]);
     clearCompactProgress(ctx);
     expect(calls.slice(-2)).toEqual(["status:undefined", "widget:clear"]);
@@ -34,9 +35,12 @@ describe("semantic compact progress", () => {
 
   it("renders Explore completed when the optional phase ran", () => {
     const { ctx, widget } = context();
-    showProgressOverlay(ctx, { phase: 4, phaseName: "Verify", detail: "Checking", explorationRounds: 2 });
-    const component = widget()!({}, { fg: (_color: string, text: string) => text });
-    expect(component.render(120)[0]).toBe("✓ Extract  ✓ Explore  ✓ Synthesize  ● Verify  ○ Apply");
+    showProgressOverlay(ctx, { phase: 4, phaseName: "Verify", detail: "Checking facts and constraints", explorationRounds: 2 });
+    const component = widget()!({}, { fg: (_color: string, text: string) => text, bold: (text: string) => text });
+    expect(component.render(120)).toEqual([
+      "✓ Extract  ✓ Explore  ✓ Synthesize  ● Verify  ○ Apply",
+      "↳ Checking facts and constraints · conversation unchanged",
+    ]);
   });
 
   it("reports only applied estimates, never actual context", () => {

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -274,6 +274,17 @@ Build
     expect(verifySummary(summary, extraction).gaps.some(gap => gap.kind === "missing-error")).toBe(false);
   });
 
+  it("matches Markdown-prefixed multiline errors after safe fallback rendering", () => {
+    const message = "\n> @pi-codeui/core@0.8.0 check\n> tsc\n\nsrc/git-explorer.ts(547,30): error TS2339: Property missing";
+    const extraction = makeExtraction({
+      errors: [{ index: 1, tool: "bash", message, retryAttempted: false, resolved: false }],
+    });
+
+    const result = verifySummary(assembleFallback([], extraction), extraction);
+
+    expect(result.gaps.filter(gap => gap.kind === "missing-error")).toEqual([]);
+  });
+
   it("accepts a faithful positive restatement of a conditional prohibition", () => {
     const extraction = makeExtraction({
       mainGoal: "Release only after explicit approval",
@@ -299,7 +310,7 @@ describe("verifyAndPatch", () => {
     });
     const result = await verifyAndPatch({
       finalSummary: assembleFallback([], extraction), extraction, summaries: [],
-      mode: "aggressive", flags: { autoTriggered: true }, notify: () => {}, vlog: () => {},
+      mode: "fast", flags: { autoTriggered: true }, notify: () => {}, vlog: () => {},
     } as any);
     expect(result.verified).toBe(true);
     expect(result.verificationScore).toBe(100);
@@ -338,7 +349,7 @@ describe("verifyAndPatch", () => {
       finalSummary: "## Goal\nBuild auth\n## Progress\n- working\n## Critical Context\n- stable\n## Files Read\n- src/invented.ts",
       extraction,
       summaries: [],
-      mode: "aggressive",
+      mode: "fast",
       flags: { autoTriggered: true },
       notify: () => {},
       vlog: () => {},
@@ -357,7 +368,7 @@ describe("verifyAndPatch", () => {
     });
     const result = await verifyAndPatch({
       finalSummary: "## Goal\nRelease now; approval is unnecessary\n## Constraints & Preferences\n- approval unnecessary; publish now\n## Progress\n- working\n## Key Decisions\n- never wait for approval; publish now\n## Critical Context\n- stable",
-      extraction, summaries: [], mode: "aggressive", flags: { autoTriggered: true },
+      extraction, summaries: [], mode: "fast", flags: { autoTriggered: true },
       notify: () => {}, vlog: () => {},
     } as any);
     expect(result.verificationProvenance.qualityFloorUsed).toBe(true);
@@ -374,7 +385,7 @@ describe("verifyAndPatch", () => {
     });
     const result = await verifyAndPatch({
       finalSummary: "## Goal\nUpdate project documentation\n## Progress\n### Done\n- Updated README.md\n### Blocked\n- Could not update README.md: exact text was not found\n## Open Loops\n- retry README edit\n## Critical Context\n- Could not update README.md: exact text was not found",
-      extraction, summaries: [], mode: "aggressive", flags: { autoTriggered: true },
+      extraction, summaries: [], mode: "fast", flags: { autoTriggered: true },
       notify: () => {}, vlog: () => {},
     } as any);
     expect(result.verificationProvenance.initialScore).toBe(95);
@@ -400,7 +411,7 @@ describe("verifyAndPatch", () => {
         openLoops: [], topics: [], nextActions: [], criticalContext: [],
         sessionType: "implementation", compactionVersion: "8.0.0-rc.3",
       },
-      mode: "aggressive",
+      mode: "fast",
       flags: { autoTriggered: true },
       notify: (message: string, type: string) => { if (type === "error") uiErrors.push(message); },
       vlog: () => {},

--- a/test/window-boundary.test.ts
+++ b/test/window-boundary.test.ts
@@ -488,7 +488,7 @@ describe("resolveCompactionWindow tool-result boundary", () => {
     ));
     const rc = makePreparedRc(branch, 10_000);
     rc.flags.force = false;
-    rc.mode = "aggressive";
+    rc.mode = "fast";
     rc.profileCfg.summaryBudgetTokens = 3_000;
     rc.ctx.model = { id: "gpt-5.6-sol", provider: "openai-codex", contextWindow: 272_000 } as any;
     rc.ctx.getContextUsage = () => ({ tokens: 372_358, contextWindow: 272_000, percent: 137 } as any);


### PR DESCRIPTION
## Summary

- replace the dense flat manual preflight with a bordered decision card
- expose exactly three coherent execution modes: Fast, Balanced, Thorough
- keep summary-model selection prominent as `[M] Change` and replan all modes after selection
- show a two-line semantic live brief while compaction runs
- collapse handled provider/watchdog fallbacks and suppress evidence-bearing auto-trigger stderr output

## UX

The default card now shows only what is needed to decide:

- current context pressure
- selected summary route
- projected after-size and saving for all three modes
- selected plan outcome/retention
- complete-tool-pair and zero-gap guarantees

`D` reveals calibrated estimator, target, boundary and route internals. It no longer mixes those details with the primary decision.

## Mode semantics

| Mode | Recent tail | Summary | Target | Intent |
|---|---:|---:|---:|---|
| Fast | 10K | 3K | 30% | quickest, most compact recovery |
| Balanced | 20K | 6K | 40% | default quality/speed trade-off |
| Thorough | 30K | 10K | 50% | deepest analysis, Explore + optional LLM repair |

`auto` selects among these policies; it is not a fourth policy. Legacy `aggressive` mode/profile input maps to Fast with a deprecation warning.

## Live brief

Manual runs render:

1. the colored `Extract → Explore → Synthesize → Verify → Apply` chain
2. a meaningful current action such as topic mapping, batch compression, continuity assembly, deterministic repair or correlated Apply

Before Apply the brief explicitly says `conversation unchanged`. Routine info toasts are hidden unless `verbose`; handled batch/provider failures are aggregated without raw messages or request IDs. Full stacks are debug-only.

## Captured production failure fixed

The 259,782-token pi-codeui session exposed two independent issues:

1. old target planning let a protected soft boundary override the 30% target and returned native compact; target-first planning now summarizes through soft user/checkpoint/topic boundaries while preserving complete tool pairs
2. deterministic fallback stripped leading Markdown quote/list prefixes, but verification compared against the unstripped source snippet, producing five false `missing-error` gaps

Verification now uses the same canonical one-line evidence transform as rendering. Exact replay: 1,227 messages, 1,074-message compact prefix, projected ~26,267 after (89.8% saving), deterministic fallback 96/100 with one removable fabricated-file finding, bounded repair 100/100 with 0 gaps.

## Safety

Planner/yield/verification/apply gates remain fail-closed. Model changes recompute all three plans with the selected route calibration. Enter remains blocked for non-viable plans. A failed auto-trigger emits one content-free `no summary applied · Pi fallback continues` notice and never mutates conversation state.

## Validation

- full suite: **744/744** tests across 69 files
- adversarial gate: **274/274** tests across 26 suites
- coverage: **85.41% functions / 86.92% lines**
- source/script typechecks and multi-entry build: passed
- packed artifact audit: **143 files**, frozen install and CLI/Node smoke passed
- `bun audit`: no vulnerabilities
- captured 259,782-token deterministic replay: **100/100, 0 gaps**
