### PR TITLE
fix: harden v8.0.7 continuity and release gates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -145,10 +145,10 @@ keeps chunked recovery instead of sending an oversized one-shot prompt to
 native summarization. Manual runs use the profile's absolute adaptive tail, so
 model-window size cannot turn an explicit command into a full-context no-op.
 
-Before summarization the pipeline also prunes redundant messages, serializes the
-compacted portion, creates a backup, loads the previous verified summary plus
-bounded continuity state, checks the incremental extraction cache, and loads
-the project fingerprint.
+Before summarization the pipeline serializes the full selected conversation,
+scrubs it, and writes that pre-prune backup; it then prunes redundant messages,
+loads the previous verified summary plus bounded continuity state, checks the
+incremental extraction cache, and loads the project fingerprint.
 
 ### Extract
 
@@ -197,8 +197,12 @@ open-loop coverage.
 idempotent) → (2) one LLM patch only in `thorough` mode if still insufficient
 → (3) replace lower-scoring output with the deterministic quality floor → (4)
 reject unless final verification has no gaps and meets the verified threshold.
-Final verification runs again after continuity injection. Unresolved-error
-source snippets and fallback-rendered evidence share `summaryEvidenceLine()`, so
+Final verification runs again after continuity injection. The final scalar is
+reported as repaired **verification coverage**, alongside the pre-repair source
+score and fallback provenance; it is not labeled as raw synthesis quality.
+Polarity checks are symmetric: adding negation to a positive fact is rejected
+just as removing negation from a prohibition is. Unresolved-error source
+snippets and fallback-rendered evidence share `summaryEvidenceLine()`, so
 Markdown prefixes and multiline wrapping cannot create false missing-error gaps.
 
 ## EESV hardening and control surfaces
@@ -206,7 +210,7 @@ Markdown prefixes and multiline wrapping cannot create false missing-error gaps.
 - **Canonical summary IR** accepts recognized H1/H2/H3 headings, preserves Progress subsections, and merges duplicate canonical kinds before state mutation.
 - **Typed verification gaps** drive mandatory deterministic repair; collision-aware path needles prevent basename cross-satisfaction. Provenance is persisted and shown before optional approval.
 - **Fine tool semantics** separate read/search/list/mutate/delete/execute operations. Pruning deduplicates only identical idempotent access signatures.
-- **Unified token planning** uses a run-bound estimator with bounded process-shared provider/model calibration, counts structured tool-call arguments, preserves an adaptive recent tail, targets mode-specific post-compaction headroom, and reserves/reconciles every request against the mode's aggregate prompt/output-token caps.
+- **Unified token planning** uses a run-bound estimator with bounded process-shared provider/model calibration, counts structured tool-call arguments, preserves an adaptive recent tail, targets mode-specific post-compaction headroom, reserves 25% of the synthesis allowance for deterministic post-summary state sections, and reserves/reconciles every request against the mode's aggregate prompt/output-token caps.
 - **Security boundaries** scrub high-confidence secrets before provider calls and durable cache/backup/state writes; PII scrubbing is opt-in.
 - **Policy controls** include focus weighting, exact call/latency budgets, fail-closed manual approval, online damage monitoring, and persisted open-loop overrides.
 - **Release gate** (`bun run gate`) covers adversarial parser, verification, tool, cache, budget, scrub and damage fixtures.
@@ -214,9 +218,10 @@ Markdown prefixes and multiline wrapping cannot create false missing-error gaps.
 ## State, caching & persistence
 
 Post-verification, `app/steps/state.ts` + `src/utils/state.ts` enrich the
-summary, then `domain/yield-gate.ts` measures the final replacement. Missing
-the planned target or 10% net-saving floor throws before a `StatedRc` can reach
-staging/apply. `session_before_compact` only stages a passing candidate; after
+summary, then `domain/yield-gate.ts` measures the final replacement. Planning
+has already reserved the bounded post-synthesis enrichment band by reducing the
+retained tail; missing the original target or 10% net-saving floor still throws
+before a `StatedRc` can reach staging/apply. `session_before_compact` only stages a passing candidate; after
 the host emits the matching `session_compact`, `app/steps/persist.ts` commits
 reusable state and success telemetry. Aborted/unconfirmed candidates write
 neither, and the UI reports `Applied` only after that correlated commit.
@@ -233,12 +238,13 @@ leaving one content-free safe-fallback notice in the UI.
 | Concern | Where | Notes |
 | --- | --- | --- |
 | Open-loop injection | `utils/state.ts` | inserted before Next Steps via the canonical parser |
-| `CompactionState` | `utils/state.ts` | conservatively merged and bounded; absence is not deletion |
-| Continuity Ledger | `utils/state.ts` | deterministic carry-forward of goal, decisions, constraints, unresolved errors, and loops |
+| `CompactionState` | `utils/state.ts` | conservatively merged and bounded across goal wording changes; newer file evidence resolves delete/present contradictions |
+| Continuity Ledger | `utils/state.ts` | prior facts carry forward until positive resolution evidence or an explicit override; goal shifts become non-destructive breadcrumbs |
 | Cross-compaction delta | `utils/state.ts` | "Changes Since Last Compaction" section |
-| Incremental extraction cache | `utils/cache.ts` + `utils/id-fingerprint.ts` | SHA-256 prefix fingerprint + tail; safe only when the pruned prefix still matches |
+| Incremental extraction cache | `utils/cache.ts` + `utils/id-fingerprint.ts` | bounded SHA-256 prefix fingerprint + tail; safe only when the pruned prefix still matches |
+| Synthesis cache | `infra/synthesis-cache.ts` | behavior key includes normalized focus, route, mode, budgets, and reasoning |
 | Session-log recovery | `utils/session-log.ts` | streaming JSONL parse; bypasses pi-toolkit truncation by entry-id mapping |
-| Project fingerprint | `utils/fingerprint.ts` | language / framework / key dirs across sessions |
+| Project fingerprint | `utils/fingerprint.ts` | locked read/merge/write; language/framework/key dirs stay bounded across sessions |
 | Damage detection | `utils/damage.ts` | best-effort post-compaction regression signals |
 | Context graph | `infra/context-graph.ts` | SQLite FTS5 facts + file edges; 2,000 non-structural nodes per project |
 
@@ -250,7 +256,11 @@ query/transaction contract to `bun:sqlite` in Bun tests and `node:sqlite`
 `DatabaseSync` in Pi's Node runtime; the packed release audit exercises both.
 The referenced queue timer survives extension
 shutdown/reload in the process; graph data is derived and a later cumulative
-state safely supersedes a missed update after a hard process kill. Recall starts from FTS5 lexical matches, expands one hop
+state safely supersedes a missed update after a hard process kill. Fact occurrences are branch-head scoped; state, recall, and resolution use the
+complete host-visible branch ancestry before equivalent facts are deduplicated.
+Schema v1 preserves user-confirmed manual memory but resets older derived
+compaction nodes once so sibling branches cannot inherit a last-writer identity.
+Recall starts from FTS5 lexical matches, expands one hop
 through file-reference edges, then applies session, branch, fact-kind,
 confidence, recency, and explicit-memory weights. Exact equivalent facts are
 deduplicated before bounded output. Resolved/superseded state is removed from
@@ -259,7 +269,7 @@ the active FTS index; another project's rows are never eligible.
 **Important retention limits:** pending in-memory compaction 5 min · exploration
 tool-support cache 1 h / 128 routes · token calibration 128 routes · extraction
 cache 1 h · compaction state 7 d · context graph 2,000 non-structural fact nodes
-per project · remediation hints 7 d · metrics and damage
+and 500 active manual memories per project · remediation hints 7 d · metrics and damage
 JSONL logs 5 MiB each.
 
 ## Concurrency & safety model
