### PR TITLE
fix: release v8.0.8 missing-file verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 No changes yet.
 
+## [8.0.8] - 2026-08-09
+
+### Fixed
+
+- Modified-file verification now accepts exact normalized paths from canonical `Files Modified` entries before collision-safe suffix matching. Root files that share a basename with nested files, plus top-level generic or short filenames, can be deterministically repaired without weakening the zero-gap verification gate.
+
 ## [8.0.7] - 2026-08-08
 
 ### Fixed

--- a/docs/MIGRATING_TO_V8.md
+++ b/docs/MIGRATING_TO_V8.md
@@ -1,6 +1,6 @@
 # Migrating from v7 to v8
 
-This guide applies to the stable `8.0.7` release.
+This guide applies to the stable `8.0.8` release.
 
 ## Compatibility
 
@@ -105,7 +105,7 @@ scrubbing, using 0600 files in a 0700 directory. Retention only prunes
 marker-owned backups.
 
 1. Back up `~/.pi/agent/settings.json` and the Smart Compact cache directory.
-2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.7`.
+2. Install the exact stable version: `pi install npm:pi-smart-compact@8.0.8`.
 3. Leave all model routes null initially.
 4. Keep `telemetryChannel: "stable"` unless intentionally running a separate
    canary cohort.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "engines": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "8.0.7";
+export const VERSION = "8.0.8";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.10;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -12,7 +12,7 @@ import { trackedComplete } from "../utils/cache.ts";
 import { getProviderCaps } from "../utils/tokens.ts";
 import { extractFileRefs } from "../utils/file-ref-detect.ts";
 import { isDiagnosticConstraintText } from "../utils/extraction.ts";
-import { buildUniquePathNeedles, isKnownPathReference } from "../utils/file-needles.ts";
+import { buildUniquePathNeedles, isKnownPathReference, normalizePath } from "../utils/file-needles.ts";
 import * as log from "../utils/logger.ts";
 import { parseSummary, findSection, appendToSection, renderSummary, summaryEvidenceLine, upsertSection } from "../domain/summary-parse.ts";
 import { canonicalHeading } from "../domain/summary-schema.ts";
@@ -267,9 +267,20 @@ export function verifySummary(
   }
 
   const modifiedPaths = extraction.modifiedFiles.map(file => file.path);
+  const listedModifiedPaths = new Set(
+    (findSection(parsed, "files-modified")?.body ?? "")
+      .split("\n")
+      .map(line => line
+        .replace(/^\s*(?:[-*+]|\d+[.)])\s+/, "")
+        .replace(/^\[[ x]\]\s+/i, "")
+        .trim())
+      .map(line => line.startsWith("`") && line.endsWith("`") ? line.slice(1, -1) : line)
+      .filter(Boolean)
+      .map(normalizePath),
+  );
   for (const file of extraction.modifiedFiles) {
     const needles = buildUniquePathNeedles(file.path, modifiedPaths);
-    if (!needles.some(needle => lower.includes(needle))) {
+    if (!listedModifiedPaths.has(normalizePath(file.path)) && !needles.some(needle => lower.includes(needle))) {
       gaps.push({ kind: "missing-file", path: file.path });
       score -= 5;
     }

--- a/src/utils/file-needles.ts
+++ b/src/utils/file-needles.ts
@@ -47,7 +47,7 @@ export const MIN_BARE_BASENAME_LEN = 5;
  * path. All needles are lowercased so substring matching can be done with
  * `errorMessage.toLowerCase().includes(needle)` cheaply.
  */
-function normalizePath(filePath: string): string {
+export function normalizePath(filePath: string): string {
   return filePath.replace(/\\/g, "/").replace(/^\.\//, "").toLowerCase();
 }
 

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -126,6 +126,21 @@ Something
     expect(result.gaps.some(gap => gap.kind === "missing-file" && gap.path === "packages/web/src/auth.ts")).toBe(true);
   });
 
+  it("accepts an exact root path without letting a nested path satisfy it", () => {
+    const extraction = makeExtraction({
+      modifiedFiles: [
+        { path: "README.md", toolCalls: 1, lastModifiedIndex: 1 },
+        { path: "agents/monitor/README.md", toolCalls: 1, lastModifiedIndex: 2 },
+      ],
+    });
+    const summary = "## Goal\nDocument monitor\n## Progress\n- docs updated\n## Files Modified\n- README.md\n- agents/monitor/README.md\n## Critical Context\n- none";
+    expect(verifySummary(summary, extraction).ok).toBe(true);
+
+    const nestedOnly = verifySummary(summary.replace("- README.md\n", ""), extraction);
+    expect(nestedOnly.gaps.some(gap => gap.kind === "missing-file" && gap.path === "README.md")).toBe(true);
+    expect(nestedOnly.gaps.some(gap => gap.kind === "missing-file" && gap.path === "agents/monitor/README.md")).toBe(false);
+  });
+
   it("penalizes potentially fabricated files", () => {
     const extraction = makeExtraction({
       modifiedFiles: [{ path: "/src/real.ts", toolCalls: 1, lastModifiedIndex: 2 }],
@@ -476,19 +491,21 @@ describe("verifyAndPatch", () => {
     expect(uiErrors).toEqual([]);
   });
 
-  it("repairs a patchable high-score gap instead of skipping it", async () => {
-    const extraction = makeExtraction({ modifiedFiles: [{ path: "src/auth.ts", toolCalls: 1, lastModifiedIndex: 1 }] });
-    const result = await verifyAndPatch({
-      finalSummary: "## Goal\nBuild auth\n## Progress\n- setup\n## Critical Context\n- stable",
-      extraction,
-      flags: { autoTriggered: true },
-      notify: () => {},
-      vlog: () => {},
-    } as any);
-    expect(result.finalSummary).toContain("src/auth.ts");
-    expect(result.verificationProvenance.initialScore).toBe(95);
-    expect(result.verificationProvenance.deterministicPatched).toHaveLength(1);
-    expect(result.verificationScore).toBe(100);
+  it("repairs top-level paths without usable suffix needles", async () => {
+    for (const path of ["index.ts", "x.ts"]) {
+      const extraction = makeExtraction({ modifiedFiles: [{ path, toolCalls: 1, lastModifiedIndex: 1 }] });
+      const result = await verifyAndPatch({
+        finalSummary: "## Goal\nBuild auth\n## Progress\n- setup\n## Critical Context\n- stable",
+        extraction,
+        flags: { autoTriggered: true },
+        notify: () => {},
+        vlog: () => {},
+      } as any);
+      expect(result.finalSummary).toContain(path);
+      expect(result.verificationProvenance.initialScore).toBe(95);
+      expect(result.verificationProvenance.deterministicPatched).toHaveLength(1);
+      expect(result.verificationScore).toBe(100);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- accept exact normalized paths from canonical `Files Modified` entries before collision-safe suffix matching
- let deterministic repair converge for root/nested basename collisions and top-level generic or short filenames
- preserve the zero-gap verification gate and existing compaction UX
- release as `8.0.8`

## Verification

- `bun run release:check`
- `bun run compat:pi 0.84.0`
- `bun run compat:pi latest` (0.84.1)
- `bun audit`
- production failure replay: 100 score, 0 gaps, unchanged fallback summary
- npm `pi-smart-compact@8.0.8` published with matching dry-run integrity