@@ -284,25 +294,24 @@ Session identity comes from [`infra/session-identity.ts`](./src/infra/session-id
 a real id when the host exposes one, otherwise a per-call unforgeable
 `unresolved:<uuid>` — two unresolved sessions can never collide.
 
-### Cancellation & hard timeout
+### Cancellation deadlines
 
 Some providers ignore `AbortSignal`. The auto-trigger therefore uses a shared
 [`ExternalCancellation`](./src/app/run-smart-compact.ts) handle as a second line
 of defense: an outer `setTimeout` fires `abort()` and sets `timedOut`, and every
 side-effect gate in the orchestrator checks that flag before writing state or
-applying compaction. No `Promise.race` is needed — the shared flag drives the
-bailout, eliminating the race where the outer timer fired while the pipeline was
-mid-`applyCompaction`.
+applying compaction. The caller waits for safe pipeline unwind; no unsafe
+`Promise.race` hard return can leave work running past the hook lifecycle.
 
 ### Filesystem & concurrency
 
-JSON/text cache writes use [`src/infra/fs.ts`](./src/infra/fs.ts): atomic
-temp-file + rename prevents half-truncated readers but intentionally does not
-claim fsync/power-loss durability. Append/trim operations use a `mkdir`-based
-cross-process lock and fail closed if ownership cannot be acquired, so sessions
-cannot interleave bytes. SQLite supplies its own WAL durability. Native
-continuity handoffs are 0600, one-shot, bounded, and keyed by project + session
-+ branch head.
+JSON/text cache writes use [`src/infra/fs.ts`](./src/infra/fs.ts): private
+artifact directories are 0700 and files are 0600; atomic temp-file + rename
+prevents half-truncated readers but intentionally does not claim fsync/power-loss
+durability. Append/trim operations use a `mkdir`-based cross-process lock and
+fail closed if ownership cannot be acquired, so sessions cannot interleave
+bytes. SQLite supplies its own WAL durability. Native continuity handoffs are
+one-shot, bounded, and keyed by project + session + branch head.
 
 ## Provider awareness
 
@@ -347,13 +356,14 @@ models.
 [`src/domain/telemetry.ts`](./src/domain/telemetry.ts) maps raw exceptions to a
 content-free failure taxonomy, aggregates schema-v2 run quality without IDs or
 conversation data, and compares an explicitly tagged `canary` cohort against
-`stable` history. A deterministic gate returns Hold, Rollback, or Promote from
-sample/quality coverage plus failure, verifier quality, p95 latency, token,
-heuristic-fallback, and post-compaction-damage thresholds. Damage observations
-join their originating compaction by local run id, dedupe per run, and require
-≥70% stable/canary coverage before promotion. It is deliberately
-advisory: rollout selection, configuration changes, and rollback remain
-external operations.
+`stable` history. Reports expose total/applied counts; only non-dry,
+host-confirmed applied outcomes count toward promotion. A deterministic green
+release check is not promotion evidence. The gate returns Hold, Rollback, or
+Promote from applied sample/quality coverage plus failure, verifier quality, p95
+latency, token, heuristic-fallback, and post-compaction-damage thresholds.
+Damage observations join their originating compaction by local run id, dedupe
+per run, and require ≥70% stable/canary coverage before promotion. It is
+advisory: rollout selection, configuration changes, and rollback remain external.
 
 Dashboard trust calculations live in
 [`src/ui/dashboard-insights.ts`](./src/ui/dashboard-insights.ts). Data
@@ -404,7 +414,6 @@ The code is organized into six layers, each with a single responsibility.
 | `app/run-context.ts` | typed stage chain (`RcBase → … → StatedRc`) |
 | `app/mode-policy.ts` | Auto selector and finite Fast/Balanced/Thorough policies; legacy Aggressive maps to Fast |
 | `app/pending-slot.ts` | encapsulated pending-compaction state cell |
-| `app/explore-wrap.ts` | thin re-export shim isolating the explore import for headless tests |
 | `app/steps/prepare.ts` | resolve config, auth, provider caps |
 | `app/steps/window.ts` | pick the prefix of messages to compact |
 | `app/steps/recover.ts` | recover full content for log-truncated messages |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 No changes yet.
 
+## [8.0.7] - 2026-08-08
+
+### Fixed
+
+- Window planning now reserves 25% of the LLM summary allowance for deterministic verification, delta, open-loop, and continuity sections added after synthesis. The reported `29,355t` versus `28,008t` near-target failure now plans a smaller retained tail and lands below the original hard target; the exact post-summary target gate and 10% minimum-saving floor remain fail-closed.
+- Auto risk refinement changes analysis depth without mutating the already-planned profile/output allowance, preventing a late Fast/Balanced/Thorough profile switch from invalidating the target contract. Manual preflight now scans and tokenizes the active branch once for all three mode previews.
+- Continuity now uses the latest substantive user request, parses host-compacted `Goal` sections, ignores acknowledgement-only turns, and treats free-form goal changes as non-destructive breadcrumbs. Prior errors, loops, next actions, and critical context remain active until positive resolution evidence or an explicit override; LLM goal paraphrases cannot silently resolve them.
+- Known transient provider/invocation diagnostics no longer become durable blockers, while project test failures that mention HTTP 429 remain real errors. Initial and merged open-loop state is capped with active, high-priority work ahead of resolved history.
+- File status follows newer successful access/mutation/delete evidence. Existing paths are removed from legacy `deletedFiles` state before persistence, eliminating the three false deletions observed in the v8.0.6 production run.
+- Context-graph facts now use branch-head occurrences and lineage-scoped resolution, preventing equivalent sibling-branch facts from overwriting or closing each other. Schema v1 preserves manual memories while resetting older derived compaction nodes once.
+- Release audit accepts both legacy-array and npm 12 object-shaped `npm pack --json` output, and the unsupported source-only Git install instruction was removed.
+- Result and approval UX now labels `100/100` as post-repair verification coverage, shows the raw source score, and explicitly identifies deterministic safety-fallback runs instead of presenting repaired coverage as raw synthesis quality.
+- Verification now rejects polarity changes symmetrically, and bounded absence never resolves continuity facts.
+- Backups contain the complete selected pre-prune conversation after scrubbing; private artifact directories/files enforce `0700`/`0600`.
+- Project memory fails closed when cwd is exactly HOME or the filesystem root, displays the complete scrubbed value for host confirmation, and caps active manual facts at 500 per project.
+- Continuity and context-graph resolution use full visible branch ancestry; focus participates in synthesis cache identity, and project fingerprints use bounded locked updates.
+- Canary reports total/applied runs and requires non-dry applied telemetry; deterministic green checks never imply `PROMOTE`.
+- Auto timeout remains a cancellation deadline that waits for safe pipeline unwind, and yield failures use the canonical `yield` telemetry kind.
+
 ## [8.0.6] - 2026-08-07
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,17 +23,18 @@ When making changes, prefer these priorities:
 ## Local setup
 
 ```bash
-bun install
-bun test
+bun install --frozen-lockfile
 bun run typecheck
+bun test
+bun run gate
 bun run build
-bun run compat:pi   # verify against latest host-provided Pi packages
+bun run release:audit
 ```
 
-The CI `verify` job runs `typecheck → test → build` on every pull request. A
-daily `pi-latest` job installs the latest Pi packages in an isolated temporary
-workspace and runs the same checks without changing the checkout. To probe an
-exact release locally, run `bun run compat:pi 0.80.6`.
+These are the exact CI `verify` commands. Scheduled/manual CI also runs
+`bun run compat:pi` against the latest host packages in an isolated workspace
+without changing the checkout. The contractually locked baseline is checked
+with `bun run compat:pi 0.84.0`.
 
 ## Repository map
 
@@ -85,9 +86,10 @@ Depending on the change, update the relevant docs:
 ### 4. Run validation before shipping
 
 ```bash
-bun run typecheck
-bun test
-bun run build
+bun run release:check
+bun run compat:pi 0.84.0
+bun run compat:pi latest
+bun audit
 ```
 
 ## Testing guidance
@@ -120,8 +122,8 @@ Before a release:
 
 1. sync `package.json` and `src/constants.ts` (`bun run sync-version`)
 2. update `CHANGELOG.md`
-3. rebuild `dist/`
-4. run tests + typecheck
+3. run `bun run release:check`
+4. run the locked and latest compatibility checks plus `bun audit`
 5. spot-check `README.md` for drift
 
 See [`docs/RELEASE.md`](./docs/RELEASE.md) for the full checklist.

--- a/README.md
+++ b/README.md
@@ -14,39 +14,44 @@
 Preserve the agent's **working state**—goals, files, decisions, errors,
 constraints, and open loops—not just a vague recap of the conversation.
 
+**Deterministic facts · fail-closed verification · branch-safe continuity · local-first privacy**
+
+[Install](#install) · [Why](#why-smart-compaction) · [Pipeline](#eesv-pipeline) · [Safety](#safety-and-privacy) · [Configuration](#configuration) · [Development](#development)
+
 </div>
 
 ## Install
+
+Requires the Pi Coding Agent on Node.js 22.19 or newer. The published extension
+uses Pi's host packages and does not bundle a second Pi runtime.
 
 ```bash
 pi install npm:pi-smart-compact
 ```
 
-Or install directly from GitHub:
-
-```bash
-pi install git:github.com/alpertarhan/pi-smart-compact
-```
+Then run `/smart-compact` for an explainable preflight before anything changes.
 
 ## Quick start
 
 ```bash
-/smart-compact                                         # explainable single-screen preflight
-/smart-compact auto                                    # adaptive default
-/smart-compact anthropic/claude-sonnet-4 fast         # direct model + mode
-/smart-compact balanced --focus=auth                   # preserve extra auth detail
-/smart-compact metrics                                 # text metrics report
-/smart-compact dashboard                               # interactive metrics dashboard
-/smart-compact restore                                 # browse and restore backups
-/smart-compact loops                                   # manage persisted open loops
+/smart-compact                                      # interactive preflight
+/smart-compact auto                                 # adaptive mode selection
+/smart-compact anthropic/claude-sonnet-4 fast      # explicit model + mode
+/smart-compact balanced --focus=auth                # preserve extra auth detail
+/smart-compact metrics                              # text metrics report
+/smart-compact dashboard                            # interactive dashboard
+/smart-compact restore                              # browse and restore backups
+/smart-compact loops                                # manage persisted open loops
 ```
 
-The extension also participates in Pi's native compaction flow automatically
-when actual context usage crosses the configured threshold (60% by default),
-and exposes `smart_compact`, `smart_recall`, and `smart_save_memory` tools for long-running agents.
+At 60% context usage by default, the extension also participates in Pi's native
+compaction flow. Long-running agents can call `smart_compact`, `smart_recall`,
+and `smart_save_memory` directly.
 
-> The tool path stages a safe pending summary. It never compacts the active
-> conversation in the middle of an agent turn.
+> [!IMPORTANT]
+> The tool path only stages a verified pending summary for Pi's next natural
+> compact. It never compacts the active conversation in the middle of an agent
+> turn.
 
 ## Why smart compaction?
 
@@ -92,12 +97,12 @@ Pi conversation
 
 - The current goal and user constraints
 - Modified, read, and deleted files
-- Unresolved **and** resolved error history
+- Unresolved **and** resolved error history; free-form goal changes never claim an unfixed error was resolved
 - Explicit and implicit decisions
 - Open follow-ups, blockers, priorities, and pinned loops
 - Next actions and critical continuation context
 - Changes since the previous compaction
-- A bounded **Continuity Ledger** carrying prior decisions, constraints, unresolved errors, and open loops until explicit resolution
+- A bounded **Continuity Ledger** carrying prior decisions, constraints, unresolved errors, and open loops across follow-ups and goal wording changes. Goal shifts are recorded as context; facts retire only through positive resolution evidence or an explicit override.
 
 Summaries use a canonical H1/H2/H3-aware structure, collision-safe file
 matching, typed verification gaps, and persisted repair provenance.
@@ -107,15 +112,19 @@ matching, typed verification gaps, and persisted repair provenance.
 Applied compactions also index their verified scoped state into a bounded,
 project-isolated SQLite FTS5 context graph. `smart_recall` searches goals,
 decisions, constraints, unresolved errors, open loops, files, and critical
-context across this project's sessions; same-session and same-branch evidence
-ranks first. File relationships add one-hop graph recall without an embedding
-service or extra LLM call.
+context across this project's sessions; recall and resolution use the complete
+visible branch ancestry, never sibling-branch state. File relationships add
+one-hop graph recall without an embedding service or extra LLM call.
 
 `smart_save_memory` persists or explicitly resolves one user-confirmed decision,
-constraint, preference, warning, procedure, or context fact. It rejects empty inputs,
-scrubs configured secrets/PII, deduplicates exact facts, and must not be used
-for guesses, transient progress, secrets, or code that is cheap to re-read.
-Set `contextGraphEnabled` to `false` to disable indexing and both tools.
+constraint, preference, warning, procedure, or context fact. It fails closed
+when the working directory is exactly `HOME` or the filesystem root, and
+requires an interactive confirmation showing the complete scrubbed title,
+content, and paths. Each project may have at most 500 active manual memories.
+It rejects empty inputs, scrubs configured secrets/PII, deduplicates exact facts,
+and must not be used for guesses, transient progress, secrets, or code that is
+cheap to re-read. Set `contextGraphEnabled` to `false` to disable indexing and
+both tools.
 
 ## Usage surfaces
 
@@ -132,8 +141,9 @@ The interactive command uses the configured summary route and exact execution
 planner before spending LLM tokens. Its compact decision card compares the
 three modes by estimated after-size and saving, highlights the recommendation,
 and keeps only the selected plan plus hard tool-pair/zero-gap guarantees in the
-primary view. Technical estimator, target, route, and boundary data stays under
-`D` instead of crowding the decision.
+primary view. The plan reserves 25% of the LLM summary allowance for verified
+state/delta/continuity sections added after synthesis. Technical estimator,
+target, route, and boundary data stays under `D` instead of crowding the decision.
 
 - `↑` / `↓` changes `Fast`, `Balanced`, or `Thorough` and recalculates the plan.
 - `Enter` runs only a viable plan; `Esc` cancels without mutation.
@@ -148,7 +158,10 @@ boundary: its older prefix is verified into the summary while the budgeted
 working tail stays raw. Tool exchanges are summarized or retained as complete
 call/result pairs, never split. If Verify, yield, provider, or native apply
 fails, the UI shows one bounded actionable line without evidence text or a
-JavaScript stack. Stack diagnostics are opt-in with `DEBUG=smart-compact`.
+JavaScript stack. A successful `100/100` is labeled **verification coverage**;
+the source score and deterministic/LLM/fallback provenance remain visible so
+repaired coverage is never presented as raw synthesis quality. Stack diagnostics
+are opt-in with `DEBUG=smart-compact`.
 During execution a two-line live brief shows the EESV phase chain and the
 meaningful current action; it states that the conversation remains unchanged
 until verified Apply. Routine phase toasts and raw per-batch watchdog/provider
@@ -169,7 +182,7 @@ brief. `verbose` restores routine phase notices; full stack diagnostics require
   does **not** attempt unsupported non-contiguous compaction.
 - `--max-calls` accepts `1–100`.
 - `--max-input-tokens` accepts `10000–1000000` aggregate prompt tokens.
-- `--max-latency` accepts `5000–600000` milliseconds as an explicit hard override; mode latency targets are otherwise soft.
+- `--max-latency` accepts `5000–600000` milliseconds as a cancellation deadline; cancellation waits for safe pipeline unwind before returning.
 - Budget exhaustion degrades to deterministic summaries instead of dropping context.
 
 The tool exposes equivalent `focus`, `max_calls`, `max_input_tokens`, and
@@ -189,7 +202,9 @@ not a fourth execution policy. Fast can use a zero-call deterministic summary
 when extraction confidence is high; otherwise it keeps the bounded LLM path.
 The mode token target is binding: recent user turns, pi-toolkit checkpoints,
 and topical grouping remain raw only when they fit the planned tail; otherwise
-the verified summary carries them forward.
+the verified summary carries them forward. Automatic risk refinement may deepen
+analysis/repair strategy after extraction, but it does not mutate the profile
+allowance or retention window that was already used to prove the target.
 
 Output caps stop subsequent calls after observed usage reaches the threshold.
 The ChatGPT Codex subscription endpoint rejects `max_output_tokens`,
@@ -238,15 +253,17 @@ Raw local JSONL remains available to the interactive dashboard, while
 `bun run telemetry-report` emits aggregate-only telemetry: no session/project
 IDs, prompts, summaries, paths, or error text. Failures use a stable taxonomy
 (cancelled, timeout, rate limit, authentication, budget, output limit,
-provider, persistence, validation, verification, internal). Verification failures
-retain only content-free score/count/gap-kind diagnostics.
+provider, persistence, validation, verification, **yield**, internal).
+Verification and yield failures retain only content-free diagnostics.
 
 Set `telemetryChannel` to `canary` only on the externally selected canary
-cohort. The report compares schema-v2 canary runs with the stable baseline and
-returns `HOLD`, `ROLLBACK`, or `PROMOTE`. Rollback triggers are: failure rate
+cohort. The report shows total/applied counts, but only non-dry, host-confirmed
+applied runs satisfy promotion evidence. A deterministic green check never
+implies `PROMOTE`; the report compares schema-v2 canary runs with the stable
+baseline and returns `HOLD`, `ROLLBACK`, or `PROMOTE`. Rollback triggers are: failure rate
 +5pp and ≥10%, verifier quality −5 points, p95 latency +50%, tokens +50%,
 heuristic fallback +10pp, or post-compaction damage +10pp. Promotion requires
-at least 20 canary runs, a stable baseline, ≥70% verifier-quality coverage,
+20 non-dry applied canary runs, a stable baseline, ≥70% verifier-quality coverage,
 ≥70% run-correlated damage-observation coverage in both cohorts, ≥85 absolute
 canary quality, and ≥95% success. The extension reports the decision; it never
 edits config or deploys automatically.
@@ -271,8 +288,9 @@ guidance for reaching the target.
 - Bounded fixed-point repair for patchable verification gaps, followed by a zero-gap deterministic quality floor
 - Cross-session guard and five-minute TTL for pending summaries
 - Session-log recovery for older, truncated tool results
-- Marker-owned retention-pruned backups before compaction; foreign files in a
-  custom directory are untouched
+- Full selected pre-prune conversation backups, scrubbed before a 0600 write;
+  marker-owned retention leaves foreign files in custom directories untouched
+- Private artifact directories are enforced as 0700 and files as 0600
 
 ### Secrets and PII
 
@@ -408,7 +426,7 @@ the run fails closed before staging or apply.
 | `summaryThinkingLevel` | `minimal \| low \| medium \| high \| xhigh \| max \| null` | `minimal` | Reasoning level for synthesis and repair; provider default when null |
 | `segmentationThinkingLevel` | `minimal \| low \| medium \| high \| xhigh \| max \| null` | `minimal` | Reasoning level for exploration; provider default when null |
 | `autoTrigger` | `boolean` | `true` | Participate in Pi's native compact hook |
-| `autoTriggerTimeoutMs` | `number` | `120000` | Hard timeout for automatic runs |
+| `autoTriggerTimeoutMs` | `number` | `120000` | Auto cancellation deadline; waits for safe pipeline unwind, never an unsafe hard return |
 | `minContextPercent` | `number` | `60` | Auto/tool context gate; manual `/smart-compact` warns and bypasses it |
 | `backupEnabled` | `boolean` | `true` | Write a pre-compaction backup |
 | `backupDir` | `string` | `~/.pi/agent/compact-backups` | Empty config value uses this path |
@@ -420,7 +438,7 @@ the run fails closed before staging or apply.
 | `maxLlmCalls` | integer `0–100` | `8` | Global ceiling combined with the selected mode |
 | `maxLlmInputTokens` | integer `0–1000000` | `0` | `0` uses the selected mode's aggregate prompt-token cap |
 | `codexMaxCallMs` | integer `0` or `5000–300000` | `0` | ChatGPT Codex per-call watchdog; `0` derives 15–90s from requested output tokens |
-| `maxLatencyMs` | `0` or `5000–600000` | `0` | `0` means unlimited |
+| `maxLatencyMs` | `0` or `5000–600000` | `0` | Pipeline cancellation deadline; `0` means unlimited |
 | `focusWeighting` | `boolean` | `true` | Weight focused topics/paths higher |
 | `zeroCallEnabled` | `boolean` | `true` | Use deterministic synthesis for high-confidence Fast runs |
 | `contextGraphEnabled` | `boolean` | `true` | Index verified state and enable project-scoped recall/save tools |
@@ -489,12 +507,15 @@ cancelled runs.
 <details>
 <summary><strong>Runtime artifacts</strong></summary>
 
-All files live under `~/.pi/agent/`.
+Default artifacts live under `~/.pi/agent/`. Smart Compact normalizes the
+private directories it creates to `0700` and its files to `0600`; a custom
+`backupDir` receives the same protection. `settings.json` remains host-owned
+and read-only to the extension.
 
 | Path | Purpose |
 | --- | --- |
 | `settings.json` | Configuration (read only) |
-| `compact-backups/` | Marker-owned retention-pruned conversation backups |
+| `compact-backups/` | Full selected pre-prune conversation backups, scrubbed before write and retention-pruned |
 | `.cache/compact-extraction-<session>.json` | Incremental extraction cache |
 | `.cache/compact-metrics.jsonl` | Tail-retained metrics log; 5 MiB cap |
 | `.cache/smart-compact-report.html` | Local HTML dashboard |
@@ -524,17 +545,15 @@ coordinate hook order or prefer a single automatic compaction owner.
 ## Development
 
 ```bash
-bun install
-bun run typecheck
-bun test
-bun run gate          # deterministic adversarial EESV release gate
+bun install --frozen-lockfile
+bun run release:check   # typecheck + tests + adversarial gate + build + package audit
 bun run bench
-bun run build
-bun run compat:pi     # isolated latest-Pi compatibility check
+bun run compat:pi       # isolated latest-Pi compatibility check
 ```
 
-Pull requests run typecheck, the complete test suite, the adversarial gate, and
-the build in GitHub Actions.
+Pull requests run the same deterministic checks in GitHub Actions. See
+[CONTRIBUTING.md](./CONTRIBUTING.md) for focused test commands and
+[docs/RELEASE.md](./docs/RELEASE.md) for publication and canary gates.
 
 ## Project documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Security fixes target the latest published version of `pi-smart-compact`.
 
 | Version | Supported |
 | --- | --- |
-| Latest `7.x` | ✅ |
+| Latest `8.x` | ✅ |
 | Older | ❌ |
 
 ## Reporting a vulnerability
@@ -33,5 +33,10 @@ Operational guidance:
 - Treat generated compaction summaries as potentially sensitive project context.
 - Review provider / model configuration before enabling auto-triggered compaction.
 
-Runtime artifacts are written under `~/.pi/agent/`; see the
-[runtime artifacts table](./README.md#runtime-artifacts) in the README.
+Runtime artifacts are written under `~/.pi/agent/`; private artifact
+directories are enforced as `0700` and files as `0600`. Pre-compaction backups
+contain the complete selected pre-prune conversation after configured
+secret/PII scrubbing. Project-memory writes fail closed when the working
+directory is exactly `HOME` or the filesystem root, require interactive
+confirmation of the complete scrubbed content, and are capped at 500 active manual facts per
+project. See the [runtime artifacts table](./README.md#runtime-artifacts).

--- a/docs/MIGRATING_TO_V8.md
+++ b/docs/MIGRATING_TO_V8.md
@@ -1,6 +1,6 @@
 # Migrating from v7 to v8
 
-This guide applies to the stable `8.0.6` release.
+This guide applies to the stable `8.0.7` release.
 
 ## Compatibility
 
@@ -34,10 +34,18 @@ the sanitized state. v8.0.3 keeps the same graph file and transparently opens it
 with `node:sqlite` under Pi or `bun:sqlite` in Bun tooling. v8.0.4 changes only
 compaction planning, UX, and privacy-safe operational metrics; v8.0.5 bounds
 user-facing failure diagnostics; v8.0.6 streamlines the three-mode decision card
-and live progress brief. None requires a state or database migration.
+and live progress brief. v8.0.7 reserves post-summary planning headroom,
+sanitizes known transient diagnostics, bounds active continuity before resolved
+history, and introduces branch-occurrence context-graph schema v1. On first graph
+open, user-confirmed manual memories remain; older derived compaction nodes are
+reset and repopulate from later apply-confirmed compactions.
 
-Facts remain conservative: absence from a new window is not deletion. A fact is
-removed only by an explicit resolved/superseded override.
+Facts remain conservative across follow-ups and free-form goal changes: bounded
+absence or new wording is never resolution. Goal shifts are retained as
+`Previous goal` context; errors and loops retire only through positive resolution
+evidence or an explicit override. Newer successful file access/mutation/delete
+evidence still resolves contradictory file status. State and graph resolution use
+the complete host-visible branch ancestry, not a truncated lineage or siblings.
 
 ### Persistent context graph
 
@@ -47,11 +55,14 @@ Applied, verified compactions are indexed into:
 ~/.pi/agent/.cache/smart-compact/context-graph.sqlite
 ```
 
-The database is local, project-partitioned, mode `0600` where supported, and
-bounded to 2,000 non-structural fact nodes per project. Apply-confirmed state is
-queued for the next event-loop turn so SQLite indexing is not part of the
-native compaction hook's latency. It enables
-`smart_recall` and confirmation-gated `smart_save_memory`. Set
+The database is local, project-partitioned, mode `0600`, and bounded to 2,000
+non-structural fact nodes per project. Private artifact directories are 0700 and
+files are 0600. Apply-confirmed state is queued for the next event-loop turn so
+SQLite indexing is not part of the native compaction hook's latency. It enables
+`smart_recall` and confirmation-gated `smart_save_memory`. Memory writes fail
+closed when the working directory is exactly `HOME` or the filesystem root; the
+interactive prompt shows the complete scrubbed memory and paths. A project may
+hold at most 500 active manual memories. Set
 `contextGraphEnabled` to `false` before first use to disable indexing and both
 tools. Disabling does not delete an existing database.
 
@@ -66,7 +77,9 @@ Consequently Data Confidence may start below 85 and rise as complete v8 runs
 replace legacy evidence.
 
 `telemetryChannel` defaults to `stable`. Use `canary` only on an externally
-selected canary installation; the extension reports Hold/Rollback/Promote but
+selected canary installation. Reports show total/applied runs, and only non-dry,
+host-confirmed applied outcomes count toward promotion; deterministic green
+checks do not imply `PROMOTE`. The extension reports Hold/Rollback/Promote but
 never deploys, edits configuration, or rolls itself back.
 
 ## New optional settings
@@ -85,10 +98,14 @@ All defaults preserve the selected model and require no migration edits.
 
 See the README configuration table for budgets and monitoring options.
 
-## Recommended rollout
+## Backups and rollout
+
+v8.0.7 backs up the complete selected pre-prune conversation after configured
+scrubbing, using 0600 files in a 0700 directory. Retention only prunes
+marker-owned backups.
 
 1. Back up `~/.pi/agent/settings.json` and the Smart Compact cache directory.
-2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.6`.
+2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.7`.
 3. Leave all model routes null initially.
 4. Keep `telemetryChannel: "stable"` unless intentionally running a separate
    canary cohort.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -26,10 +26,11 @@ bun install --frozen-lockfile
 bun run release:check
 ```
 
-`release:check` performs source + script typechecking, all tests, the adversarial
-EESV gate, the multi-entry build, package allowlist/denylist checks, a packed
-manifest/version/peer audit, an isolated install, a second frozen-lockfile
-install, extension/tool registration smoke, and packaged CLI smoke tests.
+`release:check` runs the expanded CI chain: source and scripts typechecking,
+all tests, the adversarial gate, build, and release audit. The audit verifies the
+packed manifest/version/peers, supported SECURITY major, package contents,
+isolated and frozen installs, extension/tool registration, Node SQLite, and
+packaged CLIs.
 
 Then validate the host boundary in an isolated workspace:
 
@@ -52,8 +53,8 @@ bun run telemetry-report --min-canary-runs=20
 
 Check that:
 
-- [ ] packed files are limited to `dist`, `docs`, README/license/support files,
-      and package metadata;
+- [ ] packed files are limited to `dist`, `docs`, README, LICENSE, CHANGELOG,
+      SECURITY, SUPPORT, ARCHITECTURE, and package metadata;
 - [ ] `dist/index.js`, declarations, and all three bundled CLIs are present;
 - [ ] the extension registers `smart_compact`, `smart_recall`, and
       `smart_save_memory` from the packed install;
@@ -74,10 +75,12 @@ After explicit approval to publish an RC, use the npm `next` tag rather than
 ```
 
 Keep all stage model routes null unless a separate routing decision is approved.
-Collect at least 20 schema-v2 canary runs, ≥70% verifier-quality coverage, and
-≥70% run-correlated damage-observation coverage in both stable and canary
-cohorts. Missing observations are missing evidence, never clean runs.
-Promotion requires:
+Collect at least 20 non-dry, host-confirmed **applied** schema-v2 canary runs,
+≥70% verifier-quality coverage, and ≥70% run-correlated damage-observation
+coverage in both stable and canary cohorts. Inspect the report's total/applied
+counts: dry runs and staged-but-unapplied runs are not promotion evidence.
+Missing observations are missing evidence, never clean runs. A deterministic
+green release check never implies `PROMOTE`. Promotion requires:
 
 - [ ] `telemetry-report` says `PROMOTE`;
 - [ ] dashboard Data Confidence is ≥85;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "8.0.6",
+  "version": "8.0.7",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "engines": {
@@ -40,6 +40,7 @@
     "dist",
     "docs",
     "README.md",
+    "ARCHITECTURE.md",
     "LICENSE",
     "CHANGELOG.md",
     "SECURITY.md",

--- a/scripts/release-audit-lib.ts
+++ b/scripts/release-audit-lib.ts
@@ -1,0 +1,7 @@
+export function getNpmPackFilename(result: unknown): string | null {
+  const entries = Array.isArray(result)
+    ? result
+    : result && typeof result === "object" ? Object.values(result) : [];
+  const filename = entries.find(entry => entry && typeof entry === "object" && typeof (entry as { filename?: unknown }).filename === "string");
+  return filename ? (filename as { filename: string }).filename : null;
+}

--- a/scripts/release-audit.ts
+++ b/scripts/release-audit.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { getNpmPackFilename } from "./release-audit-lib.ts";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const workspace = mkdtempSync(join(tmpdir(), "pi-smart-compact-release-"));
@@ -31,20 +32,32 @@ try {
   if (!constants.includes(`export const VERSION = "${sourceManifest.version}";`)) {
     throw new Error("package.json and src/constants.ts versions differ");
   }
+  const packageMajor = Number(sourceManifest.version.split(".")[0]);
+  if (!Number.isSafeInteger(packageMajor) || packageMajor < 0) {
+    throw new Error("package.json version has no numeric major");
+  }
+  const supportedMajor = `Latest \`${packageMajor}.x\``;
+  const securityPolicy = readFileSync(join(root, "SECURITY.md"), "utf8");
+  if (!securityPolicy.includes(supportedMajor)) {
+    throw new Error("SECURITY.md must advertise supported major as " + supportedMajor);
+  }
   for (const peer of ["@earendil-works/pi-ai", "@earendil-works/pi-coding-agent", "@earendil-works/pi-tui", "typebox"]) {
     if (sourceManifest.peerDependencies[peer] !== "*") throw new Error(peer + " must remain a wildcard peer");
   }
 
-  const packed = JSON.parse(run([
+  const packResult: unknown = JSON.parse(run([
     "npm", "pack", "--json", "--ignore-scripts", "--pack-destination", workspace,
-  ], root)) as Array<{ filename: string }>;
-  const tarball = join(workspace, packed[0]?.filename ?? "");
+  ], root));
+  const filename = getNpmPackFilename(packResult);
+  if (!filename) throw new Error("npm pack --json returned no filename");
+  const tarball = join(workspace, filename);
   const files = run(["tar", "-tzf", tarball]).trim().split("\n");
   const required = [
     "package/package.json", "package/dist/index.js", "package/dist/index.d.ts",
     "package/dist/provider-eval.js", "package/dist/provider-scenario-eval.js",
     "package/dist/telemetry-report.js", "package/README.md", "package/CHANGELOG.md",
-    "package/LICENSE", "package/docs/MIGRATING_TO_V8.md", "package/docs/RELEASE.md",
+    "package/LICENSE", "package/SECURITY.md", "package/SUPPORT.md", "package/ARCHITECTURE.md",
+    "package/docs/MIGRATING_TO_V8.md", "package/docs/RELEASE.md",
   ];
   for (const file of required) if (!files.includes(file)) throw new Error("packed artifact missing " + file);
   const forbidden = files.filter(file =>

--- a/src/app/explore-wrap.ts
+++ b/src/app/explore-wrap.ts
@@ -1,8 +1,0 @@
-/**
- * Thin re-export shim that lets `app/steps/synthesize.ts` reach the
- * exploration phase without importing through a deep path. Keeping the
- * indirection here means callers don't need to know whether the
- * implementation lives under `phases/` or some future `app/explore`.
- */
-
-export { exploreConversation, shouldExplore } from "../phases/explore.ts";

--- a/src/app/mode-policy.ts
+++ b/src/app/mode-policy.ts
@@ -11,7 +11,6 @@ export interface ModePolicy {
   allowLlmPatch: boolean;
   singlePassMultiplier: number;
   batchOutput: { min: number; perChunk: number; max: number };
-  softLatencyMs: number;
   targetContextPercent: number;
 }
 
@@ -19,17 +18,17 @@ export const MODE_POLICIES: Readonly<Record<EffectiveCompactionMode, ModePolicy>
   fast: {
     profile: "aggressive", maxLlmCalls: 3, maxInputTokens: 100_000, maxOutputTokens: 20_000,
     explore: false, allowLlmPatch: false, singlePassMultiplier: 2,
-    batchOutput: { min: 800, perChunk: 160, max: 2_400 }, softLatencyMs: 30_000, targetContextPercent: 30,
+    batchOutput: { min: 800, perChunk: 160, max: 2_400 }, targetContextPercent: 30,
   },
   balanced: {
     profile: "balanced", maxLlmCalls: 6, maxInputTokens: 200_000, maxOutputTokens: 40_000,
     explore: false, allowLlmPatch: false, singlePassMultiplier: 1.5,
-    batchOutput: { min: 1_000, perChunk: 250, max: 4_096 }, softLatencyMs: 60_000, targetContextPercent: 40,
+    batchOutput: { min: 1_000, perChunk: 250, max: 4_096 }, targetContextPercent: 40,
   },
   thorough: {
     profile: "light", maxLlmCalls: 8, maxInputTokens: 300_000, maxOutputTokens: 80_000,
     explore: true, allowLlmPatch: true, singlePassMultiplier: 0.9,
-    batchOutput: { min: 1_500, perChunk: 400, max: 6_000 }, softLatencyMs: 120_000, targetContextPercent: 50,
+    batchOutput: { min: 1_500, perChunk: 400, max: 6_000 }, targetContextPercent: 50,
   },
 };
 

--- a/src/app/preflight.ts
+++ b/src/app/preflight.ts
@@ -12,7 +12,9 @@ import { planCompactionWindow } from "./steps/window.ts";
 
 export function preflightDamageMedian(cwd: string, config: CompactConfig): number {
   if (!config.adaptiveDamageFeedback) return 0;
-  const recent = readRecentDamageScores(deriveProjectIdFromCwd(cwd), 5).slice(-3).sort((a, b) => a - b);
+  const projectId = deriveProjectIdFromCwd(cwd);
+  if (!projectId) return 0;
+  const recent = readRecentDamageScores(projectId, 5).slice(-3).sort((a, b) => a - b);
   return recent.length ? recent[Math.floor(recent.length / 2)] : 0;
 }
 
@@ -67,6 +69,47 @@ export interface ManualPreflight {
   overflowedContext: boolean;
 }
 
+export interface ManualPreflightContext {
+  branch: unknown[];
+  msgs: SessionMessageEntry[];
+  messageTokens: number[];
+  totalTokens: number;
+  rawEstimatedMessageTokens: number;
+  modelContextWindow?: number;
+  contextWindowTokens: number;
+  contextPercent: number;
+  toolPercent: number;
+  overflowedContext: boolean;
+}
+
+/** Mode-independent session scan shared by all three preview plans. */
+export function prepareManualPreflightContext(
+  ctx: ExtensionContext,
+  summaryModel: Model<Api>,
+  tokenCalibration: TokenCalibrationStore,
+): ManualPreflightContext {
+  const branch = (typeof ctx.sessionManager.buildContextEntries === "function"
+    ? ctx.sessionManager.buildContextEntries()
+    : ctx.sessionManager.getBranch()) as unknown[];
+  const msgs = branch.filter(
+    (entry): entry is SessionMessageEntry => (entry as { type?: string; message?: unknown }).type === "message"
+      && (entry as { message?: unknown }).message != null,
+  );
+  const totalTokens = ctx.getContextUsage()?.tokens ?? 0;
+  const modelContextWindow = ctx.model?.contextWindow;
+  const contextWindowTokens = modelContextWindow ?? 0;
+  const contextPercent = contextWindowTokens > 0 ? totalTokens / contextWindowTokens * 100 : 0;
+  const toolPercent = computeToolCharPercentage(branch);
+  const overflowedContext = contextWindowTokens > 0 && totalTokens > contextWindowTokens;
+  const estimator = makeTokenEstimator(summaryModel.provider, summaryModel.id, tokenCalibration);
+  const messageTokens = msgs.map(entry => estimator.message(entry.message as LlmMessage));
+  return {
+    branch, msgs, messageTokens, totalTokens,
+    rawEstimatedMessageTokens: messageTokens.reduce((sum, tokens) => sum + tokens, 0),
+    modelContextWindow, contextWindowTokens, contextPercent, toolPercent, overflowedContext,
+  };
+}
+
 export function planManualPreflight(
   ctx: ExtensionContext,
   summaryModel: Model<Api>,
@@ -74,20 +117,13 @@ export function planManualPreflight(
   tokenCalibration: TokenCalibrationStore,
   config: CompactConfig,
   damageMedian?: number,
+  shared: ManualPreflightContext = prepareManualPreflightContext(ctx, summaryModel, tokenCalibration),
 ): ManualPreflight {
   const prepared = preparePreflightProfile({ cwd: ctx.cwd, summaryModel, mode, tokenCalibration, config, damageMedian });
-  const manager = ctx.sessionManager;
-  const branch = typeof manager.buildContextEntries === "function" ? manager.buildContextEntries() : manager.getBranch();
-  const msgs = branch.filter(
-    (entry: { type: string; message?: unknown }) => entry.type === "message" && entry.message != null,
-  ) as SessionMessageEntry[];
-  const totalTokens = ctx.getContextUsage()?.tokens ?? 0;
-  const contextWindowTokens = ctx.model?.contextWindow ?? 0;
-  const contextPercent = contextWindowTokens > 0 ? totalTokens / contextWindowTokens * 100 : 0;
-  const toolPercent = computeToolCharPercentage(branch);
-  const overflowedContext = contextWindowTokens > 0 && totalTokens > contextWindowTokens;
-  const messageTokens = msgs.map(entry => prepared.estimator.message(entry.message as LlmMessage));
-  const rawEstimatedMessageTokens = messageTokens.reduce((sum, tokens) => sum + tokens, 0);
+  const {
+    branch, msgs, messageTokens, totalTokens, rawEstimatedMessageTokens,
+    modelContextWindow, contextWindowTokens, contextPercent, toolPercent, overflowedContext,
+  } = shared;
   if (msgs.length < 3) {
     return { mode, plan: null, reason: "not-enough-messages", profileCfg: prepared.profileCfg, totalTokens, rawEstimatedMessageTokens, estimatorScale: 1, adapted: prepared.adapted, damageMedian: prepared.damageMedian, contextWindowTokens, contextPercent, toolPercent, overflowedContext };
   }
@@ -96,7 +132,7 @@ export function planManualPreflight(
     branch: branch as unknown[],
     messageTokens,
     totalTokens,
-    modelContextWindow: ctx.model?.contextWindow,
+    modelContextWindow,
     mode,
     profileCfg: prepared.profileCfg,
     force: true,

--- a/src/app/steps/extract.ts
+++ b/src/app/steps/extract.ts
@@ -34,6 +34,7 @@ import { serializeConversation } from "@earendil-works/pi-coding-agent";
 import { asSerializableMessages } from "../../infra/ai-messages.ts";
 import { backupConversation } from "../../utils/helpers.ts";
 import { loadScopedCompactionState, renderContinuityCapsule } from "../../utils/state.ts";
+import { branchEntryIds } from "../../infra/session-identity.ts";
 
 export function extractWithCache(rc: TieredRc): ExtractedRc {
   const extractStepStart = Date.now();
@@ -44,7 +45,8 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
   // messages), so we let pruneRedundant build it; we then build a *second*
   // index over the pruned messages and store it on the RunContext for
   // extractors to reuse.
-  const pruning = pruneRedundant(rc.llmMessages);
+  const selectedMessages = rc.llmMessages;
+  const pruning = pruneRedundant(selectedMessages);
   const currentKeptEntryIds = pruning.keptIndices
     .map(i => currentEntryIds[i])
     .filter((id): id is string => typeof id === "string");
@@ -63,8 +65,13 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
   const extractionStart = pruneEnd;
   const convText = serializeConversation(asSerializableMessages(rc.llmMessages));
   const convTokens = rc.estimator.text(convText);
-
-  const backupPath = backupConversation(rc.services.scrubber.scrubText(convText).value, rc.sessionId);
+  let backupPath: string | null = null;
+  if (rc.config.backupEnabled) {
+    const unchanged = pruning.messages.length === selectedMessages.length
+      && pruning.messages.every((message, index) => message === selectedMessages[index]);
+    const backupText = unchanged ? convText : serializeConversation(asSerializableMessages(selectedMessages));
+    backupPath = backupConversation(rc.services.scrubber.scrubText(backupText).value, rc.sessionId);
+  }
   const prevContext = getPreviousCompactionContext(rc.branch);
 
   const cachedExt = loadCachedExtraction(rc.sessionId);
@@ -163,18 +170,19 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
   }
   const projectCtx = buildProjectContext(fingerprint);
   const manager = rc.ctx.sessionManager as { getBranch?: () => readonly { id?: string }[] } | undefined;
-  const fullBranch = manager?.getBranch ? Array.from(manager.getBranch()) : rc.branch as Array<{ id?: string }>;
-  const branchEntryIds = fullBranch.map(entry => entry.id).filter((id): id is string => typeof id === "string");
+  const fullBranch = manager?.getBranch ? manager.getBranch() : rc.branch as Array<{ id?: string }>;
+  const ancestryIds = branchEntryIds(fullBranch);
   const continuityScope = {
     schemaVersion: 2 as const,
     projectId,
     sessionId: rc.sessionId,
-    ...(branchEntryIds.length ? {
-      branchHeadId: branchEntryIds[branchEntryIds.length - 1],
-      branchAncestryIds: branchEntryIds.slice(-256),
+    ...(ancestryIds.length ? {
+      branchHeadId: ancestryIds[ancestryIds.length - 1],
+      // ponytail: full lineage grows state with branch length; add compact lineage storage only if measured size becomes material.
+      branchAncestryIds: ancestryIds,
     } : {}),
   };
-  const previousState = loadScopedCompactionState(continuityScope, branchEntryIds);
+  const previousState = loadScopedCompactionState(continuityScope, ancestryIds);
   const continuity = previousState ? renderContinuityCapsule(previousState) : "";
 
   const out = rc as TieredRc & {

--- a/src/app/steps/state.ts
+++ b/src/app/steps/state.ts
@@ -9,6 +9,8 @@
  * never write stale state when the native compact ultimately fails to apply.
  */
 
+import fs from "node:fs";
+import path from "node:path";
 import type { VerifiedRc, StatedRc } from "../run-context.ts";
 import { advance } from "../run-context.ts";
 import {
@@ -20,11 +22,12 @@ import {
 import { extractOpenLoops } from "../../utils/extraction.ts";
 import { readRemediationHints } from "../../utils/damage.ts";
 import type { SmartCompactDetails, OpenLoop, CompactionState } from "../../types.ts";
-import { VERSION } from "../../constants.ts";
+import { TRUNC, VERSION } from "../../constants.ts";
 import {
   verifySummary, repairSummaryDeterministically, formatVerificationGap, verificationFailureMessage, VerificationGateError,
 } from "../../phases/verify.ts";
 import { verifyCompactionYield } from "../../domain/yield-gate.ts";
+import { findSection, summaryEvidenceLine } from "../../domain/summary-parse.ts";
 
 export function buildState(rc: VerifiedRc): StatedRc {
   const extraction = rc.extraction;
@@ -71,9 +74,16 @@ export function buildState(rc: VerifiedRc): StatedRc {
   const currentState = buildCompactionState(
     extraction, managedLoops, rc.explorationReport, nextActions, criticalContextItems, loopOverrides,
   );
+  const summarizedGoal = summaryEvidenceLine(findSection(summary, "goal")?.body ?? "", TRUNC.MESSAGE);
   currentState.scope = rc.continuityScope;
   currentState.factOverrides = prevState?.factOverrides ?? [];
   let compactionState = mergeCompactionStates(prevState, currentState);
+  // Positive filesystem evidence resolves legacy/cache false deletions. Missing
+  // or unresolvable paths remain conservative and continue to be preserved.
+  compactionState.deletedFiles = compactionState.deletedFiles.filter(file => {
+    const candidate = path.isAbsolute(file) ? file : path.resolve(rc.ctx.cwd, file);
+    return !fs.existsSync(candidate);
+  });
   if (preserve.length > 0) {
     compactionState.readFiles = Array.from(new Set([...preserve, ...compactionState.readFiles])).slice(0, 100);
   }
@@ -94,6 +104,11 @@ export function buildState(rc: VerifiedRc): StatedRc {
       );
     }
   }
+
+  // Goal text in the verified summary may be an LLM paraphrase. Persist it so
+  // the next host-compacted Goal matches, but never use it as resolution proof
+  // or delta evidence for task-scoped facts.
+  if (summarizedGoal && currentState.goal) compactionState.goal = summarizedGoal;
 
   const continuity = renderContinuityCapsule(compactionState, undefined, summary);
   if (continuity) summary = summary.trimEnd() + "\n\n" + continuity;

--- a/src/app/steps/synthesize.ts
+++ b/src/app/steps/synthesize.ts
@@ -20,9 +20,9 @@
 
 import type { ChunkSummary, TopicBoundary } from "../../types.ts";
 import { showProgressOverlay } from "../../ui/overlays.ts";
-import { exploreConversation, shouldExplore } from "../explore-wrap.ts";
+import { exploreConversation, shouldExplore } from "../../phases/explore.ts";
 import { chunkLlmMessages, singlePassCompact, summarizeBatch, assembleLLM, assembleFallback, failedChunkSummary } from "../../phases/synthesize.ts";
-import { MAX_EXPLORATION_ROUNDS, PROFILES } from "../../constants.ts";
+import { MAX_EXPLORATION_ROUNDS } from "../../constants.ts";
 import {
   batchOutputLimit, continuityRisk, deterministicExtractionConfidence, effectiveBudget,
   MODE_POLICIES, modeFromLegacyProfile, resolveMode,
@@ -47,21 +47,17 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
       continuityRisk(rc.previousState) + (rc.adapted ? 12 : 0),
     );
     if (refined !== rc.mode) {
-      const oldBase = { ...PROFILES[rc.profile], ...(rc.config.profiles?.[rc.profile] ?? {}) };
-      const keepScale = rc.profileCfg.keepRecentTokens / oldBase.keepRecentTokens;
-      const summaryScale = rc.profileCfg.summaryBudgetTokens / oldBase.summaryBudgetTokens;
       rc.mode = refined;
-      rc.profile = MODE_POLICIES[refined].profile;
-      rc.profileCfg = { ...PROFILES[rc.profile], ...(rc.config.profiles?.[rc.profile] ?? {}) };
-      rc.profileCfg.keepRecentTokens = Math.round(rc.profileCfg.keepRecentTokens * keepScale);
-      rc.profileCfg.summaryBudgetTokens = Math.round(rc.profileCfg.summaryBudgetTokens * summaryScale);
       const policy = MODE_POLICIES[refined];
       rc.services.budget.setLimits(
         rc.maxLlmCalls ?? effectiveBudget(rc.config.maxLlmCalls, policy.maxLlmCalls),
         rc.maxLlmInputTokens ?? effectiveBudget(rc.config.maxLlmInputTokens, policy.maxInputTokens),
         policy.maxOutputTokens,
       );
-      rc.notify("Auto mode selected " + refined + " from deterministic session risk", "info");
+      // The retention window and output allowance were already planned before
+      // extraction. Refine strategy depth only; changing profileCfg here would
+      // invalidate the target contract that the yield gate later enforces.
+      rc.notify("Auto strategy refined to " + refined + " within the planned " + rc.profile + " window", "info");
     }
   }
   const pc = rc.profileCfg;
@@ -73,12 +69,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
     if (!rc.flags.autoTriggered) showProgressOverlay(rc.ctx, {
       phase: 3, phaseName: "Synthesize", detail: "Reusing the cached continuation summary · no LLM call",
     });
-    const hit = rc as ExtractedRc & {
-      _synthesized: true; finalSummary: string; method: "eesv" | "single-pass" | "heuristic";
-      methodForMetrics: string; llmCalls: number; summaries: ChunkSummary[];
-      explorationReport: import("../../types.ts").ExplorationReport | null;
-      explorationRounds: number; chunkCount: number;
-    };
+    const hit = advance<ExtractedRc, SynthesizedRc>(rc, "_synthesized");
     hit.finalSummary = cached.finalSummary;
     hit.method = cached.method;
     hit.methodForMetrics = cached.method + "-cache";
@@ -88,7 +79,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
     hit.explorationRounds = cached.explorationRounds;
     hit.chunkCount = cached.chunkCount;
     markMeasuredPhase(hit, "synthesize", synthPhaseStart);
-    return advance<ExtractedRc, SynthesizedRc>(hit, "_synthesized");
+    return hit;
   }
   const zeroCall = rc.config.zeroCallEnabled !== false
     && rc.mode === "fast"
@@ -107,11 +98,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
       explorationRounds: 0, chunkCount: 0,
     });
     rc.notify("Zero-call deterministic compaction (high-confidence extraction)", "info");
-    const deterministic = rc as ExtractedRc & {
-      _synthesized: true; finalSummary: string; method: "heuristic"; methodForMetrics: string;
-      llmCalls: number; summaries: ChunkSummary[];
-      explorationReport: null; explorationRounds: number; chunkCount: number;
-    };
+    const deterministic = advance<ExtractedRc, SynthesizedRc>(rc, "_synthesized");
     deterministic.finalSummary = finalSummary;
     deterministic.method = "heuristic";
     deterministic.methodForMetrics = "zero-call";
@@ -121,7 +108,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
     deterministic.explorationRounds = 0;
     deterministic.chunkCount = 0;
     markMeasuredPhase(deterministic, "synthesize", synthPhaseStart);
-    return advance<ExtractedRc, SynthesizedRc>(deterministic, "_synthesized");
+    return deterministic;
   }
   const shouldSkipExplore = !policy.explore;
   // convText was computed and cached on `rc` in extractWithCache to avoid a
@@ -365,17 +352,7 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
     method = "eesv";
   }
 
-  const out = rc as ExtractedRc & {
-    _synthesized: true;
-    finalSummary: string;
-    method: "eesv" | "single-pass" | "heuristic";
-    methodForMetrics: string;
-    llmCalls: number;
-    summaries: ChunkSummary[];
-    explorationReport: import("../../types.ts").ExplorationReport | null;
-    explorationRounds: number;
-    chunkCount: number;
-  };
+  const out = advance<ExtractedRc, SynthesizedRc>(rc, "_synthesized");
   out.finalSummary = finalSummary;
   out.method = method;
   out.methodForMetrics = method;
@@ -391,6 +368,6 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
     finalSummary, method, summaries, explorationReport, explorationRounds, chunkCount,
   });
   markMeasuredPhase(out, "synthesize", synthPhaseStart);
-  return advance<ExtractedRc, SynthesizedRc>(out, "_synthesized");
+  return out;
 }
 

--- a/src/app/steps/window.ts
+++ b/src/app/steps/window.ts
@@ -8,7 +8,7 @@ import type { EffectiveCompactionMode, LlmMessage, ProfileConfig, SessionMessage
 import { MODE_POLICIES, modeFromLegacyProfile } from "../mode-policy.ts";
 import { advancePastToolCallBoundary, guardToolCallBoundary, smartKeepBoundaryCandidates } from "../../utils/helpers.ts";
 import { resolveSessionId } from "../../infra/session-identity.ts";
-import { MIN_COMPACTION_SAVING_RATIO } from "../../constants.ts";
+import { MIN_COMPACTION_SAVING_RATIO, POST_SUMMARY_RESERVE_RATIO } from "../../constants.ts";
 
 export type { CompactionWindowPlan } from "../run-context.ts";
 
@@ -22,6 +22,18 @@ export interface CompactionWindowPlanInput {
   profileCfg: ProfileConfig;
   force: boolean;
   overflowedContext: boolean;
+}
+
+/** Canonical user-facing wording for every planner outcome. */
+export function compactionPlanReasonText(reason: CompactionPlanReason): string {
+  switch (reason) {
+    case "viable": return "safe window and useful estimated saving";
+    case "no-eligible-prefix": return "no older prefix is available";
+    case "unsafe-tool-boundary": return "no complete tool-call boundary is available";
+    case "retention-target-exceeded": return "a complete tool pair exceeds the tail target";
+    case "mode-target-not-met": return "the estimated result misses this preset's target";
+    case "insufficient-projected-saving": return "estimated saving is below 10%";
+  }
 }
 
 /** Pure, content-free result suitable for both execution and a later UI preview. */
@@ -38,8 +50,12 @@ export function planCompactionWindow(input: CompactionWindowPlanInput): Compacti
     ? Math.min(profileCfg.keepRecentTokens * 2, Math.max(profileCfg.keepRecentTokens, modelContextWindow * 0.04))
     : profileCfg.keepRecentTokens;
   const targetPercent = MODE_POLICIES[mode].targetContextPercent;
+  // Verification, delta, open-loop, and continuity sections are injected after
+  // the LLM's output cap. Reserve their observed upper band in the plan instead
+  // of loosening the post-summary target gate.
+  const postSummaryReserveTokens = Math.ceil(profileCfg.summaryBudgetTokens * POST_SUMMARY_RESERVE_RATIO);
   const targetRetainedTokens = modelContextWindow
-    ? Math.max(0, modelContextWindow * targetPercent / 100 - fixedContextTokens - profileCfg.summaryBudgetTokens)
+    ? Math.max(0, modelContextWindow * targetPercent / 100 - fixedContextTokens - profileCfg.summaryBudgetTokens - postSummaryReserveTokens)
     : adaptiveKeepTokens;
   const retentionCeiling = force ? adaptiveKeepTokens : Math.max(adaptiveKeepTokens, targetRetainedTokens);
   const rawMinimumTail = adaptiveKeepTokens / messageScale;
@@ -94,12 +110,12 @@ export function planCompactionWindow(input: CompactionWindowPlanInput): Compacti
   hardBoundaryAdjusted ||= keepFrom !== boundaryBeforeHardGuard;
   const compactTokens = Math.round(messageTokens.slice(0, keepFrom).reduce((sum, tokens) => sum + tokens, 0) * messageScale);
   const retainedTokens = retainedAt(keepFrom);
-  const projectedAfterTokens = fixedContextTokens + retainedTokens + profileCfg.summaryBudgetTokens;
+  const projectedAfterTokens = fixedContextTokens + retainedTokens + profileCfg.summaryBudgetTokens + postSummaryReserveTokens;
   const projectedSavedTokens = Math.max(0, totalTokens - projectedAfterTokens);
   const projectedYield = totalTokens > 0 ? projectedSavedTokens / totalTokens : 0;
   const targetAfterTokens = !force && modelContextWindow
     ? modelContextWindow * targetPercent / 100
-    : fixedContextTokens + effectiveRetentionCeiling + profileCfg.summaryBudgetTokens;
+    : fixedContextTokens + effectiveRetentionCeiling + profileCfg.summaryBudgetTokens + postSummaryReserveTokens;
 
   let reason: CompactionPlanReason = "viable";
   if ((msgs[keepFrom]?.message as { role?: string } | undefined)?.role === "toolResult") reason = "unsafe-tool-boundary";
@@ -154,16 +170,7 @@ export function resolveCompactionWindow(rc: PreparedRc): WindowedRc | null {
 
   if (!plan.viable) {
     if (rc.flags.force) {
-      const detail = plan.reason === "insufficient-projected-saving"
-        ? "projected saving is below 10%."
-        : plan.reason === "unsafe-tool-boundary"
-          ? "no safe tool-call boundary is available."
-          : plan.reason === "no-eligible-prefix"
-            ? "no eligible prefix remains."
-            : plan.reason === "retention-target-exceeded"
-              ? "a complete tool pair exceeds the retention target."
-              : "the projected context remains above the mode target.";
-      rc.notify("Manual compaction skipped: " + detail, "warning");
+      rc.notify("Manual compaction skipped: " + compactionPlanReasonText(plan.reason) + ".", "warning");
     } else {
       rc.notify("Smart compact skipped: the safe plan cannot meet its target; using native compaction instead.", "warning");
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,10 +10,19 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "8.0.6";
+export const VERSION = "8.0.7";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.10;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;
+/** Space reserved in the window plan for deterministic verification/state sections added after LLM synthesis. */
+export const POST_SUMMARY_RESERVE_RATIO = 0.25;
+
+/** Positive per-run bounds shared by CLI and tool arguments; config separately allows 0 as a mode-derived sentinel. */
+export const BUDGET_LIMITS = {
+  CALLS: { min: 1, max: 100 },
+  INPUT_TOKENS: { min: 10_000, max: 1_000_000 },
+  LATENCY_MS: { min: 5_000, max: 600_000 },
+} as const;
 
 export const COMPACT_SYSTEM_PREFIX =
   "You are an expert conversation summarizer for a coding agent. " +

--- a/src/domain/telemetry.ts
+++ b/src/domain/telemetry.ts
@@ -12,6 +12,7 @@ export interface DamageTelemetryEntry {
 
 export interface TelemetryWindowStats {
   runs: number;
+  appliedRuns: number;
   successRate: number;
   avgQuality: number | null;
   qualityCoverage: number;
@@ -102,10 +103,10 @@ function p95(values: number[]): number {
 }
 
 function stats(entries: CompactMetricsEntry[], damage: readonly DamageTelemetryEntry[]): TelemetryWindowStats {
-  const successes = entries.filter(entry => entry.status === "success" || entry.status === "dry-run");
-  const quality = successes.filter(entry => typeof entry.verificationScore === "number");
-  const appliedRuns = entries.filter(entry => entry.status === "success");
-  const appliedRunIds = new Set(appliedRuns
+  const evidence = entries.filter(entry => entry.status !== "dry-run");
+  const successfulRuns = evidence.filter(entry => entry.status === "success");
+  const quality = successfulRuns.filter(entry => typeof entry.verificationScore === "number");
+  const appliedRunIds = new Set(successfulRuns
     .filter(entry => typeof entry.runId === "string" && entry.runId.length >= 8)
     .map(entry => entry.runId!));
   const observedScores = new Map<string, number>();
@@ -120,19 +121,20 @@ function stats(entries: CompactMetricsEntry[], damage: readonly DamageTelemetryE
   const damaging = [...observedScores.values()].filter(score => score > 0).length;
   return {
     runs: entries.length,
-    successRate: entries.length ? successes.length / entries.length : 0,
+    appliedRuns: evidence.length,
+    successRate: evidence.length ? successfulRuns.length / evidence.length : 1,
     avgQuality: quality.length ? quality.reduce((sum, entry) => sum + (entry.verificationScore ?? 0), 0) / quality.length : null,
-    qualityCoverage: entries.length ? quality.length / entries.length : 0,
-    p95LatencyMs: p95(entries.map(entry => entry.durationMs ?? entry.avgLatency).filter(Number.isFinite)),
-    avgTokens: entries.length ? entries.reduce((sum, entry) =>
-      sum + entry.totalInput + entry.totalCacheHit + (entry.totalCacheWrite ?? 0) + entry.totalOutput, 0) / entries.length : 0,
-    fallbackRate: entries.length ? entries.filter(entry =>
+    qualityCoverage: evidence.length ? quality.length / evidence.length : 0,
+    p95LatencyMs: p95(evidence.map(entry => entry.durationMs ?? entry.avgLatency).filter(Number.isFinite)),
+    avgTokens: evidence.length ? evidence.reduce((sum, entry) =>
+      sum + entry.totalInput + entry.totalCacheHit + (entry.totalCacheWrite ?? 0) + entry.totalOutput, 0) / evidence.length : 0,
+    fallbackRate: evidence.length ? evidence.filter(entry =>
       entry.method === "heuristic" || (Array.isArray(entry.providerRoutes) && entry.providerRoutes.some(route => route.successes < route.calls)),
-    ).length / entries.length : 0,
+    ).length / evidence.length : 0,
     damageRate: observedScores.size ? damaging / observedScores.size : 0,
     // Missing correlation ids are missing evidence, not silently excluded
     // from the denominator.
-    damageCoverage: appliedRuns.length ? observedScores.size / appliedRuns.length : 0,
+    damageCoverage: successfulRuns.length ? observedScores.size / successfulRuns.length : 0,
   };
 }
 
@@ -170,7 +172,7 @@ export function assessCanary(
   const triggers: CanaryTrigger[] = [];
   const failureBaseline = 1 - baseline.successRate;
   const failureCanary = 1 - canary.successRate;
-  if (canary.runs >= 3 && (failureCanary > 0.050_001 || failureCanary - failureBaseline >= 0.050_001)) {
+  if (canary.appliedRuns >= 3 && (failureCanary > 0.050_001 || failureCanary - failureBaseline >= 0.050_001)) {
     triggers.push({
       metric: "failure-rate", baseline: failureBaseline, canary: failureCanary,
       threshold: failureCanary > 0.050_001 ? ">5% absolute" : "+5pp regression",
@@ -196,21 +198,23 @@ export function assessCanary(
     triggers.push({ metric: "damage", baseline: baseline.damageRate, canary: canary.damageRate, threshold: "+10pp" });
   }
 
+  const canarySampleAdequacy = Math.min(1, canary.appliedRuns / minCanaryRuns);
+  const baselineSampleAdequacy = Math.min(1, baseline.appliedRuns / Math.max(20, minCanaryRuns));
   const dataConfidence = Math.round(100 * (
-    Math.min(1, canary.runs / minCanaryRuns) * 0.25
-    + Math.min(1, baseline.runs / Math.max(20, minCanaryRuns)) * 0.15
-    + canary.qualityCoverage * 0.2
-    + canary.damageCoverage * 0.2
-    + baseline.damageCoverage * 0.2
+    canarySampleAdequacy * 0.25
+    + baselineSampleAdequacy * 0.15
+    + canary.qualityCoverage * canarySampleAdequacy * 0.2
+    + canary.damageCoverage * canarySampleAdequacy * 0.2
+    + baseline.damageCoverage * baselineSampleAdequacy * 0.2
   ));
   const reasons: string[] = [];
   let decision: CanaryAssessment["decision"] = "hold";
-  if (triggers.length && canary.runs >= 3) {
+  if (triggers.length && canary.appliedRuns >= 3) {
     decision = "rollback";
     reasons.push(...triggers.map(trigger => trigger.metric + " crossed " + trigger.threshold));
-  } else if (canary.runs < minCanaryRuns) {
-    reasons.push("need " + (minCanaryRuns - canary.runs) + " more canary runs");
-  } else if (baseline.runs < Math.max(20, minCanaryRuns)) {
+  } else if (canary.appliedRuns < minCanaryRuns) {
+    reasons.push("need " + (minCanaryRuns - canary.appliedRuns) + " more canary runs with applied outcomes");
+  } else if (baseline.appliedRuns < Math.max(20, minCanaryRuns)) {
     reasons.push("stable baseline is too small");
   } else if (canary.qualityCoverage < 0.7) {
     reasons.push("schema-v2 quality coverage is below 70%");
@@ -242,10 +246,14 @@ function safeMetricLabel(value: unknown, fallback: string): string {
   return value;
 }
 
-const FAILURE_KINDS = new Set<TelemetryFailureKind>([
+export const TELEMETRY_FAILURE_KINDS: ReadonlySet<TelemetryFailureKind> = new Set([
   "cancelled", "timeout", "rate-limit", "authentication", "budget",
   "output-limit", "provider", "persistence", "validation", "verification", "yield", "internal",
 ]);
+
+export function isTelemetryFailureKind(value: unknown): value is TelemetryFailureKind {
+  return typeof value === "string" && TELEMETRY_FAILURE_KINDS.has(value as TelemetryFailureKind);
+}
 
 export function buildPrivacySafeTelemetry(
   entries: readonly CompactMetricsEntry[],
@@ -279,7 +287,7 @@ export function buildPrivacySafeTelemetry(
     group.input += entry.totalInput + entry.totalCacheHit + (entry.totalCacheWrite ?? 0);
     group.output += entry.totalOutput;
     groups.set(key, group);
-    if (entry.failureKind && FAILURE_KINDS.has(entry.failureKind)) {
+    if (isTelemetryFailureKind(entry.failureKind)) {
       failures[entry.failureKind] = (failures[entry.failureKind] ?? 0) + 1;
     }
   }
@@ -324,7 +332,7 @@ export function formatPrivacySafeTelemetry(report: PrivacySafeTelemetry): string
   lines.push(
     "| Gate | Stable baseline | Canary |",
     "|---|---:|---:|",
-    "| Runs | " + baseline.runs + " | " + canary.runs + " |",
+    "| Runs (total/applied) | " + baseline.runs + "/" + baseline.appliedRuns + " | " + canary.runs + "/" + canary.appliedRuns + " |",
     "| Success | " + Math.round(baseline.successRate * 100) + "% | " + Math.round(canary.successRate * 100) + "% |",
     "| Verify quality | " + (baseline.avgQuality ?? "n/a") + " | " + (canary.avgQuality ?? "n/a") + " |",
     "| p95 duration | " + baseline.p95LatencyMs + "ms | " + canary.p95LatencyMs + "ms |",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { StringEnum, type Model, type Api } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import type { CompactionMode, CompressionProfile, PendingCompaction } from "./types.ts";
 import { modeFromLegacyProfile } from "./app/mode-policy.ts";
-import { VERSION, MIN_TOKEN_THRESHOLD, CONFIG_KEY, CONFIG_KEY_ALT, FIVE_MINUTES_MS } from "./constants.ts";
+import { VERSION, MIN_TOKEN_THRESHOLD, CONFIG_KEY, CONFIG_KEY_ALT, FIVE_MINUTES_MS, BUDGET_LIMITS } from "./constants.ts";
 import { loadConfig, extractUserNote, listBackups, readBackupContent, buildRestoreMessage } from "./utils/helpers.ts";
 import { getProviderCaps } from "./utils/tokens.ts";
 import { appendMetricsSnapshot, readMetricsLog } from "./utils/cache.ts";
@@ -17,7 +17,7 @@ import { buildLocalDashboardInsights, buildMetricsReport, writeMetricsDashboard 
 import { runSmartCompact } from "./app/run-smart-compact.ts";
 import { clearCompactProgress, notifyAppliedCompaction, showCompactUI, showMetricsDashboardUI, showRestorePicker, showBackupViewer, showRestoreAction, showOpenLoopsUI } from "./ui/overlays.ts";
 import { formatCompactErrorForUi } from "./ui/error-format.ts";
-import { resolveSessionId, isUnresolvedSessionId } from "./infra/session-identity.ts";
+import { branchEntryIds, resolveSessionId, isUnresolvedSessionId } from "./infra/session-identity.ts";
 import { createPendingSlot, type PendingSlot, type ConsumeResult } from "./app/pending-slot.ts";
 import { createSessionRunLock } from "./app/session-run-lock.ts";
 import { commitAppliedCompaction } from "./app/steps/persist.ts";
@@ -105,15 +105,15 @@ export function resolveModels(
 }
 
 function resolveGraphScope(ctx: ExtensionContext): ContextGraphScope | null {
+  const projectId = deriveProjectIdFromCwd(ctx.cwd);
   const sessionId = resolveSessionId(ctx);
-  if (isUnresolvedSessionId(sessionId)) return null;
-  const branchEntryIds = (ctx.sessionManager.getBranch() as Array<{ id?: string }>)
-    .map(entry => entry.id).filter((id): id is string => typeof id === "string");
+  if (!projectId || isUnresolvedSessionId(sessionId)) return null;
+  const ancestryIds = branchEntryIds(ctx.sessionManager.getBranch() as Array<{ id?: string }>);
   return {
-    projectId: deriveProjectIdFromCwd(ctx.cwd),
+    projectId,
     sessionId,
-    branchHeadId: branchEntryIds.at(-1),
-    branchEntryIds,
+    branchHeadId: ancestryIds.at(-1),
+    branchEntryIds: ancestryIds,
   };
 }
 
@@ -184,7 +184,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         return { content: [{ type: "text" as const, text: "Smart Recall is disabled by contextGraphEnabled=false." }], details: undefined };
       }
       const scope = resolveGraphScope(ctx);
-      if (!scope) return { content: [{ type: "text" as const, text: "Smart Recall needs a persisted session id." }], details: undefined };
+      if (!scope) return { content: [{ type: "text" as const, text: "Smart Recall must run from a project directory and needs a persisted session id." }], details: undefined };
       const results = recallContext(scope, params.query, {
         limit: params.limit,
         sessionOnly: params.scope === "session",
@@ -217,7 +217,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         return { content: [{ type: "text" as const, text: "Project memory is disabled by contextGraphEnabled=false." }], details: undefined };
       }
       const scope = resolveGraphScope(ctx);
-      if (!scope) return { content: [{ type: "text" as const, text: "Saving memory needs a persisted session id." }], details: undefined };
+      if (!scope) return { content: [{ type: "text" as const, text: "Saving project memory must run from a project directory and needs a persisted session id." }], details: undefined };
       const scrubber = new SecretScrubber(config.scrubSecrets, config.scrubPii);
       const title = scrubber.scrubText(params.title?.trim() || "Saved " + params.kind).value;
       const content = scrubber.scrubText(params.content).value;
@@ -228,7 +228,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
       }
       const approved = await ctx.ui.confirm(
         status === "resolved" ? "Resolve Project Memory" : "Save Project Memory",
-        "Kind: " + params.kind + "\nTitle: " + title + "\n\n" + content.slice(0, 800)
+        "Kind: " + params.kind + "\nTitle: " + title + "\n\n" + content
           + (relatedPaths.length ? "\n\nPaths: " + relatedPaths.join(", ") : ""),
       );
       if (!approved || signal?.aborted) {
@@ -272,16 +272,16 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         const maxLlmCalls = maxCallsRaw == null ? undefined : Number(maxCallsRaw);
         const maxLlmInputTokens = maxInputRaw == null ? undefined : Number(maxInputRaw);
         const maxLatencyMs = maxLatencyRaw == null ? undefined : Number(maxLatencyRaw);
-        if (maxLlmCalls !== undefined && (!Number.isInteger(maxLlmCalls) || maxLlmCalls < 1 || maxLlmCalls > 100)) {
-          ctx.ui.notify("--max-calls must be an integer from 1 to 100", "error");
+        if (maxLlmCalls !== undefined && (!Number.isInteger(maxLlmCalls) || maxLlmCalls < BUDGET_LIMITS.CALLS.min || maxLlmCalls > BUDGET_LIMITS.CALLS.max)) {
+          ctx.ui.notify("--max-calls must be an integer from " + BUDGET_LIMITS.CALLS.min + " to " + BUDGET_LIMITS.CALLS.max, "error");
           return;
         }
-        if (maxLlmInputTokens !== undefined && (!Number.isInteger(maxLlmInputTokens) || maxLlmInputTokens < 10_000 || maxLlmInputTokens > 1_000_000)) {
-          ctx.ui.notify("--max-input-tokens must be an integer from 10000 to 1000000", "error");
+        if (maxLlmInputTokens !== undefined && (!Number.isInteger(maxLlmInputTokens) || maxLlmInputTokens < BUDGET_LIMITS.INPUT_TOKENS.min || maxLlmInputTokens > BUDGET_LIMITS.INPUT_TOKENS.max)) {
+          ctx.ui.notify("--max-input-tokens must be an integer from " + BUDGET_LIMITS.INPUT_TOKENS.min + " to " + BUDGET_LIMITS.INPUT_TOKENS.max, "error");
           return;
         }
-        if (maxLatencyMs !== undefined && (!Number.isFinite(maxLatencyMs) || maxLatencyMs < 5000 || maxLatencyMs > 600000)) {
-          ctx.ui.notify("--max-latency must be 5000–600000 ms", "error");
+        if (maxLatencyMs !== undefined && (!Number.isFinite(maxLatencyMs) || maxLatencyMs < BUDGET_LIMITS.LATENCY_MS.min || maxLatencyMs > BUDGET_LIMITS.LATENCY_MS.max)) {
+          ctx.ui.notify("--max-latency must be " + BUDGET_LIMITS.LATENCY_MS.min + "–" + BUDGET_LIMITS.LATENCY_MS.max + " ms", "error");
           return;
         }
         if (flags.includes("metrics") || flags.includes("dashboard")) {
@@ -355,9 +355,12 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         }
         if (flags.includes("loops")) {
           const projectId = deriveProjectIdFromCwd(ctx.cwd);
+          if (!projectId) {
+            ctx.ui.notify("Project loops must be managed from a project directory", "warning");
+            return;
+          }
           const sessionId = resolveSessionId(ctx);
-          const branchIds = (ctx.sessionManager.getBranch() as Array<{ id?: string }>)
-            .map(entry => entry.id).filter((id): id is string => typeof id === "string");
+          const branchIds = branchEntryIds(ctx.sessionManager.getBranch() as Array<{ id?: string }>);
           const state = isUnresolvedSessionId(sessionId)
             ? null
             : loadScopedCompactionState({ projectId, sessionId }, branchIds);
@@ -539,8 +542,8 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
     }
     if (isUnresolvedSessionId(sessionId)) return;
     const projectId = deriveProjectIdFromCwd(ctx.cwd);
-    const branchIds = (ctx.sessionManager.getBranch() as Array<{ id?: string }>)
-      .map(entry => entry.id).filter((id): id is string => typeof id === "string");
+    if (!projectId) return;
+    const branchIds = branchEntryIds(ctx.sessionManager.getBranch() as Array<{ id?: string }>);
     const branchHeadId = typeof event.compactionEntry.id === "string" ? event.compactionEntry.id : branchIds.at(-1);
     if (!branchHeadId) return;
     const state = loadScopedCompactionState({ projectId, sessionId }, branchIds);
@@ -613,9 +616,9 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         report: { type: "boolean", description: "Return recent performance metrics instead of compacting." },
         dashboard: { type: "boolean", description: "Write a local HTML metrics dashboard and return its path." },
         focus: { type: "string", description: "Topic or path that should receive extra preservation budget." },
-        max_calls: { type: "number", description: "Maximum LLM calls for this run (1-100)." },
-        max_input_tokens: { type: "number", description: "Aggregate prompt-token budget for this run (10000-1000000)." },
-        max_latency_ms: { type: "number", description: "Optional hard pipeline latency budget in milliseconds (5000-600000). Modes use soft latency targets by default." },
+        max_calls: { type: "number", description: "Maximum LLM calls for this run (" + BUDGET_LIMITS.CALLS.min + "-" + BUDGET_LIMITS.CALLS.max + ")." },
+        max_input_tokens: { type: "number", description: "Aggregate prompt-token budget for this run (" + BUDGET_LIMITS.INPUT_TOKENS.min + "-" + BUDGET_LIMITS.INPUT_TOKENS.max + ")." },
+        max_latency_ms: { type: "number", description: "Optional pipeline cancellation budget in milliseconds (" + BUDGET_LIMITS.LATENCY_MS.min + "-" + BUDGET_LIMITS.LATENCY_MS.max + ")." },
       },
     },
     async execute(_id, params, signal, _onUp, ctx) {
@@ -628,9 +631,9 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
       const verbose = !!params.verbose;
       const dryRun = !!params.dry_run;
       const focus = typeof params.focus === "string" ? params.focus.trim() || undefined : undefined;
-      const maxLlmCalls = typeof params.max_calls === "number" && Number.isInteger(params.max_calls) && params.max_calls >= 1 && params.max_calls <= 100 ? params.max_calls : undefined;
-      const maxLlmInputTokens = typeof params.max_input_tokens === "number" && Number.isInteger(params.max_input_tokens) && params.max_input_tokens >= 10_000 && params.max_input_tokens <= 1_000_000 ? params.max_input_tokens : undefined;
-      const maxLatencyMs = typeof params.max_latency_ms === "number" && params.max_latency_ms >= 5000 && params.max_latency_ms <= 600000 ? params.max_latency_ms : undefined;
+      const maxLlmCalls = typeof params.max_calls === "number" && Number.isInteger(params.max_calls) && params.max_calls >= BUDGET_LIMITS.CALLS.min && params.max_calls <= BUDGET_LIMITS.CALLS.max ? params.max_calls : undefined;
+      const maxLlmInputTokens = typeof params.max_input_tokens === "number" && Number.isInteger(params.max_input_tokens) && params.max_input_tokens >= BUDGET_LIMITS.INPUT_TOKENS.min && params.max_input_tokens <= BUDGET_LIMITS.INPUT_TOKENS.max ? params.max_input_tokens : undefined;
+      const maxLatencyMs = typeof params.max_latency_ms === "number" && params.max_latency_ms >= BUDGET_LIMITS.LATENCY_MS.min && params.max_latency_ms <= BUDGET_LIMITS.LATENCY_MS.max ? params.max_latency_ms : undefined;
       if (params.report || params.dashboard) {
         const report = buildMetricsReport();
         const fp = params.dashboard ? writeMetricsDashboard() : null;

--- a/src/infra/context-graph.ts
+++ b/src/infra/context-graph.ts
@@ -13,6 +13,7 @@ const MAX_MANUAL_NODES = 500;
 const MAX_SESSION_NODES = 256;
 const MAX_QUERY_CANDIDATES = 80;
 const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1_000;
+const CONTEXT_GRAPH_SCHEMA_VERSION = 1;
 
 export type ContextMemoryKind =
   | "goal" | "decision" | "constraint" | "error" | "loop"
@@ -164,8 +165,6 @@ function openDatabase(): SqliteDatabase {
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
-    CREATE UNIQUE INDEX IF NOT EXISTS context_nodes_fact
-      ON context_nodes(project_id, session_id, kind, fact_key);
     CREATE INDEX IF NOT EXISTS context_nodes_project_status
       ON context_nodes(project_id, status, updated_at DESC);
     CREATE TABLE IF NOT EXISTS context_edges (
@@ -183,6 +182,20 @@ function openDatabase(): SqliteDatabase {
       tokenize='unicode61 remove_diacritics 2'
     );
   `);
+  const version = db.query("PRAGMA user_version").get() as { user_version: number } | null;
+  if (Number(version?.user_version ?? 0) < CONTEXT_GRAPH_SCHEMA_VERSION) {
+    db.transaction(() => {
+      db.exec(`
+        DROP INDEX IF EXISTS context_nodes_fact;
+        DELETE FROM context_nodes_fts
+          WHERE node_id IN (SELECT id FROM context_nodes WHERE source = 'compaction');
+        DELETE FROM context_nodes WHERE source = 'compaction';
+        CREATE UNIQUE INDEX context_nodes_fact
+          ON context_nodes(project_id, session_id, kind, fact_key, COALESCE(branch_head_id, ''));
+        PRAGMA user_version = ${CONTEXT_GRAPH_SCHEMA_VERSION};
+      `);
+    })();
+  }
   return db;
 }
 
@@ -249,7 +262,7 @@ function makeNode(
   const key = factKey(content);
   const now = Date.now();
   return {
-    id: stableId(scope.projectId, scope.sessionId, kind, key),
+    id: stableId(scope.projectId, scope.sessionId, kind, key, scope.branchHeadId ?? ""),
     projectId: scope.projectId,
     sessionId: scope.sessionId,
     branchHeadId: scope.branchHeadId ?? null,
@@ -279,21 +292,66 @@ function ensureFileNode(db: SqliteDatabase, scope: ContextGraphScope, file: stri
   return node;
 }
 
+function branchLineage(scope: ContextGraphScope): string[] {
+  return Array.from(new Set([...(scope.branchEntryIds ?? []), scope.branchHeadId]
+    .filter((id): id is string => typeof id === "string" && id.length > 0)));
+}
+
+function lineageFactRows(
+  db: SqliteDatabase, scope: ContextGraphScope, kind?: string, key?: string,
+): NodeRow[] {
+  const lineage = new Set(branchLineage(scope));
+  const rows = db.query(`
+    SELECT * FROM context_nodes
+    WHERE project_id = ? AND session_id = ? AND source = 'compaction'
+      ${kind ? "AND kind = ?" : ""} ${key ? "AND fact_key = ?" : ""}
+  `).all(scope.projectId, scope.sessionId, ...(kind ? [kind] : []), ...(key ? [key] : [])) as NodeRow[];
+  return rows.filter(row => lineage.size > 0
+    ? Boolean(row.branch_head_id && lineage.has(row.branch_head_id))
+    : row.branch_head_id == null);
+}
+
+function latestLineageFact(
+  db: SqliteDatabase, scope: ContextGraphScope, kind: string, key: string,
+): NodeRow | null {
+  const rank = new Map(branchLineage(scope).map((id, index) => [id, index]));
+  return lineageFactRows(db, scope, kind, key)
+    .sort((a, b) => (rank.get(b.branch_head_id ?? "") ?? -1) - (rank.get(a.branch_head_id ?? "") ?? -1)
+      || b.updated_at - a.updated_at)[0] ?? null;
+}
+
+/** Record a branch-local tombstone; never mutate a shared ancestor occurrence. */
 function markFactStatus(
   db: SqliteDatabase, scope: ContextGraphScope, kind: string, key: string,
   status: "resolved" | "superseded",
 ): void {
-  const rows = db.query(`
-    SELECT id FROM context_nodes
-    WHERE project_id = ? AND session_id = ? AND kind = ? AND fact_key = ? AND source = 'compaction'
-  `).all(scope.projectId, scope.sessionId, kind, key) as Array<{ id: string }>;
-  if (!rows.length) return;
-  db.query(`
-    UPDATE context_nodes SET status = ?, updated_at = ?
-    WHERE project_id = ? AND session_id = ? AND kind = ? AND fact_key = ? AND source = 'compaction'
-  `).run(status, Date.now(), scope.projectId, scope.sessionId, kind, key);
-  const remove = db.query("DELETE FROM context_nodes_fts WHERE node_id = ?");
-  for (const row of rows) remove.run(row.id);
+  const previous = latestLineageFact(db, scope, kind, key);
+  if (!previous || previous.status === status) return;
+  const now = Date.now();
+  upsertNode(db, {
+    id: stableId(scope.projectId, scope.sessionId, kind, key, scope.branchHeadId ?? ""),
+    projectId: scope.projectId,
+    sessionId: scope.sessionId,
+    branchHeadId: scope.branchHeadId ?? null,
+    kind,
+    factKey: key,
+    title: previous.title,
+    content: previous.content,
+    status,
+    source: "compaction",
+    confidence: previous.confidence,
+    relatedPaths: parsePaths(previous.related_paths),
+    createdAt: now,
+    updatedAt: now,
+  }, true);
+}
+
+function sameActiveFact(row: NodeRow | null, node: GraphNode): boolean {
+  return Boolean(row && row.status === "active" && node.status === "active"
+    && row.title === node.title
+    && row.content === node.content
+    && row.confidence === node.confidence
+    && JSON.stringify(parsePaths(row.related_paths)) === JSON.stringify(node.relatedPaths));
 }
 
 function addFact(
@@ -304,7 +362,8 @@ function addFact(
   if (!content.trim()) return;
   const node = makeNode(scope, kind, title, content, { relatedPaths, confidence });
   node.factKey = factKey(keyText);
-  node.id = stableId(scope.projectId, scope.sessionId, kind, node.factKey);
+  node.id = stableId(scope.projectId, scope.sessionId, kind, node.factKey, scope.branchHeadId ?? "");
+  if (sameActiveFact(latestLineageFact(db, scope, kind, node.factKey), node)) return;
   upsertNode(db, node);
   linkNodes(db, scope.projectId, sessionNodeId, node.id, "contains", 1, node.updatedAt);
   for (const file of relatedPaths) {
@@ -350,6 +409,7 @@ export function indexCompactionState(projectId: string, state: CompactionState):
     projectId,
     sessionId,
     branchHeadId: state.scope.branchHeadId,
+    branchEntryIds: state.scope.branchAncestryIds,
   };
   let db: SqliteDatabase | null = null;
   try {
@@ -366,17 +426,16 @@ export function indexCompactionState(projectId: string, state: CompactionState):
       upsertNode(db!, sessionNode);
       linkNodes(db!, projectId, projectNode.id, sessionNode.id, "contains", 1, now);
 
-      db!.query(`
-        UPDATE context_nodes SET status = 'superseded', updated_at = ?
-        WHERE project_id = ? AND session_id = ? AND kind = 'goal' AND source = 'compaction' AND status = 'active'
-      `).run(now, projectId, sessionId);
-      db!.query(`
-        DELETE FROM context_nodes_fts WHERE node_id IN (
-          SELECT id FROM context_nodes WHERE project_id = ? AND session_id = ? AND kind = 'goal' AND status <> 'active'
-        )
-      `).run(projectId, sessionId);
-
-      if (state.goal) addFact(db!, scope, sessionNode.id, "goal", "Current goal", state.goal, [], 0.98);
+      // Goal is the only complete singleton snapshot. Bounded task collections
+      // are partial: absence can mean cap eviction, never positive resolution.
+      if (state.goal) {
+        const currentGoalKey = factKey(state.goal);
+        const priorGoalKeys = new Set(lineageFactRows(db!, scope, "goal").map(row => row.fact_key));
+        for (const key of priorGoalKeys) {
+          if (key !== currentGoalKey) markFactStatus(db!, scope, "goal", key, "superseded");
+        }
+        addFact(db!, scope, sessionNode.id, "goal", "Current goal", state.goal, [], 0.98);
+      }
       for (const item of state.decisions) {
         addFact(db!, scope, sessionNode.id, "decision", "Decision", item.summary + (item.userResponse ? " → " + item.userResponse : ""), [], item.type === "explicit" ? 0.98 : 0.82, item.summary);
       }
@@ -392,6 +451,7 @@ export function indexCompactionState(projectId: string, state: CompactionState):
         const node = makeNode(scope, "loop", "Open loop", item.summary, {
           status, relatedPaths: item.files, confidence: item.priority === "critical" || item.priority === "high" ? 0.98 : 0.88,
         });
+        if (sameActiveFact(latestLineageFact(db!, scope, "loop", node.factKey), node)) continue;
         upsertNode(db!, node);
         linkNodes(db!, projectId, sessionNode.id, node.id, "contains", 1, now);
         for (const file of item.files) {
@@ -514,13 +574,17 @@ export function saveContextMemory(scope: ContextGraphScope, memory: Omit<SavedCo
     node.sessionId = "*";
     node.branchHeadId = null;
     const transaction = db.transaction(() => {
-      const exists = db!.query("SELECT 1 AS found FROM context_nodes WHERE id = ?").get(node.id) as { found: number } | null;
+      const existing = db!.query("SELECT status FROM context_nodes WHERE id = ?").get(node.id) as { status: string } | null;
       const duplicates = db!.query(`
-        SELECT id, related_paths FROM context_nodes
+        SELECT id, related_paths, status FROM context_nodes
         WHERE project_id = ? AND kind = ? AND fact_key = ? AND source = 'manual' AND id <> ?
-      `).all(scope.projectId, memory.kind, node.factKey, node.id) as Array<{ id: string; related_paths: string }>;
-      const count = db!.query("SELECT count(*) AS count FROM context_nodes WHERE project_id = ? AND source = 'manual'").get(scope.projectId) as { count: number } | null;
-      if (!exists && !duplicates.length && Number(count?.count ?? 0) >= MAX_MANUAL_NODES) {
+      `).all(scope.projectId, memory.kind, node.factKey, node.id) as Array<{ id: string; related_paths: string; status: string }>;
+      const count = db!.query(`
+        SELECT count(*) AS count FROM context_nodes
+        WHERE project_id = ? AND source = 'manual' AND status = 'active'
+      `).get(scope.projectId) as { count: number } | null;
+      const alreadyActive = existing?.status === "active" || duplicates.some(item => item.status === "active");
+      if (!alreadyActive && Number(count?.count ?? 0) >= MAX_MANUAL_NODES) {
         throw new Error("Project memory limit reached; resolve an existing memory before saving another");
       }
       node.relatedPaths = Array.from(new Set([
@@ -605,6 +669,22 @@ function parsePaths(value: string): string[] {
   } catch { return []; }
 }
 
+function latestLineageVersions(
+  db: SqliteDatabase, scope: ContextGraphScope,
+): Map<string, { id: string; status: string }> {
+  const rank = new Map(branchLineage(scope).map((id, index) => [id, index]));
+  const latest = new Map<string, { id: string; status: string; rank: number; updatedAt: number }>();
+  for (const row of lineageFactRows(db, scope)) {
+    const key = row.kind + ":" + row.fact_key;
+    const rowRank = rank.get(row.branch_head_id ?? "") ?? -1;
+    const previous = latest.get(key);
+    if (!previous || rowRank > previous.rank || (rowRank === previous.rank && row.updated_at > previous.updatedAt)) {
+      latest.set(key, { id: row.id, status: row.status, rank: rowRank, updatedAt: row.updated_at });
+    }
+  }
+  return new Map([...latest].map(([key, value]) => [key, { id: value.id, status: value.status }]));
+}
+
 /** Weighted project recall: lexical seeds + one-hop file relationships + scope/recency boosts. */
 export function recallContext(scope: ContextGraphScope, query: string, options: ContextRecallOptions = {}): ContextRecallResult[] {
   const terms = searchTerms(query.slice(0, 500));
@@ -626,7 +706,8 @@ export function recallContext(scope: ContextGraphScope, query: string, options: 
     }
 
     const allowedKinds = options.kinds?.length ? new Set(options.kinds) : null;
-    const branchIds = new Set(scope.branchEntryIds ?? []);
+    const branchIds = new Set(branchLineage(scope));
+    const latestVersions = latestLineageVersions(db, scope);
     const kindBoost: Partial<Record<ContextMemoryKind, number>> = {
       decision: 0.1, constraint: 0.1, error: 0.1, loop: 0.1,
       warning: 0.1, procedure: 0.08, critical: 0.08, goal: 0.08,
@@ -637,6 +718,10 @@ export function recallContext(scope: ContextGraphScope, query: string, options: 
       const sameBranch = Boolean(row.branch_head_id && branchIds.has(row.branch_head_id));
       if (options.sessionOnly && (!sameSession || (branchIds.size > 0 && row.branch_head_id && !sameBranch))) return [];
       if (allowedKinds && !allowedKinds.has(row.kind)) return [];
+      if (row.source === "compaction" && sameSession && sameBranch) {
+        const latest = latestVersions.get(row.kind + ":" + row.fact_key);
+        if (latest && (latest.status !== "active" || latest.id !== row.id)) return [];
+      }
       const recency = Math.max(0, 1 - (now - row.updated_at) / NINETY_DAYS_MS);
       const score = Math.min(1,
         0.05 + lexical * 0.3 + graph * 0.15

--- a/src/infra/fs.ts
+++ b/src/infra/fs.ts
@@ -38,25 +38,15 @@ const LOCK_STALE_MS = 5_000;
 const LOCK_RETRY_MS = 25;
 const LOCK_MAX_RETRIES = 80; // ≈2s
 
-/** Ensure a directory exists, ignoring EEXIST races. */
+/** Ensure a private directory exists and normalize an existing target. */
 export function ensureDir(dir: string): void {
-  try {
-    fs.mkdirSync(dir, { recursive: true });
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") {
-      log.warn("ensureDir failed for " + dir, e);
-    }
-  }
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(dir, 0o700);
 }
 
 export async function ensureDirAsync(dir: string): Promise<void> {
-  try {
-    await fsp.mkdir(dir, { recursive: true });
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") {
-      log.warn("ensureDirAsync failed for " + dir, e);
-    }
-  }
+  await fsp.mkdir(dir, { recursive: true, mode: 0o700 });
+  await fsp.chmod(dir, 0o700);
 }
 
 function tempPath(target: string): string {
@@ -73,8 +63,9 @@ export function atomicWriteFileSync(target: string, data: string | Uint8Array): 
   ensureDir(path.dirname(target));
   const tmp = tempPath(target);
   try {
-    fs.writeFileSync(tmp, data);
+    fs.writeFileSync(tmp, data, { mode: 0o600 });
     fs.renameSync(tmp, target);
+    fs.chmodSync(target, 0o600);
   } catch (e) {
     // Clean up the temp file if rename failed — we never want orphans.
     try { fs.unlinkSync(tmp); } catch { /* best effort */ }
@@ -86,8 +77,9 @@ export async function atomicWriteFile(target: string, data: string | Uint8Array)
   await ensureDirAsync(path.dirname(target));
   const tmp = tempPath(target);
   try {
-    await fsp.writeFile(tmp, data);
+    await fsp.writeFile(tmp, data, { mode: 0o600 });
     await fsp.rename(tmp, target);
+    await fsp.chmod(target, 0o600);
   } catch (e) {
     try { await fsp.unlink(tmp); } catch { /* best effort */ }
     throw e;
@@ -107,7 +99,7 @@ export function acquireLockSync(target: string): () => void {
   const lockDir = target + ".lock";
   for (let attempt = 0; attempt < LOCK_MAX_RETRIES; attempt++) {
     try {
-      fs.mkdirSync(lockDir);
+      fs.mkdirSync(lockDir, { mode: 0o700 });
       return () => { try { fs.rmdirSync(lockDir); } catch { /* ignore */ } };
     } catch (e) {
       if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") {
@@ -161,7 +153,9 @@ export function appendLineLocked(target: string, line: string): void {
   ensureDir(path.dirname(target));
   const release = acquireLockSync(target);
   try {
-    fs.appendFileSync(target, line.endsWith("\n") ? line : line + "\n");
+    if (fs.existsSync(target)) fs.chmodSync(target, 0o600);
+    fs.appendFileSync(target, line.endsWith("\n") ? line : line + "\n", { mode: 0o600 });
+    fs.chmodSync(target, 0o600);
   } finally {
     release();
   }

--- a/src/infra/git.ts
+++ b/src/infra/git.ts
@@ -22,7 +22,9 @@ export function findGitRoot(cwd: string): string | null {
   if (ROOT_CACHE.has(cwd)) return ROOT_CACHE.get(cwd) ?? null;
   let root: string | null = null;
   try {
-    const out = execSync("git rev-parse --show-toplevel", { cwd, encoding: "utf-8", timeout: 2000 });
+    const out = execSync("git rev-parse --show-toplevel", {
+      cwd, encoding: "utf-8", timeout: 2000, stdio: ["ignore", "pipe", "ignore"],
+    });
     root = out.trim() || null;
   } catch (e) {
     log.debug("git rev-parse failed for " + cwd, e);

--- a/src/infra/session-identity.ts
+++ b/src/infra/session-identity.ts
@@ -38,6 +38,11 @@ export type SessionIdentityContext = Pick<ExtensionContext, "sessionManager">;
 
 const UNRESOLVED_PREFIX = "unresolved:";
 
+/** Extract the complete ordered ancestry exposed by a session branch. */
+export function branchEntryIds(branch: Iterable<{ id?: unknown }>): string[] {
+  return Array.from(branch, entry => entry.id).filter((id): id is string => typeof id === "string");
+}
+
 /**
  * Resolve the current pi session id, or mint a per-call sentinel that can
  * never compare equal to another caller's sentinel.

--- a/src/infra/synthesis-cache.ts
+++ b/src/infra/synthesis-cache.ts
@@ -41,7 +41,7 @@ export function synthesisCacheKey(rc: ExtractedRc): string {
       codexCallMs: rc.config.codexMaxCallMs,
       latencyMs: rc.config.maxLatencyMs,
     },
-    focus: rc.config.focusWeighting ? rc.focus : undefined,
+    focus: rc.focus?.trim() || undefined,
     zeroCall: rc.config.zeroCallEnabled !== false,
     note: rc.userNote,
   });

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -67,6 +67,9 @@ const CONDITION_MARKERS = new Set([
   "only", "after", "before", "with", "requir", "until",
   "sadece", "sonra", "önce", "gerekli", "gerektirir",
 ]);
+const POLARITY_INVERTING_GUARDS = new Set([
+  "skip", "skipp", "forget", "forgett", "omit", "omitt", "neglect", "fail", "avoid",
+]);
 const SEMANTIC_STOP = new Set([
   "the", "and", "that", "this", "with", "from", "into", "must", "should",
   "only", "after", "before", "without", "never", "not", "does", "have",
@@ -99,6 +102,32 @@ function hasNearbyMarker(tokens: string[], anchor: string, markers: Set<string>)
     && tokens.slice(Math.max(0, index - 2), index + 3).some(near => markers.has(near)));
 }
 
+function hasEffectiveTargetNegation(tokens: string[], anchor: string): boolean {
+  return tokens.some((token, anchorIndex) => {
+    if (token !== anchor) return false;
+    const nearbyStart = Math.max(0, anchorIndex - 2);
+    const nearbyNegations = tokens.slice(nearbyStart, anchorIndex + 3)
+      .map((near, offset) => NEGATION_MARKERS.has(near) ? nearbyStart + offset : -1)
+      .filter(index => index >= 0);
+    const governingStart = Math.max(0, anchorIndex - 3);
+    const preceding = tokens.slice(governingStart, anchorIndex);
+    const nearbyGuards = preceding
+      .map((near, offset) => POLARITY_INVERTING_GUARDS.has(near) ? governingStart + offset : -1)
+      .filter(index => index >= 0);
+    const governingIndex = preceding.findIndex((near, offset) => NEGATION_MARKERS.has(near)
+      && POLARITY_INVERTING_GUARDS.has(preceding[offset + 1] ?? ""));
+    if (governingIndex < 0) return nearbyNegations.length > 0 || nearbyGuards.length > 0;
+
+    const absoluteGoverningIndex = governingStart + governingIndex;
+    const guardIndex = absoluteGoverningIndex + 1;
+    const nested = tokens.slice(guardIndex + 1, anchorIndex)
+      .some(inner => NEGATION_MARKERS.has(inner) || POLARITY_INVERTING_GUARDS.has(inner));
+    return nested
+      || nearbyNegations.some(index => index !== absoluteGoverningIndex && index !== guardIndex)
+      || nearbyGuards.some(index => index !== guardIndex);
+  });
+}
+
 /** Conservative deterministic semantic evidence for goals/constraints/decisions. */
 function semanticShape(source: string): {
   sourceTokens: string[]; concepts: string[]; anchor: string; negative: boolean; conditional: boolean;
@@ -122,7 +151,8 @@ function hasSemanticEvidence(source: string, target: string): boolean {
     const tokens = semanticTokens(fragment);
     const overlap = concepts.filter(concept => tokens.includes(concept)).length;
     if (overlap < required) return false;
-    if (negative && !hasNearbyMarker(tokens, anchor, NEGATION_MARKERS)) {
+    const targetNegative = hasEffectiveTargetNegation(tokens, anchor);
+    if (negative && !targetNegative) {
       // A conditional prohibition ("do not X without Y") may be faithfully
       // restated positively as "X only after/with Y".
       const conditionalRestatement = sourceTokens.includes("without")
@@ -130,6 +160,7 @@ function hasSemanticEvidence(source: string, target: string): boolean {
         && overlap >= Math.min(2, concepts.length);
       if (!conditionalRestatement) return false;
     }
+    if (!negative && targetNegative) return false;
     if (conditional && !negative
       && !tokens.some(token => CONDITION_MARKERS.has(token))) return false;
     return true;
@@ -147,12 +178,14 @@ function hasSemanticContradiction(source: string, target: string): boolean {
     // Sharing a generic anchor such as "release" or "file" is not enough:
     // another constraint in the same section must overlap the actual concepts.
     if (overlap < required) return false;
-    if (negative && !hasNearbyMarker(tokens, anchor, NEGATION_MARKERS)) {
+    const targetNegative = hasEffectiveTargetNegation(tokens, anchor);
+    if (negative && !targetNegative) {
       const validConditional = sourceTokens.includes("without")
         && tokens.some(token => CONDITION_MARKERS.has(token))
         && overlap >= Math.min(2, concepts.length);
       return !validConditional;
     }
+    if (!negative && targetNegative) return true;
     return conditional && !negative && !tokens.some(token => CONDITION_MARKERS.has(token));
   });
 }

--- a/src/ui/dashboard-insights.ts
+++ b/src/ui/dashboard-insights.ts
@@ -1,5 +1,5 @@
 import { VERSION } from "../constants.ts";
-import { assessCanary, type CanaryAssessment, type DamageTelemetryEntry } from "../domain/telemetry.ts";
+import { assessCanary, isTelemetryFailureKind, type CanaryAssessment, type DamageTelemetryEntry } from "../domain/telemetry.ts";
 import type { CompactMetricsEntry, ProviderRouteMetric, ProviderRouteStage, TelemetryFailureKind } from "../types.ts";
 import { metricDuration } from "./dashboard-format.ts";
 
@@ -243,7 +243,7 @@ export function formatDashboardCanary(insights: DashboardInsights): string[] {
     "Canary / stable control",
     "",
     "Decision: " + c.decision.toUpperCase() + " | data confidence " + c.dataConfidence + "%",
-    "Runs: stable " + c.baseline.runs + " | canary " + c.canary.runs,
+    "Runs (total/applied): stable " + c.baseline.runs + "/" + c.baseline.appliedRuns + " | canary " + c.canary.runs + "/" + c.canary.appliedRuns,
     "Success: stable " + Math.round(c.baseline.successRate * 100) + "% | canary " + Math.round(c.canary.successRate * 100) + "%",
     "Quality: stable " + (c.baseline.avgQuality?.toFixed(1) ?? "—") + " | canary " + (c.canary.avgQuality?.toFixed(1) ?? "—"),
     "p95: stable " + c.baseline.p95LatencyMs + "ms | canary " + c.canary.p95LatencyMs + "ms",
@@ -263,12 +263,8 @@ export function buildDashboardInsights(
   options: { version?: string; minCanaryRuns?: number; now?: number } = {},
 ): DashboardInsights {
   const failures: Partial<Record<TelemetryFailureKind, number>> = {};
-  const knownFailures = new Set<TelemetryFailureKind>([
-    "cancelled", "timeout", "rate-limit", "authentication", "budget",
-    "output-limit", "provider", "persistence", "validation", "verification", "internal",
-  ]);
   for (const entry of entries) {
-    if (entry.failureKind && knownFailures.has(entry.failureKind)) {
+    if (isTelemetryFailureKind(entry.failureKind)) {
       failures[entry.failureKind] = (failures[entry.failureKind] ?? 0) + 1;
     }
   }

--- a/src/ui/metrics-report.ts
+++ b/src/ui/metrics-report.ts
@@ -174,7 +174,7 @@ function canaryRows(insights: DashboardInsights): string {
   const baseline = insights.canary.baseline;
   const canary = insights.canary.canary;
   const rows: Array<[string, string, string]> = [
-    ["Runs", metricNum(baseline.runs), metricNum(canary.runs)],
+    ["Runs (total/applied)", metricNum(baseline.runs) + "/" + metricNum(baseline.appliedRuns), metricNum(canary.runs) + "/" + metricNum(canary.appliedRuns)],
     ["Success", metricPct(baseline.successRate), metricPct(canary.successRate)],
     ["Verify quality", baseline.avgQuality?.toFixed(1) ?? "—", canary.avgQuality?.toFixed(1) ?? "—"],
     ["p95 duration", metricMs(baseline.p95LatencyMs), metricMs(canary.p95LatencyMs)],
@@ -290,7 +290,7 @@ export function buildMetricsReport(
     "- Repair: initial average " + (quality.averageInitial?.toFixed(1) ?? "—") + " · average gain " + (quality.averageRepairGain?.toFixed(1) ?? "—") + " · deterministic " + quality.deterministicPatchedRuns + " · LLM " + quality.llmPatchedRuns + " · quality floor " + quality.qualityFloorRuns + " · remaining gaps " + quality.remainingGaps,
     "",
     "## Canary / stable control",
-    "Decision: " + canary.decision.toUpperCase() + " · confidence " + canary.dataConfidence + "% · stable n=" + canary.baseline.runs + " · canary n=" + canary.canary.runs,
+    "Decision: " + canary.decision.toUpperCase() + " · confidence " + canary.dataConfidence + "% · stable total/applied=" + canary.baseline.runs + "/" + canary.baseline.appliedRuns + " · canary total/applied=" + canary.canary.runs + "/" + canary.canary.appliedRuns,
     ...canary.reasons.map(item => "- " + item),
     ...canary.triggers.map(item => "- Trigger " + item.metric + ": stable " + item.baseline + " → canary " + item.canary + " (" + item.threshold + ")"),
     "",
@@ -337,7 +337,7 @@ export function writeMetricsDashboard(
         ${metricCard("Tokens saved", compactNumber(summary.totalSaved), `avg score ${summary.avgScore || "—"}`)}
         ${metricCard("Data Confidence", insights.confidence.score + "/100", `telemetry completeness · target ≥85 ${insights.confidence.targetMet ? "met" : "not met"}`, confidenceTone)}
         ${metricCard("Quality Health", insights.quality.healthScore + "/100", `actual outcomes · target ≥85 ${insights.quality.targetMet ? "met" : "not met"}`, qualityTone)}
-        ${metricCard("Canary gate", insights.canary.decision.toUpperCase(), `${insights.canary.canary.runs} canary · ${insights.canary.dataConfidence}% confidence`, canaryTone)}
+        ${metricCard("Canary gate", insights.canary.decision.toUpperCase(), `${insights.canary.canary.runs}/${insights.canary.canary.appliedRuns} canary total/applied · ${insights.canary.dataConfidence}% confidence`, canaryTone)}
       </section>
       <section class="layout">
         <div class="panel"><h2>Duration trend <span class="muted">last ${Math.min(entries.length, 80)} runs</span></h2>${sparkline(entries.slice(-80).map(metricDuration))}</div>

--- a/src/ui/overlays.ts
+++ b/src/ui/overlays.ts
@@ -4,7 +4,7 @@
 
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { DynamicBorder, Theme } from "@earendil-works/pi-coding-agent";
-import { TRUNC } from "../constants.ts";
+import { POST_SUMMARY_RESERVE_RATIO, TRUNC } from "../constants.ts";
 import { Container, Key, matchesKey, type SelectItem, SelectList, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type {
@@ -15,7 +15,8 @@ import type { BackupEntry } from "../utils/helpers.ts";
 import { createProductionServices, type SmartCompactServices } from "../infra/services.ts";
 import { effectivePromptInputTokens, getExtractionCacheStats, getMetricsSummary } from "../utils/cache.ts";
 import { getProviderCaps } from "../utils/tokens.ts";
-import { planManualPreflight, preflightDamageMedian, type ManualPreflight } from "../app/preflight.ts";
+import { planManualPreflight, preflightDamageMedian, prepareManualPreflightContext, type ManualPreflight } from "../app/preflight.ts";
+import { compactionPlanReasonText } from "../app/steps/window.ts";
 import type { EffectiveCompactionMode } from "../types.ts";
 import {
   DASHBOARD_PAGE_SIZE,
@@ -123,15 +124,7 @@ const MODE_COPY: Record<EffectiveCompactionMode, string> = {
 };
 
 export function explainPreflightReason(reason: ManualPreflight["reason"]): string {
-  switch (reason) {
-    case "viable": return "safe window and useful estimated saving";
-    case "not-enough-messages": return "fewer than 3 active messages";
-    case "no-eligible-prefix": return "no older prefix is available";
-    case "unsafe-tool-boundary": return "no complete tool-call boundary is available";
-    case "retention-target-exceeded": return "a complete tool pair exceeds the tail target";
-    case "mode-target-not-met": return "the estimated result misses this preset's target";
-    case "insufficient-projected-saving": return "estimated saving is below 10%";
-  }
+  return reason === "not-enough-messages" ? "fewer than 3 active messages" : compactionPlanReasonText(reason);
 }
 
 function recommendationEvidence(preflight: ManualPreflight): string {
@@ -197,9 +190,10 @@ export function formatPreflightSummary(preflight: ManualPreflight, modelLabel: s
     );
     return lines;
   }
+  const stateReserve = Math.ceil(plan.summaryBudgetTokens * POST_SUMMARY_RESERVE_RATIO);
   const lines = [
     "Plan  " + compactTokenCount(preflight.totalTokens) + " → ~" + compactTokenCount(plan.projectedAfterTokens) + " · ~" + compactTokenCount(plan.projectedSavedTokens) + " saved (" + percent(plan.projectedYield * 100) + ")",
-    "Keep  ~" + compactTokenCount(plan.retainedTokens) + " recent · summary up to " + compactTokenCount(plan.summaryBudgetTokens),
+    "Keep  ~" + compactTokenCount(plan.retainedTokens) + " recent · summary up to " + compactTokenCount(plan.summaryBudgetTokens) + " + ~" + compactTokenCount(stateReserve) + " verified-state reserve",
     "✓ Complete tool pairs · ✓ zero-gap verification before apply",
   ];
   if (!plan.viable) lines.unshift("Unavailable · " + explainPreflightReason(plan.reason));
@@ -251,10 +245,13 @@ export function notifyAppliedCompaction(ctx: ExtensionContext, details: SmartCom
   const after = details.estimatedAfterTokens ?? Math.max(0, before - details.tokensSaved);
   const saving = Math.round((details.estimatedYield ?? (before ? details.tokensSaved / before : 0)) * 100);
   const quality = details.qualityScore ?? 0;
+  const initial = details.provenance?.initialScore ?? quality;
+  const repaired = details.provenance && (details.provenance.deterministicPatched.length > 0 || details.provenance.llmPatched || details.provenance.qualityFloorUsed);
+  const verification = "verified " + quality + "/100 coverage" + (repaired ? " (source " + initial + "/100" + (details.provenance?.qualityFloorUsed ? ", safety fallback" : "") + ")" : "") + " · 0 gaps";
   const planned = details.plannedAfterTokens ?? after;
   ctx.ui.notify(concise
-    ? "Smart compact applied ✓ · " + before.toLocaleString() + "t → ~" + after.toLocaleString() + "t estimate (plan ~" + planned.toLocaleString() + "t) · " + saving + "% saved · quality " + quality + " · 0 gaps"
-    : "Smart compact applied ✓ — " + before.toLocaleString() + "t → planned ~" + planned.toLocaleString() + "t / ~" + after.toLocaleString() + "t applied estimate · saved " + saving + "% · quality " + quality + "/100 · 0 gaps", "info");
+    ? "Smart compact applied ✓ · " + before.toLocaleString() + "t → ~" + after.toLocaleString() + "t estimate (plan ~" + planned.toLocaleString() + "t) · " + saving + "% saved · " + verification
+    : "Smart compact applied ✓ — " + before.toLocaleString() + "t → planned ~" + planned.toLocaleString() + "t / ~" + after.toLocaleString() + "t applied estimate · saved " + saving + "% · " + verification, "info");
 }
 
 // Same narrowing rationale as showProgressOverlay: only ctx.ui.custom is
@@ -293,15 +290,18 @@ export async function showResultScreen(
     }
 
     const scoreColor = details.qualityScore >= 80 ? "success" : details.qualityScore >= 50 ? "warning" : "error";
-    c.addChild(new Text(theme.fg("text", "  Quality: ") + theme.fg(scoreColor, details.qualityScore + "/100"), 0, 0));
+    c.addChild(new Text(theme.fg("text", "  Verification coverage: ") + theme.fg(scoreColor, details.qualityScore + "/100"), 0, 0));
     if (details.provenance) {
       const provenance = details.provenance;
       c.addChild(new Text(
-        theme.fg("dim", "  Provenance: score " + provenance.initialScore + " → deterministic " + provenance.deterministicPatched.length +
-          (provenance.llmPatched ? " → LLM patch" : "") + " → " + provenance.finalScore +
+        theme.fg("dim", "  Provenance: source " + provenance.initialScore + " → deterministic " + provenance.deterministicPatched.length +
+          (provenance.llmPatched ? " → LLM patch" : "") + " → verified " + provenance.finalScore +
           " (" + provenance.remainingGaps.length + " remaining)"),
         0, 0,
       ));
+      if (provenance.qualityFloorUsed) {
+        c.addChild(new Text(theme.fg("warning", "  Safety fallback used · verified coverage is not raw synthesis quality"), 0, 0));
+      }
     }
     if ((details.redactions ?? 0) > 0) {
       c.addChild(new Text(theme.fg("warning", "  Security: " + details.redactions + " sensitive value(s) redacted"), 0, 0));
@@ -442,8 +442,9 @@ export async function showResultScreen(
   if (!opts.approval) return "closed";
   const approved = await ctx.ui.confirm(
     "Apply Smart Compact?",
-    "Quality " + details.qualityScore + "/100 · " + details.gaps.length + " remaining gap(s) · " +
-      details.tokensSaved.toLocaleString() + " estimated tokens saved.\n\nCancel keeps the current conversation unchanged.",
+    "Verification coverage " + details.qualityScore + "/100 · source " + (details.provenance?.initialScore ?? details.qualityScore) + "/100 · " +
+      details.gaps.length + " remaining gap(s) · " + details.tokensSaved.toLocaleString() +
+      " estimated tokens saved.\n\nCancel keeps the current conversation unchanged.",
   );
   return approved ? "apply" : "cancel";
 }
@@ -576,7 +577,11 @@ export async function showCompactUI(
   const damageMedian = preflightDamageMedian(ctx.cwd, opts.config);
 
   while (true) {
-    const plans = new Map(PRIMARY_MODES.map(mode => [mode, planManualPreflight(ctx, selectedModel.model, mode, calibration, opts.config, damageMedian)]));
+    const shared = prepareManualPreflightContext(ctx, selectedModel.model, calibration);
+    const plans = new Map(PRIMARY_MODES.map(mode => [
+      mode,
+      planManualPreflight(ctx, selectedModel.model, mode, calibration, opts.config, damageMedian, shared),
+    ]));
     const recommended = recommendPreflight(plans);
     const action = await ctx.ui.custom<EffectiveCompactionMode | "model" | null>((tui, theme, keybindings, done) => {
       let selected = Math.max(0, PRIMARY_MODES.indexOf(recommended.mode));

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -12,7 +12,7 @@ import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
 import type { LLMCallMetric, StructuredExtraction, CachedExtraction, CacheAwareOptions, CompactMetricsEntry, LlmMessage } from "../types.ts";
-import { flattenToolCallBlock, type ToolCallIndex } from "./extraction.ts";
+import { flattenToolCallBlock, isTransientToolDiagnostic, type ToolCallIndex } from "./extraction.ts";
 import { estimateTokens, calibrateFromResponse, getProviderCaps } from "./tokens.ts";
 import * as log from "./logger.ts";
 import type { Model, Api, AssistantMessage, Context } from "@earendil-works/pi-ai";
@@ -332,13 +332,22 @@ export function mergeExtractions(
       ? { ...file, toolCalls: previous.toolCalls + file.toolCalls, lastModifiedIndex: Math.max(previous.lastModifiedIndex, file.lastModifiedIndex) }
       : file);
   }
+  const deltaPresent = new Set([...offsetModifiedFiles.map(file => file.path), ...delta.readFiles]);
+  const deltaDeleted = new Set(delta.deletedFiles);
+  for (const file of deltaDeleted) modified.delete(file);
+  const readFiles = new Set([...base.readFiles, ...delta.readFiles]);
+  for (const file of deltaDeleted) readFiles.delete(file);
+  const deletedFiles = new Set([...base.deletedFiles, ...delta.deletedFiles]);
+  for (const file of deltaPresent) deletedFiles.delete(file);
+
   const reconciledBaseErrors = reconcileCachedErrors(base.errors, deltaMessages, deltaToolCalls, baseMsgCount);
-  const mergedErrors = [...reconciledBaseErrors, ...offsetErrors];
+  const mergedErrors = [...reconciledBaseErrors, ...offsetErrors]
+    .filter(error => !isTransientToolDiagnostic(error.message));
 
   return {
     modifiedFiles: [...modified.values()],
-    readFiles: [...new Set([...base.readFiles, ...delta.readFiles])],
-    deletedFiles: [...new Set([...base.deletedFiles, ...delta.deletedFiles])],
+    readFiles: [...readFiles],
+    deletedFiles: [...deletedFiles],
     referencedFiles: [...new Set([...(base.referencedFiles ?? []), ...(delta.referencedFiles ?? [])])].slice(0, 200),
     mediaAttachments: [...(base.mediaAttachments ?? []), ...offsetMedia],
     errors: mergedErrors,
@@ -346,9 +355,9 @@ export function mergeExtractions(
     constraints: [...base.constraints, ...offsetConstraints],
     topics: [...base.topics, ...offsetTopics],
     timeline: [...base.timeline, ...offsetTimeline],
-    // mainGoal is the FIRST user message (the original objective) — base holds
-    // it; the delta suffix's first user message is mid-conversation, not the goal.
-    mainGoal: base.mainGoal ?? delta.mainGoal,
+    // The latest substantive user request is the active goal; a suffix with no
+    // real request (tool-only work or an acknowledgement) leaves the base intact.
+    mainGoal: delta.mainGoal ?? base.mainGoal,
     // "last N" must span the cache boundary: the suffix alone is incomplete
     // when it carries fewer than N user messages / errors.
     lastUserMessages: [...base.lastUserMessages, ...delta.lastUserMessages].slice(-5),

--- a/src/utils/extraction.ts
+++ b/src/utils/extraction.ts
@@ -10,6 +10,7 @@ import { isToolCallBlock, isTextBlock } from "../utils/type-guards.ts";
 import { buildPathNeedles } from "./file-needles.ts";
 import { classifyToolOperation, extractToolPath } from "../domain/tool-semantics.ts";
 import { extractFileRefs } from "./file-ref-detect.ts";
+import { findSection, summaryEvidenceLine } from "../domain/summary-parse.ts";
 
 /** pi-toolkit truncation marker: content.slice(0, 20) + `…✂${content.length}` */
 export const TRUNCATE_RE = /…✂\d+$/;
@@ -17,10 +18,6 @@ export const TRUNCATE_RE = /…✂\d+$/;
 export function isTruncated(content: unknown): boolean {
   return TRUNCATE_RE.test(extractText(content));
 }
-
-/** Best-effort delete detection: arguments can't tell a delete from a read
- *  (both carry only a path), so the result text is the only signal. */
-const DELETE_RESULT_RE = /\b(?:deleted|removed|unlinked)\b/i;
 
 /** Reusable tool call index type */
 export type ToolCallIndex = Map<string, { name: string; arguments: Record<string, unknown>; msgIndex: number }>;
@@ -30,6 +27,13 @@ export interface FlatToolCall {
   name: string;
   id?: string;
   arguments: Record<string, unknown>;
+}
+
+/** Identity contract shared by extraction and pruning for nested parallel calls. */
+export function nestedToolCallId(wrapperId: string | undefined, messageIndex: number, toolIndex: number, nestedId?: unknown): string {
+  return typeof nestedId === "string"
+    ? nestedId
+    : wrapperId ? wrapperId + "_" + toolIndex : ID_PREFIX.MULTI_TOOL_USE_SYNTHETIC + messageIndex + "_" + toolIndex;
 }
 
 /**
@@ -122,8 +126,8 @@ export function buildToolCallIndex(msgs: LlmMessage[]): ToolCallIndex {
         const nested = flattenToolCallBlock(b);
         for (let t = 0; t < nested.length; t++) {
           const tool = nested[t];
-          const syntheticId = b.id ? b.id + "_" + t : "mtu_" + i + "_" + t;
-          idx.set(tool.id || syntheticId, { name: tool.name, arguments: tool.arguments, msgIndex: i });
+          const id = nestedToolCallId(b.id, i, t, tool.id);
+          idx.set(id, { name: tool.name, arguments: tool.arguments, msgIndex: i });
         }
       }
     }
@@ -153,14 +157,17 @@ export function trackFileOps(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): { modi
       if (isTruncated(resultText) || !NO_OP_RE.test(resultText)) {
         const existing = modMap.get(filePath);
         modMap.set(filePath, { toolCalls: (existing?.toolCalls ?? 0) + 1, lastIdx: i });
+        delSet.delete(filePath);
       }
     } else if (operation === "delete") {
       delSet.add(filePath);
+      modMap.delete(filePath);
+      readSet.delete(filePath);
     } else if (operation === "read" || operation === "search" || operation === "list") {
-      // Unknown path-only tools default to read; preserve result-text fallback
-      // for providers whose delete tool has no useful name.
-      if (DELETE_RESULT_RE.test(extractText(m.content))) delSet.add(filePath);
-      else readSet.add(filePath);
+      // A successful access proves the path is present now. Never infer a
+      // deletion from source/search prose merely containing "removed".
+      readSet.add(filePath);
+      delSet.delete(filePath);
     }
   }
 
@@ -188,6 +195,14 @@ function hasCommandFailureSignal(text: string): boolean {
   return LIKELY_ERROR_RE.test(firstLine) || /^(?:npm\s+error|fatal:|traceback\b)/i.test(firstLine);
 }
 
+export function isTransientToolDiagnostic(text: string): boolean {
+  const candidate = text.trim();
+  return /\bBrave Search API error\s*\(429\)/i.test(candidate)
+    || (/\bnpm error code ENOLOCK\b/i.test(candidate) && /(?:audit|existing lockfile|loadVirtual)/i.test(candidate))
+    || /^Found \d+ occurrences? of edits\[\d+\](?!\w)/i.test(candidate)
+    || (/^Unknown JSON field:/i.test(candidate) && /Available fields:/i.test(candidate));
+}
+
 export function catalogErrors(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): StructuredExtraction["errors"] {
   const tcIdx = _tcIdx ?? buildToolCallIndex(msgs);
   const errors: StructuredExtraction["errors"] = [];
@@ -198,7 +213,7 @@ export function catalogErrors(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): Struc
     const tc = tcIdx.get(m.toolCallId ?? "");
 
     const text = extractText(m.content);
-    if (tc && isBenignSearchResult(tc, text)) continue;
+    if ((tc && isBenignSearchResult(tc, text)) || isTransientToolDiagnostic(text)) continue;
 
     if (m.isError) {
       errors.push({ index: i, tool: tc?.name ?? "unknown", message: text.slice(0, TRUNC.ERROR_DETAIL), retryAttempted: false, resolved: false });
@@ -384,11 +399,30 @@ export function buildTimeline(msgs: LlmMessage[], errors: StructuredExtraction["
     : timeline;
 }
 
+const HISTORY_SUMMARY_RE = /^(?:The conversation history before this point was compacted|The following is a summary of a branch that this conversation came back from)[\s\S]*<summary>/i;
+const ACK_ONLY_RE = /^(?:(?:ok(?:ay)?|tamam|evet|yes|thanks?|teşekkürler|continue|devam(?:\s+et)?|go\s+ahead|proceed)[\s.!]*){1,3}$/iu;
+
+/** Machine status from an earlier compaction is context, not an active user goal. */
+export function isCompactionStatusText(text: string): boolean {
+  const candidate = summaryEvidenceLine(text, TRUNC.MESSAGE).replace(/^["'`]+/, "").trim();
+  return /^(?:EESV Compact\b|Smart compact (?:skipped|prepared|run finished)\b|Auto-compacting\b)/i.test(candidate);
+}
+
 export function extractMainGoal(msgs: LlmMessage[]): string | null {
-  for (const m of msgs) {
+  // The latest substantive request is the active goal. Commands and bare
+  // acknowledgements do not supersede it; a host compaction message contributes
+  // only its canonical Goal section and forms a boundary to older raw history.
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const m = msgs[i];
     if (m?.role !== "user") continue;
-    const txt = extractText(m.content).trim();
-    if (txt && !txt.startsWith("/")) return txt.slice(0, TRUNC.MESSAGE);
+    const text = extractText(m.content).trim();
+    if (!text) continue;
+    if (HISTORY_SUMMARY_RE.test(text)) {
+      const carried = summaryEvidenceLine(findSection(text, "goal")?.body ?? "", TRUNC.MESSAGE);
+      return carried && !isCompactionStatusText(carried) ? carried : null;
+    }
+    if (text.startsWith("/") || ACK_ONLY_RE.test(text)) continue;
+    return summaryEvidenceLine(text, TRUNC.MESSAGE) || null;
   }
   return null;
 }

--- a/src/utils/fingerprint.ts
+++ b/src/utils/fingerprint.ts
@@ -8,7 +8,7 @@ import crypto from "node:crypto";
 import type { StructuredExtraction } from "../types.ts";
 import * as log from "./logger.ts";
 import { projectFingerprintFile } from "../infra/paths.ts";
-import { writeJsonSync, readJsonSync } from "../infra/fs.ts";
+import { acquireLockSync, ensureDir, writeJsonSync, readJsonSync } from "../infra/fs.ts";
 import { findGitRoot as findGitRootCached } from "../infra/git.ts";
 import { THIRTY_DAYS_MS, ID_PREFIX, TRUNC } from "../constants.ts";
 
@@ -159,8 +159,12 @@ function deriveFromRelativePaths(paths: string[]): string {
  * Using cwd/git-root as primary prevents cross-project fingerprint contamination
  * when a session has no file operations (review, discussion, debugging).
  */
-export function deriveProjectIdFromCwd(cwd: string): string {
-  return hashProjectId(findGitRoot(cwd) ?? cwd);
+export function deriveProjectIdFromCwd(cwd: string): string | null {
+  if (!cwd) return null;
+  const resolved = path.resolve(cwd);
+  const home = process.env.HOME ? path.resolve(process.env.HOME) : null;
+  if (resolved === path.parse(resolved).root || resolved === home) return null;
+  return hashProjectId(findGitRoot(resolved) ?? resolved);
 }
 
 export function deriveProjectId(cwd: string, extraction: StructuredExtraction, sessionId?: string): string {
@@ -268,26 +272,37 @@ export function saveProjectFingerprint(
   extraction: StructuredExtraction,
 ): void {
   try {
-    const existing = loadProjectFingerprint(projectId);
-    const newKnownFiles = [...new Set([
-      ...(existing?.knownFiles ?? []),
-      ...extraction.modifiedFiles.map(f => f.path),
-      ...extraction.readFiles,
-    ])].slice(-50); // Keep last 50 unique files
+    const fingerprintPath = getFingerprintPath(projectId);
+    ensureDir(path.dirname(fingerprintPath));
+    const release = acquireLockSync(fingerprintPath);
+    try {
+      const existing = loadProjectFingerprint(projectId);
+      const newKnownFiles = [...new Set([
+        ...(existing?.knownFiles ?? []),
+        ...extraction.modifiedFiles.map(f => f.path),
+        ...extraction.readFiles,
+      ])].slice(-50); // Keep last 50 unique files
 
-    const detectedLanguage = detectLanguage(extraction);
-    const detectedFramework = detectFramework(extraction);
-    const fingerprint: ProjectFingerprint = {
-      id: projectId,
-      language: existing?.language && existing.language !== "unknown" ? existing.language : detectedLanguage,
-      framework: existing?.framework ?? detectedFramework,
-      keyDirectories: extractKeyDirs(extraction),
-      knownFiles: newKnownFiles,
-      sessionCount: (existing?.sessionCount ?? 0) + 1,
-      updatedAt: Date.now(),
-    };
+      const detectedLanguage = detectLanguage(extraction);
+      const detectedFramework = detectFramework(extraction);
+      const keyDirectories = [...new Set([
+        ...(existing?.keyDirectories ?? []),
+        ...extractKeyDirs(extraction),
+      ])].slice(-20);
+      const fingerprint: ProjectFingerprint = {
+        id: projectId,
+        language: existing?.language && existing.language !== "unknown" ? existing.language : detectedLanguage,
+        framework: existing?.framework ?? detectedFramework,
+        keyDirectories,
+        knownFiles: newKnownFiles,
+        sessionCount: (existing?.sessionCount ?? 0) + 1,
+        updatedAt: Date.now(),
+      };
 
-    writeJsonSync(getFingerprintPath(projectId), fingerprint, true);
+      writeJsonSync(fingerprintPath, fingerprint, true);
+    } finally {
+      release();
+    }
   } catch (e) { log.warn("saveProjectFingerprint failed", e); }
 }
 

--- a/src/utils/pruning.ts
+++ b/src/utils/pruning.ts
@@ -5,7 +5,7 @@
 
 import type { LlmMessage } from "../types.ts";
 import { isToolCallBlock } from "../utils/type-guards.ts";
-import { extractText, buildToolCallIndex, type ToolCallIndex } from "./extraction.ts";
+import { extractText, buildToolCallIndex, nestedToolCallId, type ToolCallIndex } from "./extraction.ts";
 import { estimateTokens } from "./tokens.ts";
 
 export interface PruningResult {
@@ -193,9 +193,7 @@ export function pruneRedundant(msgs: LlmMessage[], precomputedTcIdx?: ToolCallIn
         if (block.name === "multi_tool_use.parallel" && Array.isArray(block.arguments?.tool_uses)) {
           const tools = block.arguments.tool_uses as Record<string, unknown>[];
           const retained = tools.filter((tool, toolIndex) => {
-            const id = typeof tool.id === "string"
-              ? tool.id
-              : block.id ? block.id + "_" + toolIndex : "mtu_" + idx + "_" + toolIndex;
+            const id = nestedToolCallId(block.id, idx, toolIndex, tool.id);
             return !removedToolCallIds.has(id);
           });
           if (retained.length !== tools.length) changed = true;

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -11,7 +11,7 @@ import type {
 } from "../types.ts";
 import { VERSION, SEVEN_DAYS_MS, TRUNC, ID_PREFIX } from "../constants.ts";
 import { inferSessionType, normalizeFactKey } from "./helpers.ts";
-import { isDiagnosticConstraintText } from "./extraction.ts";
+import { isCompactionStatusText, isDiagnosticConstraintText, isTransientToolDiagnostic } from "./extraction.ts";
 import * as log from "./logger.ts";
 import { compactionStateFile, scopedCompactionStateFile } from "../infra/paths.ts";
 import { writeJsonSync, readJsonSync } from "../infra/fs.ts";
@@ -30,13 +30,19 @@ function isLegacySearchOutput(text: string): boolean {
 }
 
 export function sanitizeCompactionStateEvidence(state: CompactionState): CompactionState {
+  const isNoise = (text: string) => isLegacySearchOutput(text) || isTransientToolDiagnostic(text.replace(/^Unresolved error:\s*/i, ""));
+  const goal = state.goal && !isCompactionStatusText(state.goal) ? state.goal : null;
   const constraints = state.constraints.filter(item => !isDiagnosticConstraintText(item.text));
-  const unresolvedErrors = state.unresolvedErrors.filter(item => !isLegacySearchOutput(item.message));
-  const openLoops = state.openLoops.filter(item => !isLegacySearchOutput(item.summary));
-  if (constraints.length === state.constraints.length &&
+  const unresolvedErrors = state.unresolvedErrors.filter(item => !isNoise(item.message));
+  const resolvedErrors = state.resolvedErrors.filter(item => !isNoise(item.message));
+  const openLoops = state.openLoops.filter(item => !isNoise(item.summary));
+  const criticalContext = state.criticalContext.filter(item => !isNoise(item));
+  if (goal === state.goal && constraints.length === state.constraints.length &&
       unresolvedErrors.length === state.unresolvedErrors.length &&
-      openLoops.length === state.openLoops.length) return state;
-  return { ...state, constraints, unresolvedErrors, openLoops };
+      resolvedErrors.length === state.resolvedErrors.length &&
+      openLoops.length === state.openLoops.length &&
+      criticalContext.length === state.criticalContext.length) return state;
+  return { ...state, goal, constraints, unresolvedErrors, resolvedErrors, openLoops, criticalContext };
 }
 
 function freshState(fp: string, data: CompactionState | null): CompactionState | null {
@@ -218,20 +224,39 @@ function mergeBy<T>(current: T[], previous: T[], key: (item: T) => string, limit
   }).slice(0, limit);
 }
 
+const LOOP_PRIORITY: Record<OpenLoop["priority"], number> = { critical: 0, high: 1, normal: 2, low: 3 };
+
+/** Active work must consume the bounded loop budget before resolved history. */
+function mergeOpenLoops(current: OpenLoop[], previous: OpenLoop[]): OpenLoop[] {
+  return mergeBy(current, previous, item => normalizeFactKey(item.summary), Number.MAX_SAFE_INTEGER)
+    .map((item, order) => ({ item, order }))
+    .sort((a, b) => Number(a.item.status === "resolved") - Number(b.item.status === "resolved")
+      || LOOP_PRIORITY[a.item.priority] - LOOP_PRIORITY[b.item.priority]
+      || a.order - b.order)
+    .slice(0, 25)
+    .map(({ item }, index) => ({ ...item, id: ID_PREFIX.OPEN_LOOP + (index + 1) }));
+}
+
 /**
- * Conservative cross-compaction merge: absence from the latest active window
- * is not evidence that a decision, constraint, error, or loop was resolved.
+ * Conservative cross-compaction merge: neither absence nor free-form goal text
+ * is evidence that a decision, constraint, error, or loop was resolved.
  * Current facts win, old unresolved facts remain, and every collection is
- * bounded so continuity cannot grow without limit.
+ * bounded so continuity cannot grow without limit. Goal shifts are recorded as
+ * context; only positive resolution evidence or an explicit override retires a fact.
  */
 export function mergeCompactionStates(previous: CompactionState | null, current: CompactionState): CompactionState {
-  if (!previous) return applyContinuityOverrides(current, current.factOverrides ?? []);
+  if (!previous) {
+    const active = applyContinuityOverrides(current, current.factOverrides ?? []);
+    return { ...active, openLoops: mergeOpenLoops(active.openLoops, []) };
+  }
   const factOverrides = mergeBy(
     current.factOverrides ?? [], previous.factOverrides ?? [],
     item => item.kind + ":" + item.summaryKey, 50,
   );
   const activeCurrent = applyContinuityOverrides(current, factOverrides);
   const activePrevious = applyContinuityOverrides(previous, factOverrides);
+  const currentPresent = new Set([...activeCurrent.modifiedFiles, ...activeCurrent.readFiles].map(normalizeFactKey));
+  const currentDeleted = new Set(activeCurrent.deletedFiles.map(normalizeFactKey));
   const resolvedKeys = new Set(activeCurrent.resolvedErrors.map(error => normalizeFactKey(error.message)));
   const decisions = mergeBy(activeCurrent.decisions, activePrevious.decisions, item => normalizeFactKey(item.summary), 30)
     .map((item, index) => ({ ...item, id: ID_PREFIX.DECISION + (index + 1) }));
@@ -243,12 +268,7 @@ export function mergeCompactionStates(previous: CompactionState | null, current:
     item => normalizeFactKey(item.message),
     15,
   ).map((item, index) => ({ ...item, id: ID_PREFIX.ERROR + (index + 1) }));
-  const openLoops = mergeBy(
-    activeCurrent.openLoops,
-    activePrevious.openLoops.filter(loop => loop.status !== "resolved"),
-    item => normalizeFactKey(item.summary),
-    25,
-  ).map((item, index) => ({ ...item, id: ID_PREFIX.OPEN_LOOP + (index + 1) }));
+  const openLoops = mergeOpenLoops(activeCurrent.openLoops, activePrevious.openLoops);
   const oldGoal = activePrevious.goal && activeCurrent.goal && normalizeFactKey(activePrevious.goal) !== normalizeFactKey(activeCurrent.goal)
     ? ["Previous goal: " + activePrevious.goal]
     : [];
@@ -257,9 +277,21 @@ export function mergeCompactionStates(previous: CompactionState | null, current:
     goal: activeCurrent.goal ?? activePrevious.goal,
     decisions,
     constraints,
-    modifiedFiles: mergeBy(activeCurrent.modifiedFiles, activePrevious.modifiedFiles, normalizeFactKey, 100),
-    readFiles: mergeBy(activeCurrent.readFiles, activePrevious.readFiles, normalizeFactKey, 100),
-    deletedFiles: mergeBy(activeCurrent.deletedFiles, activePrevious.deletedFiles, normalizeFactKey, 50),
+    modifiedFiles: mergeBy(
+      activeCurrent.modifiedFiles,
+      activePrevious.modifiedFiles.filter(file => !currentDeleted.has(normalizeFactKey(file))),
+      normalizeFactKey, 100,
+    ),
+    readFiles: mergeBy(
+      activeCurrent.readFiles,
+      activePrevious.readFiles.filter(file => !currentDeleted.has(normalizeFactKey(file))),
+      normalizeFactKey, 100,
+    ),
+    deletedFiles: mergeBy(
+      activeCurrent.deletedFiles,
+      activePrevious.deletedFiles.filter(file => !currentPresent.has(normalizeFactKey(file))),
+      normalizeFactKey, 50,
+    ),
     unresolvedErrors,
     resolvedErrors: mergeBy(activeCurrent.resolvedErrors, activePrevious.resolvedErrors, item => normalizeFactKey(item.message), 20),
     openLoops,
@@ -341,34 +373,40 @@ export interface CompactionDelta {
 }
 
 export function computeDelta(prev: CompactionState, current: CompactionState): CompactionDelta {
-  // Match on full normalized text. Extraction is deterministic, so the same
-  // item yields identical text across compactions — the old `slice(0, N)` prefix
-  // keys collided two different items that shared an opening and made the
-  // change invisible in the delta (newDecisions/removedDecisions both empty).
-  const key = (s: string): string => s.toLowerCase().replace(/\s+/g, " ").trim();
+  // Match on full canonical fact identity. Extraction is deterministic, so the
+  // same item yields identical text across compactions.
+  const overrides = current.factOverrides ?? [];
+  const retired = (kind: ContinuityOverride["kind"]): Set<string> => new Set(overrides
+    .filter(item => item.kind === kind && item.status !== "active")
+    .map(item => item.summaryKey));
 
   // Decisions
-  const prevDecisionTexts = new Set(prev.decisions.map(d => key(d.summary)));
-  const currDecisionTexts = new Set(current.decisions.map(d => key(d.summary)));
+  const prevDecisionTexts = new Set(prev.decisions.map(d => normalizeFactKey(d.summary)));
   const newDecisions = current.decisions
-    .filter(d => !prevDecisionTexts.has(key(d.summary)))
+    .filter(d => !prevDecisionTexts.has(normalizeFactKey(d.summary)))
     .map(d => d.summary);
+  const retiredDecisions = retired("decision");
   const removedDecisions = prev.decisions
-    .filter(d => !currDecisionTexts.has(key(d.summary)))
+    .filter(d => retiredDecisions.has(normalizeFactKey(d.summary)))
     .map(d => d.summary);
 
   // Open loops (summaries are already bounded to ~120 chars at extraction time)
-  const prevLoopSummaries = new Map(prev.openLoops.filter(loop => loop.status !== "resolved").map(l => [key(l.summary), l]));
-  const currLoopKeys = new Set(current.openLoops.filter(loop => loop.status !== "resolved").map(l => key(l.summary)));
+  const prevLoopSummaries = new Map(prev.openLoops.filter(loop => loop.status !== "resolved").map(l => [normalizeFactKey(l.summary), l]));
+  const currLoopKeys = new Set(current.openLoops.filter(loop => loop.status !== "resolved").map(l => normalizeFactKey(l.summary)));
+  const resolvedLoopKeys = new Set([
+    ...current.openLoops.filter(loop => loop.status === "resolved").map(loop => normalizeFactKey(loop.summary)),
+    ...(current.loopOverrides ?? []).filter(item => item.status === "resolved").map(item => item.summaryKey),
+    ...retired("loop"),
+  ]);
   const resolvedLoops: string[] = [];
   const persistentLoops: string[] = [];
   for (const [k, loop] of prevLoopSummaries) {
     if (currLoopKeys.has(k)) persistentLoops.push(loop.summary);
-    else resolvedLoops.push(loop.summary);
+    else if (resolvedLoopKeys.has(k)) resolvedLoops.push(loop.summary);
   }
   const newLoops = current.openLoops
     .filter(loop => loop.status !== "resolved")
-    .filter(l => !prevLoopSummaries.has(key(l.summary)))
+    .filter(l => !prevLoopSummaries.has(normalizeFactKey(l.summary)))
     .map(l => l.summary);
 
   // Files: diff sets
@@ -376,13 +414,16 @@ export function computeDelta(prev: CompactionState, current: CompactionState): C
   const newModifiedFiles = current.modifiedFiles.filter(f => !prevFiles.has(f));
 
   // Errors (messages bounded to ~300 chars at build time)
-  const prevErrorMsgs = new Set(prev.unresolvedErrors.map(e => key(e.message)));
-  const currErrorMsgs = new Set(current.unresolvedErrors.map(e => key(e.message)));
+  const prevErrorMsgs = new Set(prev.unresolvedErrors.map(e => normalizeFactKey(e.message)));
+  const resolvedErrorKeys = new Set([
+    ...current.resolvedErrors.map(error => normalizeFactKey(error.message)),
+    ...retired("error"),
+  ]);
   const resolvedErrors = prev.unresolvedErrors
-    .filter(e => !currErrorMsgs.has(key(e.message)))
+    .filter(e => resolvedErrorKeys.has(normalizeFactKey(e.message)))
     .map(e => e.message);
   const newErrors = current.unresolvedErrors
-    .filter(e => !prevErrorMsgs.has(key(e.message)))
+    .filter(e => !prevErrorMsgs.has(normalizeFactKey(e.message)))
     .map(e => e.message);
 
   // Goal change

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -4,6 +4,7 @@
 
 import { CHARS_PER_TOKEN, TUNING } from "../constants.ts";
 import type { LlmMessage, ProviderCapabilities } from "../types.ts";
+import { lruGet, lruSet } from "./lru.ts";
 
 const PROVIDER_MAP: Record<string, ProviderCapabilities> = {
   // ── Anthropic family ──
@@ -126,39 +127,23 @@ export class TokenCalibrationStore {
   get(provider?: string, model?: string): number {
     if (!provider) return 1.0;
     const exactKey = calibrationKey(provider, model);
-    const exact = this.factors.get(exactKey);
-    if (exact !== undefined) {
-      this.factors.delete(exactKey);
-      this.factors.set(exactKey, exact);
-      return exact;
-    }
+    const exact = lruGet(this.factors, exactKey);
+    if (exact !== undefined) return exact;
     // Fall back to the provider-wide bucket so a fresh model still benefits
     // from sibling calibration until it builds up its own samples.
-    const providerKey = calibrationKey(provider);
-    const fallback = this.factors.get(providerKey);
-    if (fallback !== undefined) {
-      this.factors.delete(providerKey);
-      this.factors.set(providerKey, fallback);
-    }
-    return fallback ?? 1.0;
+    return lruGet(this.factors, calibrationKey(provider)) ?? 1.0;
   }
 
   calibrate(estimated: number, actual: number, provider?: string, model?: string): void {
     if (actual <= 0 || estimated <= 0 || !provider) return;
     const key = calibrationKey(provider, model);
-    const prev = this.factors.get(key) ?? 1.0;
+    const prev = lruGet(this.factors, key) ?? 1.0;
     // `estimated` already includes the previous factor. Convert the observed
     // actual/estimated correction back into an absolute target factor before
     // EMA smoothing; otherwise repeated calibration converges to sqrt(target).
     const target = prev * actual / estimated;
     const clamped = Math.max(TUNING.CALIBRATION_CLAMP_MIN, Math.min(TUNING.CALIBRATION_CLAMP_MAX, target));
-    this.factors.delete(key);
-    this.factors.set(key, prev * TUNING.EMA_PREV + clamped * TUNING.EMA_SAMPLE);
-    while (this.factors.size > Math.max(1, this.maxEntries)) {
-      const oldest = this.factors.keys().next().value;
-      if (oldest === undefined) break;
-      this.factors.delete(oldest);
-    }
+    lruSet(this.factors, key, prev * TUNING.EMA_PREV + clamped * TUNING.EMA_SAMPLE, Math.max(1, this.maxEntries));
   }
 
   size(): number { return this.factors.size; }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -200,11 +200,36 @@ describe("mergeExtractions — deduplication", () => {
 
     expect([...merged.readFiles].sort()).toEqual(["a.ts", "b.ts", "c.ts"]);
   });
+
+  it("uses newer file evidence to reconcile cached deletion status", () => {
+    const revived = mergeExtractions(
+      makeExtraction({ deletedFiles: ["src/a.ts"] }),
+      makeExtraction({ readFiles: ["src/a.ts"] }),
+      5,
+    );
+    expect(revived.deletedFiles).toEqual([]);
+    expect(revived.readFiles).toEqual(["src/a.ts"]);
+
+    const removed = mergeExtractions(
+      makeExtraction({ modifiedFiles: [{ path: "src/a.ts", toolCalls: 1, lastModifiedIndex: 1 }] }),
+      makeExtraction({ deletedFiles: ["src/a.ts"] }),
+      5,
+    );
+    expect(removed.modifiedFiles).toEqual([]);
+    expect(removed.deletedFiles).toEqual(["src/a.ts"]);
+  });
 });
 
 // ── messageCount ──
 
 describe("mergeExtractions — cached error reconciliation", () => {
+  it("drops transient diagnostics inherited from an older cache", () => {
+    const base = makeExtraction({
+      errors: [{ index: 1, tool: "web_search", message: "Brave Search API error (429): rate limit exceeded", retryAttempted: false, resolved: false }],
+    });
+    expect(mergeExtractions(base, makeExtraction(), 5).errors).toEqual([]);
+  });
+
   it("matches full extraction when a cached error is resolved in the delta", () => {
     const failed: LlmMessage[] = [
       { role: "user", content: [{ type: "text", text: "run tests" }] },
@@ -254,12 +279,10 @@ describe("mergeExtractions — messageCount", () => {
 // ── mainGoal / lastUserMessages / lastErrors ──
 
 describe("mergeExtractions — field precedence", () => {
-  it("preserves the original (base) mainGoal over the delta suffix", () => {
-    // mainGoal is the FIRST user message (the original objective). The delta
-    // suffix's first user message is mid-conversation, not the goal — so base wins.
+  it("lets a newer substantive user goal supersede the cached goal", () => {
     const base = makeExtraction({ mainGoal: "old goal" });
     const delta = makeExtraction({ mainGoal: "new goal" });
-    expect(mergeExtractions(base, delta, 5).mainGoal).toBe("old goal");
+    expect(mergeExtractions(base, delta, 5).mainGoal).toBe("new goal");
   });
 
   it("falls back to base.mainGoal when delta is null", () => {

--- a/test/context-graph.test.ts
+++ b/test/context-graph.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Database } from "bun:sqlite";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -8,6 +9,8 @@ import {
   type ContextGraphScope,
 } from "../src/infra/context-graph.ts";
 import type { CompactionState } from "../src/types.ts";
+import { contextGraphFile } from "../src/infra/paths.ts";
+import { mergeCompactionStates } from "../src/utils/state.ts";
 
 const originalHome = process.env.HOME;
 let home = "";
@@ -77,6 +80,104 @@ describe("persistent context graph", () => {
     expect(alpha.some(result => result.content.includes("beta"))).toBe(false);
     expect(beta.some(result => result.content.includes("beta"))).toBe(true);
     expect(beta.some(result => result.content.includes("alpha"))).toBe(false);
+  });
+
+  it("keeps equivalent sibling occurrences isolated from resolution and overrides", () => {
+    const sharedDecision = { id: "decision", summary: "Use the shared release gate", type: "explicit" as const };
+    const sharedError = { id: "error", message: "Shared deployment port is occupied", tool: "bash", files: [] };
+    for (const branch of ["branch-a", "branch-b"]) {
+      indexCompactionState("project-a", state("project-a", "session-a", branch, {
+        decisions: [sharedDecision], unresolvedErrors: [sharedError],
+      }));
+    }
+
+    for (const branch of ["branch-a", "branch-b"]) {
+      const current = scope("project-a", "session-a", branch);
+      expect(recallContext(current, "shared release gate", { sessionOnly: true, kinds: ["decision"] })).toHaveLength(1);
+      expect(recallContext(current, "deployment port occupied", { sessionOnly: true, kinds: ["error"] })).toHaveLength(1);
+    }
+
+    indexCompactionState("project-a", state("project-a", "session-a", "branch-a", {
+      resolvedErrors: [sharedError],
+      factOverrides: [{
+        id: "override", kind: "decision", summaryKey: "use the shared release gate",
+        status: "superseded", updatedAt: Date.now(),
+      }],
+    }));
+
+    const branchA = scope("project-a", "session-a", "branch-a");
+    const branchB = scope("project-a", "session-a", "branch-b");
+    expect(recallContext(branchA, "shared release gate", { sessionOnly: true, kinds: ["decision"] })).toEqual([]);
+    expect(recallContext(branchA, "deployment port occupied", { sessionOnly: true, kinds: ["error"] })).toEqual([]);
+    expect(recallContext(branchB, "shared release gate", { sessionOnly: true, kinds: ["decision"] })).toHaveLength(1);
+    expect(recallContext(branchB, "deployment port occupied", { sessionOnly: true, kinds: ["error"] })).toHaveLength(1);
+  });
+
+  it("keeps common-ancestor facts active on a sibling after one branch resolves them", () => {
+    const decision = { id: "decision", summary: "Keep the ancestor release gate", type: "explicit" as const };
+    const error = { id: "error", message: "Ancestor deployment port is occupied", tool: "bash", files: [] };
+    indexCompactionState("project-a", state("project-a", "session-a", "ancestor", {
+      goal: "Ship the ancestor release", decisions: [decision], unresolvedErrors: [error],
+    }));
+
+    const branchAState = state("project-a", "session-a", "branch-a", {
+      goal: "Build the branch A API", resolvedErrors: [error],
+      factOverrides: [{
+        id: "override", kind: "decision", summaryKey: "keep the ancestor release gate",
+        status: "superseded", updatedAt: Date.now(),
+      }],
+    });
+    branchAState.scope!.branchAncestryIds = ["ancestor", "branch-a"];
+    indexCompactionState("project-a", branchAState);
+
+    const branchA = { ...scope(), branchEntryIds: ["ancestor", "branch-a"] };
+    const branchB = { ...scope("project-a", "session-a", "branch-b"), branchEntryIds: ["ancestor", "branch-b"] };
+    expect(recallContext(branchA, "ancestor release gate", { sessionOnly: true })).toEqual([]);
+    expect(recallContext(branchA, "ancestor deployment port", { sessionOnly: true })).toEqual([]);
+    expect(recallContext(branchA, "ancestor release", { sessionOnly: true, kinds: ["goal"] })).toEqual([]);
+    expect(recallContext(branchB, "ancestor release gate", { sessionOnly: true })
+      .some(result => result.content === "Keep the ancestor release gate")).toBeTrue();
+    expect(recallContext(branchB, "ancestor deployment port", { sessionOnly: true })
+      .some(result => result.content === "Ancestor deployment port is occupied")).toBeTrue();
+    expect(recallContext(branchB, "ancestor release", { sessionOnly: true, kinds: ["goal"] })
+      .some(result => result.content === "Ship the ancestor release")).toBeTrue();
+  });
+
+  it("resolves and supersedes facts beyond 256 entries on the same lineage", () => {
+    const error = { id: "old-error", message: "E1 lineage checksum is stale", tool: "bash", files: [] };
+    indexCompactionState("project-a", state("project-a", "session-a", "entry-1", {
+      goal: "Ship the E1 lineage release", unresolvedErrors: [error],
+    }));
+
+    const lineage = Array.from({ length: 301 }, (_, index) => "entry-" + (index + 1));
+    const current = state("project-a", "session-a", lineage.at(-1)!, {
+      goal: "Ship the replacement lineage release", resolvedErrors: [error],
+    });
+    current.scope!.branchAncestryIds = lineage;
+    indexCompactionState("project-a", current);
+
+    const currentScope = {
+      projectId: "project-a", sessionId: "session-a",
+      branchHeadId: lineage.at(-1), branchEntryIds: lineage,
+    };
+    expect(recallContext(currentScope, "E1 lineage checksum", { sessionOnly: true, kinds: ["error"] })).toEqual([]);
+    expect(recallContext(currentScope, "E1 lineage release", { sessionOnly: true, kinds: ["goal"] })
+      .some(result => result.content === "Ship the E1 lineage release")).toBeFalse();
+    expect(recallContext(currentScope, "replacement lineage release", { sessionOnly: true, kinds: ["goal"] })
+      .some(result => result.content === "Ship the replacement lineage release")).toBeTrue();
+  });
+
+  it("retires task facts only on the current branch lineage", () => {
+    indexCompactionState("project-a", state("project-a", "session-a", "branch-a", {
+      openLoops: [{ id: "loop-a", type: "bugfix", priority: "high", status: "open", summary: "repair alpha branch", files: [] }],
+    }));
+    indexCompactionState("project-a", state("project-a", "session-a", "branch-b"));
+    expect(recallContext(scope("project-a", "session-a", "branch-a"), "repair alpha", { sessionOnly: true })).not.toEqual([]);
+
+    const successor = state("project-a", "session-a", "branch-a-next");
+    successor.scope!.branchAncestryIds = ["branch-a", "branch-a-next"];
+    indexCompactionState("project-a", successor);
+    expect(recallContext(scope("project-a", "session-a", "branch-a-next"), "repair alpha", { sessionOnly: true })).toEqual([]);
   });
 
   it("indexes scoped state and never recalls another project", () => {
@@ -153,6 +254,91 @@ describe("persistent context graph", () => {
     expect(recallContext(scope(), "port occupied").some(result => result.kind === "error")).toBe(false);
   });
 
+  it("does not retire omitted task facts without positive resolution evidence", () => {
+    indexCompactionState("project-a", state("project-a", "session-a", "branch-a", {
+      goal: "Ship legacy release",
+      unresolvedErrors: [{ id: "error-1", message: "legacy release checksum failed", tool: "bash", files: [] }],
+      openLoops: [{ id: "loop-1", type: "bugfix", priority: "high", status: "open", summary: "repair legacy checksum", files: [] }],
+      nextActions: ["publish legacy candidate"],
+      criticalContext: ["legacy release branch is frozen"],
+    }));
+
+    indexCompactionState("project-a", state("project-a", "session-a", "branch-a", {
+      goal: "Build current API",
+      nextActions: ["implement current endpoint"],
+      criticalContext: ["current API remains backwards compatible"],
+    }));
+
+    expect(recallContext(scope(), "legacy checksum")).not.toEqual([]);
+    expect(recallContext(scope(), "legacy candidate")).not.toEqual([]);
+    expect(recallContext(scope(), "legacy branch frozen")).not.toEqual([]);
+    expect(recallContext(scope(), "current endpoint")).not.toEqual([]);
+    expect(recallContext(scope(), "backwards compatible")).not.toEqual([]);
+  });
+
+  it("keeps an unresolved loop recallable after bounded state evicts it", () => {
+    let merged: CompactionState | null = null;
+    const lineage: string[] = [];
+    for (let index = 0; index < 30; index++) {
+      const branch = "branch-" + index;
+      lineage.push(branch);
+      const current = state("project-a", "session-a", branch, {
+        openLoops: [{
+          id: "loop-" + index, type: "bugfix", priority: "critical", status: "open",
+          summary: "fix real production issue " + index, files: [],
+        }],
+      });
+      current.scope!.branchAncestryIds = [...lineage];
+      merged = mergeCompactionStates(merged, current);
+      indexCompactionState("project-a", merged);
+    }
+
+    expect(merged!.openLoops).toHaveLength(25);
+    expect(merged!.openLoops.some(loop => loop.summary === "fix real production issue 0")).toBeFalse();
+    expect(recallContext({
+      projectId: "project-a", sessionId: "session-a",
+      branchHeadId: lineage.at(-1), branchEntryIds: lineage,
+    }, "fix real production issue 0", { sessionOnly: true, kinds: ["loop"] })
+      .some(result => result.content === "fix real production issue 0")).toBeTrue();
+  });
+
+  it("migrates legacy derived facts away while preserving manual memory and FTS", () => {
+    const file = contextGraphFile();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const db = new Database(file);
+    db.exec(`
+      CREATE TABLE context_nodes (
+        id TEXT PRIMARY KEY, project_id TEXT NOT NULL, session_id TEXT NOT NULL,
+        branch_head_id TEXT, kind TEXT NOT NULL, fact_key TEXT NOT NULL,
+        title TEXT NOT NULL, content TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'active',
+        source TEXT NOT NULL, confidence REAL NOT NULL DEFAULT 0.8,
+        related_paths TEXT NOT NULL DEFAULT '[]', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+      );
+      CREATE UNIQUE INDEX context_nodes_fact ON context_nodes(project_id, session_id, kind, fact_key);
+      CREATE VIRTUAL TABLE context_nodes_fts USING fts5(
+        node_id UNINDEXED, title, content, kind, tokenize='unicode61 remove_diacritics 2'
+      );
+    `);
+    const insert = db.query(`
+      INSERT INTO context_nodes(
+        id, project_id, session_id, branch_head_id, kind, fact_key, title, content,
+        status, source, confidence, related_paths, created_at, updated_at
+      ) VALUES (?, 'project-a', ?, NULL, ?, ?, ?, ?, 'active', ?, 1, '[]', 1, 1)
+    `);
+    insert.run("manual-id", "*", "procedure", "preserve manual sentinel", "Legacy memory", "Preserve manual sentinel", "manual");
+    insert.run("derived-id", "session-a", "decision", "ephemeral zircon artifact", "Legacy fact", "Ephemeral zircon artifact", "compaction");
+    db.query("INSERT INTO context_nodes_fts(node_id, title, content, kind) VALUES (?, ?, ?, ?)")
+      .run("manual-id", "Legacy memory", "Preserve manual sentinel", "procedure");
+    db.query("INSERT INTO context_nodes_fts(node_id, title, content, kind) VALUES (?, ?, ?, ?)")
+      .run("derived-id", "Legacy fact", "Ephemeral zircon artifact", "decision");
+    db.close();
+
+    expect(recallContext(scope(), "preserve manual sentinel")[0]).toMatchObject({
+      id: "manual-id", source: "manual",
+    });
+    expect(recallContext(scope(), "ephemeral zircon artifact")).toEqual([]);
+  });
+
   it("saves explicit memory idempotently", () => {
     const input = {
       kind: "procedure" as const,
@@ -170,6 +356,35 @@ describe("persistent context graph", () => {
     expect(getContextGraphStats("project-a").activeNodes).toBeGreaterThan(0);
     expect(closeContextMemory("project-a", "procedure", input.content, "resolved")).toBe(1);
     expect(recallContext(scope(), "frozen install audit")).toEqual([]);
+  });
+
+  it("counts only active manual memory and permits idempotent saves at the cap", () => {
+    const existing = {
+      kind: "context" as const, title: "Existing", content: "active cap sentinel",
+    };
+    saveContextMemory(scope(), existing);
+    const db = new Database(contextGraphFile());
+    const insert = db.query(`
+      INSERT INTO context_nodes(
+        id, project_id, session_id, branch_head_id, kind, fact_key, title, content,
+        status, source, confidence, related_paths, created_at, updated_at
+      ) VALUES (?, 'project-a', '*', NULL, 'context', ?, 'Cap item', ?, 'active', 'manual', 1, '[]', 1, 1)
+    `);
+    for (let index = 1; index < 500; index++) {
+      insert.run("cap-" + index, "cap fact " + index, "cap fact " + index);
+    }
+    db.close();
+
+    expect(() => saveContextMemory(scope(), existing)).not.toThrow();
+    expect(() => saveContextMemory(scope(), {
+      kind: "context", title: "Blocked", content: "distinct over-cap memory",
+    })).toThrow("Project memory limit reached");
+
+    expect(closeContextMemory("project-a", "context", existing.content, "resolved")).toBe(1);
+    expect(() => saveContextMemory(scope(), {
+      kind: "context", title: "Replacement", content: "distinct replacement memory",
+    })).not.toThrow();
+    expect(recallContext(scope(), "distinct replacement memory")).toHaveLength(1);
   });
 
   it("deduplicates explicit memory across sessions and never evicts it with compaction facts", () => {

--- a/test/context-tools.test.ts
+++ b/test/context-tools.test.ts
@@ -27,11 +27,11 @@ function registeredTools(): Map<string, any> {
   return tools;
 }
 
-function context(approved = true) {
+function context(approved = true, cwd = process.cwd()) {
   return {
-    cwd: process.cwd(),
+    cwd,
     hasUI: true,
-    ui: { confirm: async () => approved },
+    ui: { confirm: async (_title: string, _message: string) => approved },
     sessionManager: {
       getSessionId: () => "session-a",
       getBranch: () => [{ id: "branch-root" }, { id: "branch-head" }],
@@ -89,12 +89,42 @@ describe("context memory tools", () => {
     expect(after.content[0].text).toContain("No matching");
   });
 
-  it("requires an independent host confirmation", async () => {
-    const save = registeredTools().get("smart_save_memory");
-    const result = await save.execute("save-2", {
-      kind: "context", content: "an inferred guess",
-    }, new AbortController().signal, () => {}, context(false));
+  it("fails closed for project memory save and recall from HOME or root", async () => {
+    const tools = registeredTools();
+    for (const cwd of [home, path.parse(home).root]) {
+      const ctx = context(true, cwd);
+      const saved = await tools.get("smart_save_memory").execute("unsafe-save", {
+        kind: "context", content: "must not cross projects",
+      }, new AbortController().signal, () => {}, ctx);
+      const recalled = await tools.get("smart_recall").execute("unsafe-recall", {
+        query: "cross projects",
+      }, new AbortController().signal, () => {}, ctx);
+      expect(saved.content[0].text).toContain("run from a project directory");
+      expect(recalled.content[0].text).toContain("run from a project directory");
+    }
+  });
+
+  it("shows the full scrubbed content before an unapproved long memory write", async () => {
+    const tools = registeredTools();
+    const content = "a".repeat(850) + " visible-confirmation-tail";
+    let confirmation = "";
+    const ctx = context();
+    ctx.ui.confirm = async (_title: string, message: string) => {
+      confirmation = message;
+      return false;
+    };
+
+    const result = await tools.get("smart_save_memory").execute("save-2", {
+      kind: "context", content,
+    }, new AbortController().signal, () => {}, ctx);
+
+    expect(confirmation).toContain(content);
+    expect(confirmation).toContain("visible-confirmation-tail");
     expect(result.content[0].text).toContain("user did not approve");
+    const recalled = await tools.get("smart_recall").execute("recall-unapproved", {
+      query: "visible confirmation tail",
+    }, new AbortController().signal, () => {}, ctx);
+    expect(recalled.content[0].text).toContain("No matching");
   });
 
   it("refuses memory writes in a non-interactive host", async () => {

--- a/test/dashboard-insights.test.ts
+++ b/test/dashboard-insights.test.ts
@@ -82,6 +82,7 @@ describe("dashboard trust insights", () => {
       ...Array.from({ length: 20 }, () => run()),
       ...Array.from({ length: 20 }, () => run({ releaseChannel: "canary", qualityFloorUsed: true })),
       run({ status: "error", failureKind: "provider", verificationScore: undefined }),
+      run({ status: "error", failureKind: "yield", verificationScore: undefined }),
     ];
     const damage = entries
       .filter(entry => entry.status === "success")
@@ -96,9 +97,12 @@ describe("dashboard trust insights", () => {
       stage: "synthesize", provider: "openai", model: "gpt", reliability: 1,
     });
     expect(insights.failures.provider).toBe(1);
+    expect(insights.failures.yield).toBe(1);
     expect(insights.canary.decision).toBe("promote");
     expect(formatDashboardQuality(insights).join("\n")).toContain("Data Confidence");
     expect(formatDashboardProviders(insights).join("\n")).toContain("openai/gpt");
-    expect(formatDashboardCanary(insights).join("\n")).toContain("PROMOTE");
+    const canaryText = formatDashboardCanary(insights).join("\n");
+    expect(canaryText).toContain("PROMOTE");
+    expect(canaryText).toContain("Runs (total/applied): stable 22/22 | canary 20/20");
   });
 });

--- a/test/extraction.test.ts
+++ b/test/extraction.test.ts
@@ -10,6 +10,7 @@ import {
   extractMainGoal,
   extractMediaAttachments,
   extractStructured,
+  nestedToolCallId,
 } from "../src/utils/extraction.ts";
 import type { LlmMessage, ProfileConfig } from "../src/types.ts";
 
@@ -70,6 +71,18 @@ describe("trackFileOps", () => {
     expect(ops.read[0]).toBe("/tmp/bar.ts");
   });
 
+  it("does not infer deletion from source prose and lets newer access revive a path", () => {
+    const msgs: LlmMessage[] = [
+      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "delete", arguments: { path: "/tmp/bar.ts" } }] },
+      { role: "toolResult", toolCallId: "1", content: "deleted" },
+      { role: "assistant", content: [{ type: "toolCall", id: "2", name: "read", arguments: { path: "/tmp/bar.ts" } }] },
+      { role: "toolResult", toolCallId: "2", content: "// removed legacy branch, file remains" },
+    ];
+    const ops = trackFileOps(msgs);
+    expect(ops.deleted).toEqual([]);
+    expect(ops.read).toEqual(["/tmp/bar.ts"]);
+  });
+
   it("classifies payload-carrying path tools as modifications (name-agnostic)", () => {
     // Names are deliberately varied/unknown to prove classification is by
     // argument shape, not name: any tool carrying a path + content payload is
@@ -128,6 +141,38 @@ describe("catalogErrors", () => {
     const errs = catalogErrors(msgs);
     expect(errs.length).toBe(1);
     expect(errs[0].tool).toBe("bash");
+  });
+
+  it("excludes transient provider and invocation diagnostics from continuity errors", () => {
+    const messages = [
+      "Brave Search API error (429): rate limit exceeded for plan",
+      "npm error code ENOLOCK\nnpm error audit This command requires an existing lockfile",
+      "Found 2 occurrences of edits[2] in test/a.ts. Each oldText must be unique.",
+      "Unknown JSON field: url Available fields: tagName name",
+    ];
+    for (const [index, content] of messages.entries()) {
+      const id = String(index);
+      expect(catalogErrors([
+        { role: "assistant", content: [{ type: "toolCall", id, name: "bash", arguments: { command: "failing command" } }] },
+        { role: "toolResult", toolCallId: id, isError: true, content },
+      ])).toEqual([]);
+    }
+    expect(catalogErrors([
+      { role: "assistant", content: [{ type: "toolCall", id: "real", name: "bash", arguments: { command: "bun test" } }] },
+      { role: "toolResult", toolCallId: "real", isError: true, content: "test failed in auth.ts" },
+    ])).toHaveLength(1);
+  });
+
+  it("keeps real project test failures that mention HTTP 429 rate limits", () => {
+    const errors = catalogErrors([
+      { role: "assistant", content: [{ type: "toolCall", id: "429-test", name: "bash", arguments: { command: "bun test" } }] },
+      {
+        role: "toolResult", toolCallId: "429-test", isError: true,
+        content: "FAIL rate limiter returns HTTP 429 when rate limit is exceeded\nExpected: 429\nReceived: 200",
+      },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].tool).toBe("bash");
   });
 
   it("ignores rg/grep exit 1 when every chained command is a search", () => {
@@ -225,12 +270,35 @@ describe("mineConstraints", () => {
 });
 
 describe("extractMainGoal", () => {
-  it("extracts first non-command user message", () => {
+  it("uses the latest substantive request while ignoring commands and acknowledgements", () => {
     const msgs: LlmMessage[] = [
       { role: "user", content: "/compact" },
       { role: "user", content: "Build a todo app" },
+      { role: "user", content: "Now fix the authentication regression" },
+      { role: "user", content: "tamam devam et" },
     ];
-    expect(extractMainGoal(msgs)).toBe("Build a todo app");
+    expect(extractMainGoal(msgs)).toBe("Now fix the authentication regression");
+  });
+
+  it("recovers the canonical goal from a host compaction summary", () => {
+    const compacted = "The conversation history before this point was compacted into the following summary:\n\n<summary>\n## Goal\nShip the stable release\n\n## Progress\n- working\n</summary>";
+    expect(extractMainGoal([
+      { role: "user", content: compacted },
+      { role: "user", content: "okay" },
+    ])).toBe("Ship the stable release");
+  });
+
+  it("treats a goal-less host summary as a boundary to older raw goals", () => {
+    const compacted = "The conversation history before this point was compacted into the following summary:\n\n<summary>\n## Progress\n- working\n</summary>";
+    expect(extractMainGoal([
+      { role: "user", content: "Old raw goal that predates compaction" },
+      { role: "user", content: compacted },
+    ])).toBeNull();
+  });
+
+  it("does not revive a compaction status banner as the active goal", () => {
+    const compacted = "The conversation history before this point was compacted into the following summary:\n\n<summary>\n## Goal\nEESV Compact (model, balanced) — 259,782t Warning: Smart compact skipped\n</summary>";
+    expect(extractMainGoal([{ role: "user", content: compacted }])).toBeNull();
   });
 });
 
@@ -270,6 +338,12 @@ describe("extractStructured", () => {
 // ── multi_tool_use.parallel wrapper shape ──
 
 describe("buildToolCallIndex — multi_tool_use.parallel", () => {
+  it("uses one exact identity contract for real and synthetic nested calls", () => {
+    expect(nestedToolCallId("wrapper", 7, 2, "real-id")).toBe("real-id");
+    expect(nestedToolCallId("wrapper", 7, 2)).toBe("wrapper_2");
+    expect(nestedToolCallId(undefined, 7, 2)).toBe("mtu_7_2");
+  });
+
   it("flattens nested tool_uses with real ids when present", () => {
     const msgs: LlmMessage[] = [
       {

--- a/test/fingerprint.test.ts
+++ b/test/fingerprint.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "bun:test";
-import { deriveProjectId, findGitRoot, buildProjectContext } from "../src/utils/fingerprint.ts";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { acquireLockSync, ensureDir } from "../src/infra/fs.ts";
+import { deriveProjectId, deriveProjectIdFromCwd, findGitRoot, buildProjectContext } from "../src/utils/fingerprint.ts";
 import type { StructuredExtraction } from "../src/types.ts";
 
 const TEST_CWD = ""; // empty cwd forces path-based derivation in tests
@@ -198,6 +203,18 @@ describe("deriveProjectId — absolute path resolution", () => {
 // ── Git-root based projectId ──
 
 describe("deriveProjectId — cwd/git-root priority", () => {
+  it("fails closed for HOME and filesystem root", () => {
+    expect(deriveProjectIdFromCwd(process.env.HOME!)).toBeNull();
+    expect(deriveProjectIdFromCwd(path.parse(process.cwd()).root)).toBeNull();
+  });
+
+  it("preserves repository cwd parity", () => {
+    const rootId = deriveProjectIdFromCwd(process.cwd());
+    expect(rootId).not.toBeNull();
+    expect(deriveProjectIdFromCwd(path.join(process.cwd(), "src"))).toBe(rootId);
+    expect(rootId).toBe(deriveProjectId(process.cwd(), makeExtraction()));
+  });
+
   it("finds the real git root for the current directory", () => {
     const root = findGitRoot(process.cwd());
     expect(root).not.toBeNull();
@@ -218,6 +235,54 @@ describe("deriveProjectId — cwd/git-root priority", () => {
     const id2 = deriveProjectId(process.cwd(), makeExtraction({ readFiles: ["b.ts", "c.ts"] }));
     // Same cwd → same projectId (git-root or cwd hash)
     expect(id1).toBe(id2);
+  });
+});
+
+describe("saveProjectFingerprint", () => {
+  it("merges independent process updates under one project lock", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "psc-fingerprint-race-"));
+    const projectId = "proj-concurrent";
+    const target = path.join(home, ".pi", "agent", ".cache", "smart-compact", "projects", projectId + ".json");
+    ensureDir(path.dirname(target));
+    const release = acquireLockSync(target);
+    const moduleUrl = pathToFileURL(path.resolve("src/utils/fingerprint.ts")).href;
+    const workers = Array.from({ length: 4 }, (_, index) => {
+      const marker = path.join(home, "ready-" + index);
+      const source = `
+        import fs from "node:fs";
+        import { saveProjectFingerprint } from ${JSON.stringify(moduleUrl)};
+        fs.writeFileSync(process.env.MARKER, "ready");
+        saveProjectFingerprint(${JSON.stringify(projectId)}, {
+          modifiedFiles: [{ path: "src/area-${index}/file.ts", toolCalls: 1, lastModifiedIndex: 1 }],
+          readFiles: [], deletedFiles: [], errors: [], decisions: [], constraints: [], topics: [], timeline: [],
+          mainGoal: null, lastUserMessages: [], lastErrors: [], messageCount: 1
+        });
+      `;
+      return { marker, process: Bun.spawn([process.execPath, "-e", source], { env: { ...process.env, HOME: home, MARKER: marker } }) };
+    });
+
+    let released = false;
+    const releaseLock = () => {
+      if (!released) { release(); released = true; }
+    };
+    try {
+      const deadline = Date.now() + 5_000;
+      while (workers.some(worker => !fs.existsSync(worker.marker)) && Date.now() < deadline) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+      }
+      expect(workers.every(worker => fs.existsSync(worker.marker))).toBe(true);
+      releaseLock();
+
+      expect(await Promise.all(workers.map(worker => worker.process.exited))).toEqual([0, 0, 0, 0]);
+      const fingerprint = JSON.parse(fs.readFileSync(target, "utf8"));
+      expect(fingerprint.sessionCount).toBe(4);
+      expect(fingerprint.knownFiles.sort()).toEqual(Array.from({ length: 4 }, (_, index) => "src/area-" + index + "/file.ts"));
+      expect(fingerprint.keyDirectories.sort()).toEqual(Array.from({ length: 4 }, (_, index) => "src/area-" + index));
+    } finally {
+      releaseLock();
+      await Promise.allSettled(workers.map(worker => worker.process.exited));
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/index-tool.test.ts
+++ b/test/index-tool.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import smartCompactExtension from "../src/index.ts";
+import { BUDGET_LIMITS } from "../src/constants.ts";
 
 describe("smart_compact tool cancellation", () => {
   it("publishes mode and aggregate token-budget controls", () => {
@@ -12,7 +13,9 @@ describe("smart_compact tool cancellation", () => {
 
     expect(tool.parameters.properties.mode.description).toContain("fast, balanced, thorough");
     expect(tool.parameters.properties.mode.description).not.toContain("aggressive");
-    expect(tool.parameters.properties.max_input_tokens).toBeDefined();
+    expect(tool.parameters.properties.max_input_tokens.description).toContain(BUDGET_LIMITS.INPUT_TOKENS.min + "-" + BUDGET_LIMITS.INPUT_TOKENS.max);
+    expect(tool.parameters.properties.max_calls.description).toContain(BUDGET_LIMITS.CALLS.min + "-" + BUDGET_LIMITS.CALLS.max);
+    expect(tool.parameters.properties.max_latency_ms.description).toBe("Optional pipeline cancellation budget in milliseconds (" + BUDGET_LIMITS.LATENCY_MS.min + "-" + BUDGET_LIMITS.LATENCY_MS.max + ").");
   });
 
   it("does not start the pipeline when the host signal is already aborted", async () => {

--- a/test/infra-fs.test.ts
+++ b/test/infra-fs.test.ts
@@ -10,7 +10,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import {
-  atomicWriteFileSync, appendLineLocked, readJsonSync, writeJsonSync,
+  atomicWriteFile, atomicWriteFileSync, appendLineLocked, readJsonSync, writeJsonSync,
   ensureDir, acquireLockSync, trimFileTailLocked,
 } from "../src/infra/fs.ts";
 
@@ -27,6 +27,27 @@ describe("atomicWriteFileSync", () => {
     expect(fs.readFileSync(target, "utf8")).toBe("hello");
     const orphans = fs.readdirSync(tmp).filter(name => name.includes(".tmp."));
     expect(orphans).toEqual([]);
+  });
+
+  it("creates and normalizes private files and directories under umask 000", async () => {
+    const dir = path.join(tmp, "private");
+    const target = path.join(dir, "state.json");
+    fs.mkdirSync(dir, { mode: 0o777 });
+    fs.writeFileSync(target, "old", { mode: 0o666 });
+    fs.chmodSync(dir, 0o777);
+    fs.chmodSync(target, 0o666);
+    const previousUmask = process.umask(0);
+    try {
+      atomicWriteFileSync(target, "sync");
+      expect(fs.statSync(dir).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(target).mode & 0o777).toBe(0o600);
+
+      const asyncTarget = path.join(dir, "async.json");
+      await atomicWriteFile(asyncTarget, "async");
+      expect(fs.statSync(asyncTarget).mode & 0o777).toBe(0o600);
+    } finally {
+      process.umask(previousUmask);
+    }
   });
 
   it("preserves the previous file when the writer never gets to rename", () => {
@@ -48,6 +69,23 @@ describe("appendLineLocked", () => {
     expect(lines.map(l => JSON.parse(l).i)).toEqual([0, 1, 2, 3, 4]);
   });
 
+  it("normalizes append targets and directories under umask 000", () => {
+    const dir = path.join(tmp, "metrics");
+    const target = path.join(dir, "metrics.jsonl");
+    fs.mkdirSync(dir, { mode: 0o777 });
+    fs.writeFileSync(target, "old\n", { mode: 0o666 });
+    fs.chmodSync(dir, 0o777);
+    fs.chmodSync(target, 0o666);
+    const previousUmask = process.umask(0);
+    try {
+      appendLineLocked(target, "new");
+      expect(fs.statSync(dir).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(target).mode & 0o777).toBe(0o600);
+    } finally {
+      process.umask(previousUmask);
+    }
+  });
+
   it("returns a release function after acquiring a lock", () => {
     const target = path.join(tmp, "log2.jsonl");
     const release = acquireLockSync(target);
@@ -62,9 +100,8 @@ describe("appendLineLocked", () => {
     expect(fs.readFileSync(target, "utf8")).toContain("\"ok\":1");
   });
 
-  it("fails closed instead of appending without a lock", () => {
-    expect(() => appendLineLocked(path.join("/dev/null", "log.jsonl"), "unsafe"))
-      .toThrow("Failed to acquire lock");
+  it("fails closed instead of appending through a non-directory parent", () => {
+    expect(() => appendLineLocked(path.join("/dev/null", "log.jsonl"), "unsafe")).toThrow();
   });
 });
 

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -169,6 +169,9 @@ describe("metrics reporting", () => {
     expect(html).toContain("PROMOTE");
     expect(html).toContain("Stage provider/model comparison");
     expect(html).toContain("openai/gpt");
+    expect(html).toContain("Runs (total/applied)");
+    expect(html).toContain("20/20");
+    expect(metricsReport.buildMetricsReport(entries, damage)).toContain("stable total/applied=20/20 · canary total/applied=20/20");
   });
 
   it("caps provider cache hit rate when cacheRead exceeds uncached input", () => {

--- a/test/pipeline-integration.test.ts
+++ b/test/pipeline-integration.test.ts
@@ -29,6 +29,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { extractWithCache } from "../src/app/steps/extract.ts";
 import { summarizeConversation } from "../src/app/steps/synthesize.ts";
 import { setLlmClient, resetLlmClient } from "../src/infra/llm-client.ts";
@@ -38,6 +41,8 @@ import type { TieredRc } from "../src/app/run-context.ts";
 import type { LlmMessage } from "../src/types.ts";
 import { createServices } from "../src/infra/services.ts";
 import { makeTokenEstimator } from "../src/utils/tokens.ts";
+import { resetConfigCache } from "../src/utils/helpers.ts";
+import { MAX_TOOL_OUTPUT_CHARS } from "../src/constants.ts";
 
 /**
  * Build a TieredRc with the minimum fields synthesizeConversation +
@@ -137,6 +142,76 @@ afterEach(() => {
 });
 
 describe("pipeline integration: extract -> synthesize (single-pass)", () => {
+  it("carries the full current branch lineage into continuity scope", () => {
+    const lineage = Array.from({ length: 301 }, (_, index) => ({ id: "entry-" + (index + 1) }));
+    const tiered = makeTieredRc([userMsg("continue the long lineage")]);
+    (tiered.ctx as any).sessionManager = { getBranch: () => lineage };
+
+    const extracted = extractWithCache(tiered);
+
+    expect(extracted.continuityScope.branchHeadId).toBe("entry-301");
+    expect(extracted.continuityScope.branchAncestryIds).toEqual(lineage.map(entry => entry.id));
+  });
+
+  it("skips backup serialization and scrubbing when backups are disabled", () => {
+    const tiered = makeTieredRc([
+      userMsg("Start"), assistantMsg("I'll be pruned"), userMsg("Continue"),
+      assistantMsg("Substantive evidence"), userMsg("Finish"),
+    ]);
+    tiered.services.scrubber = {
+      scrubText: () => { throw new Error("backup scrub should not run"); },
+      scrubValue: <T>(value: T) => ({ value, findings: [] }),
+      count: () => 0,
+    } as any;
+
+    expect(extractWithCache(tiered).backupPath).toBeNull();
+  });
+
+  it("backs up the full selected span while synthesis receives pruned input", async () => {
+    const previousHome = process.env.HOME;
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "psc-full-backup-"));
+    const backupDir = path.join(home, "backups");
+    fs.mkdirSync(path.join(home, ".pi", "agent"), { recursive: true });
+    fs.writeFileSync(path.join(home, ".pi", "agent", "settings.json"), JSON.stringify({
+      smartCompact: { backupEnabled: true, backupDir },
+    }));
+    process.env.HOME = home;
+    resetConfigCache();
+    const removedEvidence = "I'll remove-only backup evidence";
+    const truncatedEvidence = "TRUNCATED-MIDDLE-BACKUP-EVIDENCE";
+    const longToolResult: LlmMessage = {
+      role: "toolResult", toolCallId: "long-output", isError: false, timestamp: Date.now(),
+      content: [{ type: "text", text: "a".repeat(MAX_TOOL_OUTPUT_CHARS) + truncatedEvidence + "b".repeat(MAX_TOOL_OUTPUT_CHARS) }],
+    };
+    const messages = [
+      userMsg("Preserve the selected span"), assistantMsg(removedEvidence), longToolResult,
+      userMsg("Continue"), assistantMsg("Substantive synthesis evidence"), userMsg("Finish"),
+    ];
+    let request = "";
+    setLlmClient({ complete: async (...args: any[]) => {
+      request = JSON.stringify(args);
+      return makeSummaryResponse("## Goal\nPreserve evidence\n## Progress\n### Done\n- done\n### In Progress\n- none\n### Blocked\n- none\n## Critical Context\n- context");
+    } });
+
+    try {
+      const tiered = makeTieredRc(messages);
+      tiered.config.backupEnabled = true;
+      const extracted = extractWithCache(tiered);
+      expect(extracted.convText).not.toContain(removedEvidence);
+      expect(extracted.convText).not.toContain(truncatedEvidence);
+      const backup = fs.readFileSync(extracted.backupPath!, "utf8");
+      expect(backup).toContain(removedEvidence);
+      expect(backup).toContain(truncatedEvidence);
+      await summarizeConversation(extracted);
+      expect(request).not.toContain(removedEvidence);
+      expect(request).not.toContain(truncatedEvidence);
+    } finally {
+      process.env.HOME = previousHome;
+      resetConfigCache();
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("produces a summary when the LLM returns a well-formed markdown response", async () => {
     const messages: LlmMessage[] = [
       userMsg("Help me refactor src/auth.ts to use async/await."),
@@ -190,6 +265,31 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
     expect(synthesized.llmCalls).toBe(0);
     expect(callCount).toBe(0);
     expect(synthesized.finalSummary).toContain("src/auth.ts");
+  });
+
+  it("refines auto strategy without invalidating the already planned window budget", async () => {
+    const messages = [userMsg("Resolve the risky release"), assistantMsg("Working on it")];
+    setLlmClient({ complete: async () => makeSummaryResponse(
+      "## Goal\nResolve the risky release\n## Progress\n### Done\n- none\n### In Progress\n- release\n### Blocked\n- none\n## Critical Context\n- preserve context",
+    ) });
+    const tiered = makeTieredRc(messages);
+    tiered.requestedMode = "auto";
+    tiered.mode = "balanced";
+    tiered.config.maxLlmCalls = 0;
+    tiered.config.maxLlmInputTokens = 0;
+    (tiered as any).compactionPlan = { summaryBudgetTokens: tiered.profileCfg.summaryBudgetTokens };
+    const extracted = extractWithCache(tiered);
+    extracted.extraction.errors = Array.from({ length: 6 }, (_, index) => ({
+      index, tool: "bash", message: "test failed " + index, retryAttempted: false, resolved: false,
+    }));
+    const plannedBudget = extracted.profileCfg.summaryBudgetTokens;
+    const plannedProfile = extracted.profile;
+
+    const synthesized = await summarizeConversation(extracted);
+
+    expect(synthesized.mode).toBe("thorough");
+    expect(synthesized.profile).toBe(plannedProfile);
+    expect(synthesized.profileCfg.summaryBudgetTokens).toBe(plannedBudget);
   });
 
   it("does not use zero-call for token-dense tool-heavy context", async () => {

--- a/test/preflight-ui.test.ts
+++ b/test/preflight-ui.test.ts
@@ -121,6 +121,15 @@ describe("smart compact preflight UI", () => {
     expect(details).toContain("Route  openai/summary");
   });
 
+  it("discloses the verified-state reserve behind the projected result", () => {
+    const item = preview("balanced", true);
+    item.plan!.projectedAfterTokens = 27_500;
+    item.plan!.projectedSavedTokens = 62_500;
+    item.plan!.projectedYield = 62_500 / 90_000;
+    expect(formatPreflightSummary(item, "openai/summary").join("\n"))
+      .toContain("summary up to 6K + ~1.5K verified-state reserve");
+  });
+
   it("renders the three-mode decision card, supports D, and never exceeds width", async () => {
     const result = await showCompactUI(context((component, done) => {
       const narrowLines = component.render(36);
@@ -143,6 +152,20 @@ describe("smart compact preflight UI", () => {
       expect(done.value).toBeDefined();
     }), opts);
     expect(result?.mode).toBe("fast");
+  });
+
+  it("scans the active branch once for all three mode previews", async () => {
+    const ctx = context(component => component.handleInput("esc"));
+    const original = ctx.sessionManager.buildContextEntries;
+    let scans = 0;
+    ctx.sessionManager.buildContextEntries = () => {
+      scans++;
+      return original();
+    };
+
+    await showCompactUI(ctx, opts);
+
+    expect(scans).toBe(1);
   });
 
   it("uses the configured summary route as the initial preflight model", async () => {

--- a/test/progress-feedback.test.ts
+++ b/test/progress-feedback.test.ts
@@ -48,8 +48,10 @@ describe("semantic compact progress", () => {
     notifyAppliedCompaction(ctx, {
       tokensBefore: 1_000, tokensSaved: 400, plannedAfterTokens: 550, estimatedAfterTokens: 600, estimatedYield: 0.4,
       qualityScore: 100,
+      provenance: { initialScore: 11, deterministicPatched: [{ kind: "missing-goal", goal: "ship" }], llmPatched: false, qualityFloorUsed: true, finalScore: 100, remainingGaps: [] },
     } as any, false);
     expect(calls.at(-1)).toContain("1,000t → planned ~550t / ~600t applied estimate");
+    expect(calls.at(-1)).toContain("verified 100/100 coverage (source 11/100, safety fallback)");
     expect(calls.at(-1)).toContain("0 gaps");
     expect(calls.at(-1)).not.toContain("actual");
   });

--- a/test/pruning.test.ts
+++ b/test/pruning.test.ts
@@ -151,6 +151,26 @@ describe("pruneRedundant", () => {
     expect(wrapper.flatMap(block => block.arguments?.tool_uses ?? []).map(tool => tool.id)).toEqual(["e1"]);
   });
 
+  it("uses extraction's synthetic nested identity when pruning id-less parallel calls", () => {
+    const msgs: LlmMessage[] = [
+      makeMsg("user", "parallel reads"),
+      {
+        role: "assistant",
+        content: [{
+          type: "toolCall", name: "multi_tool_use.parallel",
+          arguments: { tool_uses: [{ recipient_name: "functions.read", parameters: { path: "a.ts" } }] },
+        }],
+      },
+      makeToolResult("mtu_1_0", "first"),
+      makeAssistantWithToolCall("r2", "read", { path: "a.ts" }),
+      makeToolResult("r2", "second"),
+    ];
+
+    const result = pruneRedundant(msgs);
+    expect(result.messages.some(message => message.toolCallId === "mtu_1_0")).toBe(false);
+    expect(result.messages.some(message => message.toolCallId === "r2")).toBe(true);
+  });
+
   it("prunes agent acknowledgment messages", () => {
     const msgs: LlmMessage[] = [
       makeMsg("user", "fix the bug"),

--- a/test/release-audit.test.ts
+++ b/test/release-audit.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { getNpmPackFilename } from "../scripts/release-audit-lib.ts";
+
+describe("release audit npm pack compatibility", () => {
+  it("accepts legacy array and npm 12 object output", () => {
+    expect(getNpmPackFilename([{ filename: "legacy.tgz" }])).toBe("legacy.tgz");
+    expect(getNpmPackFilename({ "pi-smart-compact": { filename: "npm12.tgz" } })).toBe("npm12.tgz");
+  });
+
+  it("rejects output without a filename", () => {
+    expect(getNpmPackFilename({ "pi-smart-compact": {} })).toBeNull();
+  });
+});

--- a/test/session-identity.test.ts
+++ b/test/session-identity.test.ts
@@ -12,6 +12,7 @@ import {
   resolveSessionId,
   isUnresolvedSessionId,
   type SessionIdentityContext,
+  branchEntryIds,
 } from "../src/infra/session-identity.ts";
 
 function ctxWith(id: string | undefined): SessionIdentityContext {
@@ -23,6 +24,12 @@ function ctxWith(id: string | undefined): SessionIdentityContext {
     },
   } as unknown as SessionIdentityContext;
 }
+
+describe("branchEntryIds", () => {
+  it("preserves full ordered ancestry while excluding absent and non-string ids", () => {
+    expect(branchEntryIds([{ id: "root" }, {}, { id: 42 }, { id: "leaf" }])).toEqual(["root", "leaf"]);
+  });
+});
 
 describe("resolveSessionId — real session id", () => {
   it("returns the host-provided id verbatim when present", () => {

--- a/test/state-step-continuity.test.ts
+++ b/test/state-step-continuity.test.ts
@@ -10,7 +10,7 @@ describe("buildState continuity integration", () => {
     const previous: CompactionState = {
       goal: "Ship auth", decisions: [{ id: "decision-1", summary: "Use JWT", type: "explicit" }],
       constraints: [{ id: "constraint-1", text: "No new dependencies", category: "prohibition", confidence: 1 }],
-      modifiedFiles: [], readFiles: [], deletedFiles: [],
+      modifiedFiles: [], readFiles: [], deletedFiles: ["package.json", "missing-v807-file.ts"],
       unresolvedErrors: [{ id: "error-1", message: "auth test still fails", tool: "bash", files: [] }], resolvedErrors: [],
       openLoops: [{ id: "loop-1", type: "bugfix", priority: "high", status: "open", summary: "fix auth test", files: [] }],
       topics: [], nextActions: [], criticalContext: [], sessionType: "implementation", compactionVersion: "7.22.0", updatedAt: Date.now(),
@@ -18,11 +18,12 @@ describe("buildState continuity integration", () => {
     previous.scope = { schemaVersion: 2, projectId, sessionId: "session-1", branchHeadId: "entry-1" };
     const extraction: StructuredExtraction = {
       modifiedFiles: [], readFiles: [], deletedFiles: [], errors: [], decisions: [], constraints: [], topics: [], timeline: [],
-      mainGoal: null, lastUserMessages: [], lastErrors: [], messageCount: 2,
+      mainGoal: "Ship auth", lastUserMessages: [], lastErrors: [], messageCount: 2,
     };
     const services = createServices();
     const rc: any = {
-      extraction, finalSummary: "## Goal\nContinue work\n\n## Next Steps\n1. Continue",
+      ctx: { cwd: process.cwd() },
+      extraction, finalSummary: "## Goal\nShip auth safely\n\n## Next Steps\n1. Continue",
       projectId, continuityScope: previous.scope, previousState: previous,
       llmMessages: [], explorationReport: null, config: { pinPaths: [] }, services,
       estimator: makeTokenEstimator("openai", "test", services.tokenCalibration),
@@ -45,7 +46,11 @@ describe("buildState continuity integration", () => {
     expect(result.finalSummary).toContain("No new dependencies");
     expect(result.finalSummary).toContain("auth test still fails");
     expect(result.finalSummary).toContain("fix auth test");
+    expect(result.finalSummary).not.toContain("Goal shifted");
     expect(result.details.mode).toBe("balanced");
+    expect(result.compactionState.goal).toBe("Ship auth safely");
+    expect(result.compactionState.deletedFiles).not.toContain("package.json");
+    expect(result.compactionState.deletedFiles).toContain("missing-v807-file.ts");
     expect(result.tokensSaved).toBeGreaterThan(10_000);
     expect(result.tokensSaved).toBeLessThan(20_000);
   });

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -5,7 +5,7 @@ import {
   computeDelta, formatDeltaSection, hasDeltaChanges, injectDeltaSection,
   saveCompactionState, loadCompactionState, loadScopedCompactionState,
   applyLoopOverrides, upsertLoopOverride, mergeCompactionStates, renderContinuityCapsule,
-  upsertContinuityOverride,
+  sanitizeCompactionStateEvidence, upsertContinuityOverride,
 } from "../src/utils/state.ts";
 import { scopedCompactionStateFile } from "../src/infra/paths.ts";
 import type { LlmMessage, StructuredExtraction, OpenLoop, ExplorationReport, CompactionState } from "../src/types.ts";
@@ -284,6 +284,99 @@ describe("continuity state", () => {
     expect(merged.openLoops.map(item => item.summary)).toContain("fix auth test");
   });
 
+  it("caps the first state and budgets active loops before resolved history", () => {
+    const first = mergeCompactionStates(null, makeFullState({
+      openLoops: Array.from({ length: 80 }, (_, index) => ({
+        id: "loop-" + index, type: "follow-up" as const, priority: "normal" as const,
+        status: "open" as const, summary: "first open " + index, files: [],
+      })),
+    }));
+    expect(first.openLoops).toHaveLength(25);
+
+    const active = Array.from({ length: 10 }, (_, index) => ({
+      id: "active-" + index, type: "bugfix" as const, priority: "critical" as const,
+      status: "open" as const, summary: "critical open " + index, files: [],
+    }));
+    const mixed = mergeCompactionStates(
+      makeFullState({
+        openLoops: Array.from({ length: 30 }, (_, index) => ({
+          id: "resolved-" + index, type: "follow-up" as const, priority: "normal" as const,
+          status: "resolved" as const, summary: "resolved history " + index, files: [],
+        })),
+      }),
+      makeFullState({ openLoops: active }),
+    );
+    expect(mixed.openLoops).toHaveLength(25);
+    expect(mixed.openLoops.filter(loop => loop.status !== "resolved").map(loop => loop.summary))
+      .toEqual(active.map(loop => loop.summary));
+  });
+
+  it("drops stale compaction status and transient diagnostics from continuity", () => {
+    const clean = sanitizeCompactionStateEvidence(makeFullState({
+      goal: "EESV Compact (model, balanced) — 259,782t Warning: Smart compact skipped",
+      unresolvedErrors: [{ id: "error-1", message: "Brave Search API error (429): rate limit exceeded", tool: "web_search", files: [] }],
+      resolvedErrors: [{ id: "error-2", message: "npm error code ENOLOCK npm audit requires an existing lockfile", tool: "bash" }],
+      openLoops: [{ id: "loop-1", type: "bugfix", priority: "normal", status: "open", summary: "Found 2 occurrences of edits[2]; oldText must be unique", files: [] }],
+      criticalContext: ["Unresolved error: Unknown JSON field: url Available fields: tagName", "Keep this invariant"],
+    }));
+    expect(clean.goal).toBeNull();
+    expect(clean.unresolvedErrors).toEqual([]);
+    expect(clean.resolvedErrors).toEqual([]);
+    expect(clean.openLoops).toEqual([]);
+    expect(clean.criticalContext).toEqual(["Keep this invariant"]);
+  });
+
+  it("records a newer goal without claiming carried diagnostics were resolved", () => {
+    const previous = makeFullState({
+      goal: "Ship the old release",
+      decisions: [{ id: "decision-1", summary: "Keep signed tags", type: "explicit" }],
+      unresolvedErrors: [{ id: "error-1", message: "old release test failed", tool: "bash", files: ["src/release.ts"] }],
+      openLoops: [
+        { id: "loop-1", type: "bugfix", priority: "high", status: "open", summary: "fix old release", files: ["src/release.ts"] },
+        { id: "loop-2", type: "follow-up", priority: "normal", status: "open", summary: "keep pinned", files: [] },
+      ],
+      loopOverrides: [{ id: "loop-2", summaryKey: "keep pinned", pinned: true }],
+      nextActions: ["publish old release"],
+      criticalContext: ["old release branch"],
+    });
+    const merged = mergeCompactionStates(previous, makeFullState({
+      goal: "Also add a regression test",
+      modifiedFiles: ["test/release.test.ts"],
+    }));
+
+    expect(merged.goal).toBe("Also add a regression test");
+    expect(merged.unresolvedErrors.map(error => error.message)).toContain("old release test failed");
+    expect(merged.resolvedErrors).toEqual([]);
+    expect(merged.openLoops.map(loop => [loop.summary, loop.status])).toEqual([
+      ["fix old release", "open"], ["keep pinned", "open"],
+    ]);
+    expect(merged.nextActions).toContain("publish old release");
+    expect(merged.criticalContext).toContain("Previous goal: Ship the old release");
+    expect(merged.criticalContext).toContain("old release branch");
+    expect(merged.decisions.map(item => item.summary)).toEqual(["Keep signed tags"]);
+
+    const nextCompaction = mergeCompactionStates(merged, makeFullState({ goal: "Also add a regression test" }));
+    expect(nextCompaction.unresolvedErrors.map(error => error.message)).toContain("old release test failed");
+    expect(nextCompaction.resolvedErrors).toEqual([]);
+    expect(nextCompaction.criticalContext.filter(item => item === "Previous goal: Ship the old release")).toHaveLength(1);
+  });
+
+  it("uses current file evidence to resolve prior deletion/presence status", () => {
+    const revived = mergeCompactionStates(
+      makeFullState({ deletedFiles: ["src/a.ts"] }),
+      makeFullState({ goal: null, readFiles: ["src/a.ts"] }),
+    );
+    expect(revived.deletedFiles).toEqual([]);
+
+    const removed = mergeCompactionStates(
+      makeFullState({ modifiedFiles: ["src/a.ts"], readFiles: ["src/a.ts"] }),
+      makeFullState({ goal: null, deletedFiles: ["src/a.ts"] }),
+    );
+    expect(removed.modifiedFiles).toEqual([]);
+    expect(removed.readFiles).toEqual([]);
+    expect(removed.deletedFiles).toEqual(["src/a.ts"]);
+  });
+
   it("drops diagnostic constraints carried from legacy state", () => {
     const previous = makeFullState({
       constraints: [
@@ -335,11 +428,13 @@ describe("computeDelta", () => {
     expect(delta.removedDecisions).toEqual([]);
   });
 
-  it("detects removed decisions", () => {
+  it("detects decisions removed by explicit override", () => {
     const prev = makeFullState({
       decisions: [{ id: "decision-1", summary: "Use sessions", type: "explicit" }],
     });
-    const curr = makeFullState();
+    const curr = makeFullState({
+      factOverrides: [{ id: "decision-override-1", kind: "decision", summaryKey: "use sessions", status: "superseded", updatedAt: 1 }],
+    });
     const delta = computeDelta(prev, curr);
     expect(delta.removedDecisions).toEqual(["Use sessions"]);
     expect(delta.newDecisions).toEqual([]);
@@ -354,6 +449,7 @@ describe("computeDelta", () => {
     });
     const curr = makeFullState({
       openLoops: [
+        { id: "loop-1", type: "bugfix", priority: "high", status: "resolved", summary: "fix auth bug", files: [] },
         { id: "loop-2", type: "follow-up", priority: "normal", status: "open", summary: "add tests", files: [] },
         { id: "loop-3", type: "bugfix", priority: "high", status: "open", summary: "fix caching issue", files: [] },
       ],
@@ -377,10 +473,38 @@ describe("computeDelta", () => {
     });
     const curr = makeFullState({
       unresolvedErrors: [{ id: "error-2", message: "build error", tool: "edit", files: [] }],
+      resolvedErrors: [{ id: "error-1", message: "test failed", tool: "bash" }],
     });
     const delta = computeDelta(prev, curr);
     expect(delta.resolvedErrors).toEqual(["test failed"]);
     expect(delta.newErrors).toEqual(["build error"]);
+  });
+
+  it("does not resolve cap-evicted loops, errors, or decisions by absence", () => {
+    const previous = makeFullState({
+      decisions: Array.from({ length: 30 }, (_, index) => ({ id: "decision-" + index, summary: "old decision " + index, type: "explicit" as const })),
+      unresolvedErrors: Array.from({ length: 15 }, (_, index) => ({ id: "error-" + index, message: "old error " + index, tool: "bash", files: [] })),
+      openLoops: Array.from({ length: 25 }, (_, index) => ({
+        id: "loop-" + index, type: "follow-up" as const, priority: "normal" as const,
+        status: "open" as const, summary: "old loop " + index, files: [],
+      })),
+    });
+    const merged = mergeCompactionStates(previous, makeFullState({
+      decisions: [{ id: "decision-new", summary: "new decision", type: "explicit" }],
+      unresolvedErrors: [{ id: "error-new", message: "new error", tool: "bash", files: [] }],
+      openLoops: [{ id: "loop-new", type: "bugfix", priority: "critical", status: "open", summary: "new critical loop", files: [] }],
+    }));
+    const delta = computeDelta(previous, merged);
+
+    expect(merged.decisions).toHaveLength(30);
+    expect(merged.unresolvedErrors).toHaveLength(15);
+    expect(merged.openLoops).toHaveLength(25);
+    expect(delta.removedDecisions).toEqual([]);
+    expect(delta.resolvedErrors).toEqual([]);
+    expect(delta.resolvedLoops).toEqual([]);
+    expect(delta.newDecisions).toEqual(["new decision"]);
+    expect(delta.newErrors).toEqual(["new error"]);
+    expect(delta.newLoops).toEqual(["new critical loop"]);
   });
 
   it("detects goal change", () => {

--- a/test/synthesis-cache.test.ts
+++ b/test/synthesis-cache.test.ts
@@ -45,6 +45,16 @@ describe("synthesis cache", () => {
     expect(getCachedSynthesis(synthesisCacheKey(differentRetention), 101)).toBeNull();
   });
 
+  it("separates differing focus even when focus weighting is disabled", () => {
+    const first = rc("s1");
+    first.config.focusWeighting = false;
+    const second = rc("s1");
+    second.config.focusWeighting = false;
+    second.focus = "database";
+
+    expect(synthesisCacheKey(first)).not.toBe(synthesisCacheKey(second));
+  });
+
   it("caches chunk summaries by content without sharing mutable arrays", () => {
     const key = batchCacheKey({ model: "x", text: "chunk" });
     setCachedBatch(key, [{

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -48,6 +48,22 @@ describe("privacy-safe canary telemetry", () => {
     expect(report.reasons[0]).toContain("more canary runs");
   });
 
+  it("holds when 19 dry-runs and one applied success only mimic a full canary sample", () => {
+    const baseline = Array.from({ length: 20 }, () => metric("stable"));
+    const canary = [
+      ...Array.from({ length: 19 }, () => metric("canary", { status: "dry-run" })),
+      metric("canary"),
+    ];
+    const report = assessCanary([...baseline, ...canary], observed([...baseline, ...canary]), {
+      version: "8.0.0", minCanaryRuns: 20,
+    });
+    expect(report.canary.runs).toBe(20);
+    expect(report.canary.appliedRuns).toBe(1);
+    expect(report.decision).toBe("hold");
+    expect(report.reasons[0]).toContain("19 more canary runs with applied outcomes");
+    expect(report.dataConfidence).toBeLessThan(60);
+  });
+
   it("promotes only when baseline, sample, quality, and damage-observation gates pass", () => {
     const entries = [
       ...Array.from({ length: 20 }, () => metric("stable")),
@@ -55,6 +71,7 @@ describe("privacy-safe canary telemetry", () => {
     ];
     const report = assessCanary(entries, observed(entries), { version: "8.0.0", minCanaryRuns: 20 });
     expect(report.decision).toBe("promote");
+    expect(report.canary.appliedRuns).toBe(20);
     expect(report.triggers).toEqual([]);
     expect(report.dataConfidence).toBe(100);
   });
@@ -85,6 +102,40 @@ describe("privacy-safe canary telemetry", () => {
     const report = assessCanary(entries, [], { version: "8.0.0", minCanaryRuns: 20 });
     expect(report.decision).toBe("rollback");
     expect(report.triggers).toContainEqual(expect.objectContaining({ metric: "failure-rate", threshold: ">5% absolute" }));
+  });
+
+  it("does not let dry-runs satisfy the early rollback sample floor", () => {
+    const entries = [
+      ...Array.from({ length: 20 }, () => metric("stable")),
+      ...Array.from({ length: 19 }, () => metric("canary", { status: "dry-run" })),
+      metric("canary", { status: "failure", verificationScore: 0 }),
+    ];
+    const report = assessCanary(entries, observed(entries), { version: "8.0.0", minCanaryRuns: 20 });
+    expect(report.canary.runs).toBe(20);
+    expect(report.canary.appliedRuns).toBe(1);
+    expect(report.decision).toBe("hold");
+  });
+
+  it("rolls back early with three real non-dry outcomes", () => {
+    const entries = [
+      ...Array.from({ length: 20 }, () => metric("stable")),
+      ...Array.from({ length: 3 }, () => metric("canary", { status: "failure", verificationScore: 0 })),
+    ];
+    const report = assessCanary(entries, [], { version: "8.0.0", minCanaryRuns: 20 });
+    expect(report.canary.appliedRuns).toBe(3);
+    expect(report.decision).toBe("rollback");
+  });
+
+  it("keeps failed non-dry runs in latency, token, and fallback evidence", () => {
+    const entries = [
+      ...Array.from({ length: 20 }, () => metric("stable")),
+      metric("canary", { avgLatency: 1_000, totalInput: 1_000, totalOutput: 0 }),
+      metric("canary", { status: "failure", avgLatency: 9_000, totalInput: 9_000, totalOutput: 0, method: "heuristic" }),
+    ];
+    const report = assessCanary(entries, observed(entries), { version: "8.0.0", minCanaryRuns: 20 });
+    expect(report.canary.p95LatencyMs).toBe(9_000);
+    expect(report.canary.avgTokens).toBe(5_000);
+    expect(report.canary.fallbackRate).toBe(0.5);
   });
 
   it("rolls back early on measurable regressions", () => {

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -243,6 +243,63 @@ Build
     expect(result.score).toBeLessThan(50);
   });
 
+  it("rejects target-added negation for positive goals, constraints, and decisions", () => {
+    const extraction = makeExtraction({
+      mainGoal: "Build the release with Bun",
+      constraints: [{ index: 1, text: "Build the release with Bun", category: "requirement", confidence: 1 }],
+      decisions: [{ index: 2, type: "explicit", summary: "Use Bun for release builds" }],
+    });
+    const summary = "## Goal\nDo not build the release with Bun\n## Constraints & Preferences\n- Do not build the release with Bun\n## Progress\n- waiting\n## Key Decisions\n- Do not use Bun for release builds\n## Critical Context\n- stable";
+    const result = verifySummary(summary, extraction);
+
+    expect(result.ok).toBe(false);
+    expect(result.gaps.filter(gap => gap.kind === "missing-goal")).toHaveLength(1);
+    expect(result.gaps.filter(gap => gap.kind === "missing-constraint")).toHaveLength(1);
+    expect(result.gaps.filter(gap => gap.kind === "missing-decision")).toHaveLength(1);
+    expect(result.gaps.filter(gap => gap.kind === "inconsistency")).toHaveLength(3);
+  });
+
+  it("accepts faithful double-negative restatements", () => {
+    const extraction = makeExtraction({
+      mainGoal: "Run release tests",
+      constraints: [{ index: 1, text: "Build the release with Bun", category: "requirement", confidence: 1 }],
+      decisions: [{ index: 2, type: "explicit", summary: "Run the release audit" }],
+    });
+    const summary = "## Goal\nNever forget to run release tests\n## Constraints & Preferences\n- Never skip building the release with Bun\n## Progress\n- working\n## Key Decisions\n- Do not fail to run the release audit\n## Critical Context\n- stable";
+
+    expect(verifySummary(summary, extraction).gaps).toEqual([]);
+  });
+
+  it("rejects standalone polarity-inverting guards", () => {
+    const targets = [
+      "Skip building the release",
+      "Forget to build the release",
+      "Omit building the release",
+      "Neglect to build the release",
+      "Fail to build the release",
+      "Avoid building the release",
+    ];
+    for (const target of targets) {
+      const summary = `## Goal\n${target}\n## Progress\n- waiting\n## Critical Context\n- stable`;
+      const result = verifySummary(summary, makeExtraction({ mainGoal: "Build the release" }));
+      expect(result.gaps.filter(gap => gap.kind === "missing-goal")).toHaveLength(1);
+      expect(result.gaps.filter(gap => gap.kind === "inconsistency")).toHaveLength(1);
+    }
+  });
+
+  it("keeps nested negation and inverting guards fail-closed", () => {
+    const cases = [
+      ["Run release tests", "Never forget not to run release tests"],
+      ["Build release artifacts", "Never forget to skip building release artifacts"],
+    ];
+    for (const [source, target] of cases) {
+      const summary = `## Goal\n${target}\n## Progress\n- waiting\n## Critical Context\n- stable`;
+      const result = verifySummary(summary, makeExtraction({ mainGoal: source }));
+      expect(result.gaps.filter(gap => gap.kind === "missing-goal")).toHaveLength(1);
+      expect(result.gaps.filter(gap => gap.kind === "inconsistency")).toHaveLength(1);
+    }
+  });
+
   it("does not confuse separate constraints that share a generic anchor", () => {
     const extraction = makeExtraction({
       constraints: [

--- a/test/window-boundary.test.ts
+++ b/test/window-boundary.test.ts
@@ -3,6 +3,8 @@ import { planCompactionWindow, resolveCompactionWindow } from "../src/app/steps/
 import type { PreparedRc } from "../src/app/run-context.ts";
 import type { SessionMessageEntry } from "../src/types.ts";
 import { makeTokenEstimator, TokenCalibrationStore } from "../src/utils/tokens.ts";
+import { POST_SUMMARY_RESERVE_RATIO } from "../src/constants.ts";
+import { verifyCompactionYield } from "../src/domain/yield-gate.ts";
 
 function messageEntry(
   id: string,
@@ -97,7 +99,7 @@ describe("resolveCompactionWindow tool-result boundary", () => {
     rc.notify = message => { notices.push(message); };
 
     expect(resolveCompactionWindow(rc)).toBeNull();
-    expect(notices.join(" ")).toContain("no eligible prefix remains");
+    expect(notices.join(" ")).toContain("no older prefix is available");
   });
 
   it("backs up when the token window naturally starts at a toolResult", () => {
@@ -350,9 +352,35 @@ describe("resolveCompactionWindow tool-result boundary", () => {
     expect(plan.projectedYield).toBeGreaterThanOrEqual(0.1);
     expect(plan.fixedContextTokens).toBeGreaterThan(500_000);
     expect(plan.summaryBudgetTokens).toBe(10_000);
-    expect(plan.targetAfterTokens).toBe(plan.fixedContextTokens + plan.retentionTargetTokens + plan.summaryBudgetTokens);
+    expect(plan.targetAfterTokens).toBe(
+      plan.fixedContextTokens + plan.retentionTargetTokens + plan.summaryBudgetTokens +
+        Math.ceil(plan.summaryBudgetTokens * POST_SUMMARY_RESERVE_RATIO),
+    );
     expect(plan.projectedAfterTokens).toBeLessThanOrEqual(plan.targetAfterTokens);
     expect(plan.hardBoundaryAdjusted).toBeFalse();
+  });
+
+  it("reserves post-synthesis state overhead and admits the reported near-target result", () => {
+    const branch = [
+      messageEntry("old", null, { role: "user", content: [{ type: "text", text: "old context" }] }),
+      messageEntry("recent", "old", { role: "assistant", content: [{ type: "text", text: "recent context" }] }),
+      messageEntry("tail", "recent", { role: "assistant", content: [{ type: "text", text: "tail" }] }),
+    ];
+    const profileCfg = {
+      summaryBudgetTokens: 6_000, keepRecentTokens: 20_000,
+      minChunkTokens: 500, maxChunkTokens: 8_000,
+      singlePassMaxTokens: 30_000, batchMaxTokens: 24_000,
+    };
+    const plan = planCompactionWindow({
+      msgs: branch, branch, messageTokens: [49_492, 20_008, 500], totalTokens: 70_000,
+      modelContextWindow: 70_020, mode: "balanced", profileCfg,
+      force: false, overflowedContext: false,
+    });
+
+    expect(plan.targetAfterTokens).toBe(28_008);
+    expect(plan.retainedTokens).toBe(20_508);
+    expect(plan.projectedAfterTokens).toBe(28_008);
+    expect(verifyCompactionYield(70_000, 7_347, plan).estimatedAfterTokens).toBe(27_855);
   });
 
   it("retains context up to the mode target instead of stopping at the minimum tail", () => {
@@ -452,7 +480,8 @@ describe("resolveCompactionWindow tool-result boundary", () => {
     expect(result.compactionPlan.retentionTargetTokens).toBeGreaterThanOrEqual(result.accTokens);
     expect(result.compactionPlan.summaryBudgetTokens).toBe(10_000);
     expect(result.compactionPlan.targetAfterTokens).toBe(
-      result.compactionPlan.fixedContextTokens + result.compactionPlan.retentionTargetTokens + 10_000,
+      result.compactionPlan.fixedContextTokens + result.compactionPlan.retentionTargetTokens + 10_000 +
+        Math.ceil(10_000 * POST_SUMMARY_RESERVE_RATIO),
     );
     expect(result.compactionPlan.hardBoundaryAdjusted).toBeFalse();
     expect(result.compactionPlan.relaxedSoftBoundaries).toContain("recent-user-turn");
@@ -473,7 +502,7 @@ describe("resolveCompactionWindow tool-result boundary", () => {
     rc.notify = message => { notices.push(message); };
 
     expect(resolveCompactionWindow(rc)).toBeNull();
-    expect(notices.join(" ")).toContain("projected saving is below 10%");
+    expect(notices.join(" ")).toContain("estimated saving is below 10%");
   });
 
   it("recovers with EESV when reported usage exceeds the active model window", () => {


### PR DESCRIPTION
## Summary

- preserve unresolved continuity across bounded state and branch-local graph lineage
- harden semantic verification, private persistence, project scope, backups, and manual memory consent
- require non-dry applied evidence for canary promotion and expose total/applied telemetry
- centralize correctness-critical identities and limits; remove dead indirection
- refresh README, architecture, migration, security, changelog, and package audit contracts

## Verification

- `bun run release:check`
- 792/792 main tests
- 302/302 adversarial gate tests
- TypeScript source/scripts typecheck and build
- 142-file packed artifact audit, frozen install, and CLI smoke tests
- Pi compatibility: locked 0.84.0 and latest 0.84.1
- `bun audit`: no vulnerabilities

## Rollout

Publish `pi-smart-compact@8.0.7` under the `next` dist-tag. Promote to `latest` only after sufficient real applied canary telemetry; dry-runs do not count as promotion evidence.
