### PR TITLE
release: v9.1.0

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -213,11 +213,11 @@ Markdown prefixes and multiline wrapping cannot create false missing-error gaps.
 
 ## EESV hardening and control surfaces
 
-- **Canonical summary IR** accepts recognized H1/H2/H3 headings, preserves Progress subsections, and merges duplicate canonical kinds before state mutation.
-- **Typed verification gaps** drive mandatory deterministic repair; collision-aware path needles prevent basename cross-satisfaction. Provenance is persisted and shown before optional approval.
+- **Canonical summary IR** accepts recognized H1/H2/H3 headings outside fenced code, preserves Progress subsections, and merges duplicate canonical kinds before state mutation.
+- **Typed verification gaps** drive mandatory deterministic repair; collision-aware path needles prevent basename cross-satisfaction. Tool/file provenance and normalized semantic evidence are indexed once per verification pass, and truncated or delimiter-incomplete LLM patches are rejected. Provenance is persisted and shown before optional approval.
 - **Fine tool semantics** separate read/search/list/mutate/delete/execute operations. Pruning deduplicates only identical idempotent access signatures.
 - **Unified token planning** uses a run-bound estimator with bounded process-shared provider/model calibration, counts structured tool-call arguments, preserves an adaptive recent tail, targets mode-specific post-compaction headroom, reserves bounded deterministic post-summary state sections, clamps every provider request to the model's advertised output limit, and reserves/reconciles every request against aggregate prompt/output-token caps. Missing provider usage is estimated conservatively. Tool exchanges remain atomic; oversized result bodies are head/tail bounded only for synthesis after full deterministic extraction.
-- **Security boundaries** scrub high-confidence secrets before provider calls and durable cache/backup/state writes; PII scrubbing is opt-in. Backups remain in memory until confirmed apply.
+- **Security boundaries** recursively scrub structured messages before host serialization or provider calls, redact secret-bearing primitive values, and scrub plus hard-cap exploration tool feedback. PII scrubbing is opt-in. Backups remain unmaterialized until confirmed apply.
 - **Policy controls** include focus weighting, exact call/latency budgets, default fail-closed manual approval, online damage monitoring, and persisted open-loop overrides. Interactive review time is outside the pipeline deadline.
 - **Release gates** (`bun run gate`, `bun run bench`) cover adversarial parser, verification, tool, cache, budget, scrub and damage fixtures plus bounded p95 regressions for extraction, pruning, chunking, summary parsing, and path matching.
 
@@ -249,36 +249,41 @@ leaving one content-free safe-fallback notice in the UI.
 | `CompactionState` | `utils/state.ts` | immutable project/session/branch-head snapshots; descendants resolve the newest matching ancestor and siblings never overwrite each other |
 | Continuity Ledger | `utils/state.ts` | prior facts carry forward until positive resolution evidence or an explicit override; goal shifts become non-destructive breadcrumbs |
 | Cross-compaction delta | `utils/state.ts` | "Changes Since Last Compaction" section |
-| Incremental extraction cache | `utils/cache.ts` + `utils/id-fingerprint.ts` | bounded SHA-256 prefix fingerprint + tail; safe only when the pruned prefix still matches |
+| Incremental extraction cache | `utils/cache.ts` + `utils/id-fingerprint.ts` | bounded SHA-256 prefix fingerprint + tail; an exact pruned-payload match is reused directly, while incremental reuse is allowed only when the pruned prefix still matches |
 | Synthesis cache | `infra/synthesis-cache.ts` | behavior key includes normalized focus, route, mode, profile limits, run-level call/input/latency limits, and reasoning |
-| Session-log recovery | `utils/session-log.ts` | async bounded-memory JSONL scan with event-loop yields; bypasses pi-toolkit truncation by entry-id mapping without dropping late active-branch IDs at a fixed byte cap |
+| Session-log recovery | `utils/session-log.ts` | async bounded-memory JSONL scan with event-loop yields and a bounded path cache; bypasses pi-toolkit truncation by entry-id mapping without dropping late active-branch IDs at a fixed byte cap |
 | Project fingerprint | `utils/fingerprint.ts` | locked read/merge/write; language/framework/key dirs stay bounded and `sessionCount` tracks distinct hashed session identities |
 | Damage detection | `utils/damage.ts` | best-effort post-compaction regression signals |
 | Context graph | `infra/context-graph.ts` | SQLite FTS5 facts + file edges; 2,000 non-structural nodes per project |
 
 Apply-confirmed verified state is queued and duplicate updates coalesce only
-for the exact project/session/branch head, then indexed on the next event-loop
-turn so SQLite work is not part of the native
-compaction hook's latency. `infra/context-graph.ts` adapts the same synchronous
-query/transaction contract to `bun:sqlite` in Bun tests and `node:sqlite`
-`DatabaseSync` in Pi's Node runtime; the packed release audit exercises both.
-The referenced queue timer survives extension
+for the exact project/session/branch head. Replacing an existing key refreshes
+that pending value even at capacity; a divergent 65th key is rejected rather
+than evicting accepted work. The next event-loop turn drains the accepted
+batch through one reused SQLite connection, so connection setup and graph work
+are not part of the native compaction hook's latency.
+`infra/context-graph.ts` adapts the same fail-closed transaction contract to
+`bun:sqlite` in Bun tests and `node:sqlite` `DatabaseSync` in Pi's Node runtime;
+the packed release audit exercises both. The queue timer survives extension
 shutdown/reload in the process; graph data is derived and a later cumulative
-state safely supersedes a missed update after a hard process kill. Fact occurrences are branch-head scoped; state, recall, and resolution use the
+state safely supersedes a missed update after a hard process kill. Fact
+occurrences are branch-head scoped; state, recall, and resolution use the
 complete host-visible branch ancestry before equivalent facts are deduplicated.
 Schema v1 preserves user-confirmed manual memory but resets older derived
 compaction nodes once so sibling branches cannot inherit a last-writer identity.
-Recall starts from FTS5 lexical matches, expands one hop
-through file-reference edges, then applies session, branch, fact-kind,
-confidence, recency, and explicit-memory weights. Exact equivalent facts are
-deduplicated before bounded output. Resolved/superseded state is removed from
-the active FTS index; another project's rows are never eligible.
+Recall starts from FTS5 lexical matches whose rowids are the owning
+`context_nodes` rowids, expands one hop through file-reference edges, then
+applies session, branch, fact-kind, confidence, recency, and explicit-memory
+weights. Exact equivalent facts are deduplicated before bounded output.
+Resolved/superseded state is removed from the active FTS index; another
+project's rows are never eligible.
 
 **Important retention limits:** pending in-memory compaction 5 min · exploration
 tool-support cache 1 h / 128 routes · token calibration 128 routes · extraction
-cache 1 h · compaction state 7 d · context graph 2,000 non-structural fact nodes
-and 500 active manual memories per project · remediation hints 7 d · metrics and damage
-JSONL logs 5 MiB each.
+cache 1 h · compaction state 7 d / 64 snapshots · context graph 2,000
+non-structural fact nodes, 64 pending branch-head updates, and 500 active manual
+memories per project · remediation hints 7 d · metrics and damage JSONL logs
+5 MiB each · one exploration tool result 12,000 characters.
 
 ## Concurrency & safety model
 
@@ -296,30 +301,35 @@ loop). `consume()` returns a discriminated result:
 | `ok` | fresh payload for this session |
 | `empty` | nothing staged |
 | `expired` | older than the 5-minute TTL |
-| `mismatch` | staged by a **different** session (cross-session leak guard) |
+| `mismatch` | staged by a different session, project, or non-ancestor branch head |
 
 Session identity comes from [`infra/session-identity.ts`](./src/infra/session-identity.ts):
 a real id when the host exposes one, otherwise a per-call unforgeable
-`unresolved:<uuid>` — two unresolved sessions can never collide.
+`unresolved:<uuid>` — two unresolved sessions can never collide. Apply also
+requires the staged branch head to be the current head or one of its visible
+ancestors, so navigation to a sibling branch cannot consume stale payload.
 
 ### Cancellation deadlines
 
-Some providers ignore `AbortSignal`. The auto-trigger therefore uses a shared
-[`ExternalCancellation`](./src/app/run-smart-compact.ts) handle as a second line
-of defense: an outer `setTimeout` fires `abort()` and sets `timedOut`, and every
-side-effect gate in the orchestrator checks that flag before writing state or
-applying compaction. The caller waits for safe pipeline unwind; no unsafe
-`Promise.race` hard return can leave work running past the hook lifecycle.
+Automatic compaction combines the host event's `AbortSignal` with its own
+deadline through a shared [`ExternalCancellation`](./src/app/run-smart-compact.ts)
+handle. Either source calls `abort()`, and every side-effect gate in the
+orchestrator checks the shared state before writing or applying compaction.
+The caller waits for safe pipeline unwind; no unsafe `Promise.race` hard return
+can leave work running past the hook lifecycle.
 
 ### Filesystem & concurrency
 
 JSON/text cache writes use [`src/infra/fs.ts`](./src/infra/fs.ts): private
 artifact directories are 0700 and files are 0600; atomic temp-file + rename
 prevents half-truncated readers but intentionally does not claim fsync/power-loss
-durability. Append/trim operations use a `mkdir`-based cross-process lock and
-fail closed if ownership cannot be acquired, so sessions cannot interleave
-bytes. SQLite supplies its own WAL durability. Native continuity handoffs are
-one-shot, bounded, and keyed by project + session + branch head.
+durability. Append/trim operations run asynchronously, yield before synchronous
+filesystem work, and hold a `mkdir`-based cross-process lock for the complete
+transaction. Lock ownership is reclaimed by atomic rename, never by deleting a
+possibly renewed lease in place. Sessions therefore cannot interleave bytes or
+steal a live successor's lock. SQLite supplies its own WAL durability. Native
+continuity handoffs are one-shot, bounded, and keyed by project + session +
+branch head.
 
 ## Provider awareness
 
@@ -332,7 +342,7 @@ drives pipeline behavior:
 | --- | --- |
 | `maxOutputTokens` | caps synthesis / patch budgets |
 | `supportsTools` (`true \| false \| "probe"`) | exploration tool-call probing |
-| `concurrencyLimit` | batch synthesis wave scheduling |
+| `concurrencyLimit` | bounded batch-synthesis worker-pool width |
 | `cacheStrategy` | prompt-cache retention per call |
 | `timeoutMultiplier` | auto-trigger hard-timeout headroom |
 | `singlePassTokenMultiplier` | single-pass vs chunked threshold |
@@ -460,14 +470,14 @@ All external-world interaction.
 
 | File | Responsibility |
 | --- | --- |
-| `infra/fs.ts` | atomic writes, advisory locks |
+| `infra/fs.ts` | atomic writes, advisory locks, and yielding async append/trim |
 | `infra/paths.ts` | canonical cache/session/backup paths |
 | `infra/git.ts` | cached git-root discovery |
 | `infra/clock.ts` | injectable wall clock |
 | `infra/llm-client.ts` | LLM seam, custom-Codex wire cap, and ChatGPT Codex stream watchdog |
 | `infra/services.ts` | per-run services container |
 | `infra/session-identity.ts` | robust session-id resolution with opaque `unresolved:` fallback |
-| `infra/ai-messages.ts` | boundary adapters between `LlmMessage` and pi-ai `Message` |
+| `infra/ai-messages.ts` | validated message upcasts and recursive pre-serialization redaction |
 
 ### Utility layer (`src/utils/`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [9.1.0] - 2026-08-11
+
+### Fixed
+
+- Provider-bound messages are recursively redacted before host serialization, secret-bearing object keys redact non-string primitive values, and exploration tool results are redacted and hard-capped before re-entering model context.
+- Native apply now requires matching project/session branch ancestry, automatic hooks forward host cancellation into the shared abort path, stale run-lock leases are reclaimed atomically, and retained state snapshots are capped.
+- Incremental extraction preserves bounded evidence and exact cache payloads; shell mutation tracking covers explicit literal targets without treating arbitrary command text as paths.
+- Canonical summary parsing ignores headings inside fenced code, verifier patches reject truncation and unclosed fences, file-operation provenance is indexed once, and exact done-file checks no longer accept path collisions.
+- Stable normalized goal identities prevent paraphrase-only goal shifts, and task-specific completion evidence can close completed follow-up loops without generic acknowledgements doing so.
+- Zero/invalid context-window metadata follows one safe percentage policy, metrics tail reads honor the actual byte count, and nested `provider/model` identifiers are accepted by command and tool routing.
+
+### Performance
+
+- Window planning and extraction reuse token, tool-call, and referenced-file indexes; exact pruned extraction cache hits bypass recomputation.
+- Batch synthesis uses a bounded worker pool, session-log path discovery is cached, metrics appends yield off the event loop, state ancestry lookup is filename-indexed, and pending-slot newest lookup is constant-time.
+- Context-graph FTS rowids match their content rows, queued same-branch updates refresh in place, SQLite transactions share fail-closed rollback semantics, and one connection is reused per drain.
+
 ## [9.0.0] - 2026-08-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "engines": {

--- a/src/app/native-continuity-bridge.ts
+++ b/src/app/native-continuity-bridge.ts
@@ -32,6 +32,15 @@ function sameScope(a: NativeContinuityScope, b: NativeContinuityScope): boolean 
   return a.projectId === b.projectId && a.sessionId === b.sessionId && a.branchHeadId === b.branchHeadId;
 }
 
+function boundedContinuityText(text: string): string {
+  const bytes = Buffer.from(text);
+  if (bytes.length <= MAX_TEXT_BYTES) return text;
+  const marker = Buffer.from("\n… [continuity truncated from " + bytes.length + " bytes]\n");
+  let end = Math.max(0, MAX_TEXT_BYTES - marker.length);
+  while (end > 0 && (bytes[end] & 0xc0) === 0x80) end--;
+  return Buffer.concat([bytes.subarray(0, end), marker]).toString("utf8");
+}
+
 export function createNativeContinuityBridge(opts: {
   ttlMs?: number;
   maxEntries?: number;
@@ -98,13 +107,14 @@ export function createNativeContinuityBridge(opts: {
 
   return {
     stage(scope, text) {
-      if (!validScope(scope) || !text.trim() || Buffer.byteLength(text) > MAX_TEXT_BYTES) return;
+      if (!validScope(scope) || !text.trim()) return;
+      const boundedText = boundedContinuityText(text);
       try {
         locked(() => {
           const target = fileFor(scope);
           try { fs.unlinkSync(target); } catch { /* replace or absent */ }
           prune(1);
-          const entry: Entry = { schemaVersion: 1, scope, text, createdAt: now() };
+          const entry: Entry = { schemaVersion: 1, scope, text: boundedText, createdAt: now() };
           atomicWriteFileSync(target, JSON.stringify(entry));
           try { fs.chmodSync(target, 0o600); } catch { /* best effort */ }
         });

--- a/src/app/pending-slot.ts
+++ b/src/app/pending-slot.ts
@@ -32,57 +32,69 @@ interface PendingEntry {
 export function createPendingSlot(opts: PendingSlotOptions): PendingSlot {
   const ttlMs = opts.ttlMs;
   const now = opts.now ?? Date.now;
-  const maxEntries = Math.max(1, opts.maxEntries ?? 16);
+  const maxEntries = Math.max(1, opts.maxEntries ?? 64);
   const entries = new Map<string, PendingEntry>();
+  let newestSessionId: string | null = null;
 
-  const prune = () => {
-    const timestamp = now();
-    for (const [sessionId, entry] of entries) {
-      if (timestamp - entry.createdAt > ttlMs) entries.delete(sessionId);
-    }
+  const refreshNewest = (): void => {
+    newestSessionId = null;
+    for (const sessionId of entries.keys()) newestSessionId = sessionId;
   };
-
-  const newest = (): PendingEntry | undefined => {
-    let result: PendingEntry | undefined;
-    for (const entry of entries.values()) {
-      if (!result || entry.createdAt >= result.createdAt) result = entry;
+  const deleteEntry = (sessionId: string): void => {
+    if (!entries.delete(sessionId)) return;
+    if (newestSessionId === sessionId) refreshNewest();
+  };
+  const prune = (): void => {
+    const current = now();
+    let removedNewest = false;
+    for (const [sessionId, entry] of entries) {
+      if (current - entry.createdAt <= ttlMs) continue;
+      entries.delete(sessionId);
+      if (newestSessionId === sessionId) removedNewest = true;
     }
-    return result;
+    if (removedNewest) refreshNewest();
   };
 
   return {
     set(pending): void {
       prune();
+      // Reinsert overwrites at the newest position.
       entries.delete(pending.sessionId);
-      while (entries.size >= maxEntries) {
-        const oldestSession = entries.keys().next().value as string | undefined;
-        if (!oldestSession) break;
-        entries.delete(oldestSession);
-      }
       entries.set(pending.sessionId, { value: pending, createdAt: now() });
+      newestSessionId = pending.sessionId;
+      while (entries.size > maxEntries) {
+        const oldest = entries.keys().next().value as string | undefined;
+        if (oldest === undefined) break;
+        deleteEntry(oldest);
+      }
     },
 
     consume(ctx): ConsumeResult {
       const currentSessionId = resolveSessionId(ctx);
       const entry = entries.get(currentSessionId);
-      if (!entry) {
-        const other = entries.values().next().value as PendingEntry | undefined;
-        return other
-          ? { kind: "mismatch", expected: other.value.sessionId, actual: currentSessionId }
-          : { kind: "empty" };
+      if (entry) {
+        const ageMs = now() - entry.createdAt;
+        if (ageMs > ttlMs) {
+          deleteEntry(currentSessionId);
+          prune();
+          return { kind: "expired", ageMs };
+        }
+        deleteEntry(currentSessionId);
+        return { kind: "ok", pending: entry.value };
       }
-      const ageMs = now() - entry.createdAt;
-      if (ageMs > ttlMs) {
-        entries.delete(currentSessionId);
-        return { kind: "expired", ageMs };
-      }
-      entries.delete(currentSessionId);
-      return { kind: "ok", pending: entry.value };
+      prune();
+      const other = newestSessionId == null ? undefined : entries.get(newestSessionId);
+      return other
+        ? { kind: "mismatch", expected: other.value.sessionId, actual: currentSessionId }
+        : { kind: "empty" };
     },
 
     clear(sessionId): void {
-      if (sessionId) entries.delete(sessionId);
-      else entries.clear();
+      if (sessionId) deleteEntry(sessionId);
+      else {
+        entries.clear();
+        newestSessionId = null;
+      }
     },
 
     isPresent(sessionId): boolean {
@@ -92,9 +104,15 @@ export function createPendingSlot(opts: PendingSlotOptions): PendingSlot {
 
     peek(sessionId): Readonly<PendingCompaction> | null {
       prune();
-      return (sessionId ? entries.get(sessionId) : newest())?.value ?? null;
+      const entry = sessionId
+        ? entries.get(sessionId)
+        : newestSessionId == null ? undefined : entries.get(newestSessionId);
+      return entry?.value ?? null;
     },
 
-    size(): number { prune(); return entries.size; },
+    size(): number {
+      prune();
+      return entries.size;
+    },
   };
 }

--- a/src/app/preflight.ts
+++ b/src/app/preflight.ts
@@ -1,11 +1,11 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { PROFILES } from "../constants.ts";
-import type { CompactConfig, EffectiveCompactionMode, LlmMessage, ProfileConfig, SessionMessageEntry } from "../types.ts";
+import type { CompactConfig, EffectiveCompactionMode, LlmMessage, ProfileConfig, ProviderCapabilities, SessionMessageEntry } from "../types.ts";
 import { deriveProjectIdFromCwd } from "../utils/fingerprint.ts";
 import { computeToolCharPercentage } from "../utils/helpers.ts";
 import { readRecentDamageScores } from "../utils/damage.ts";
-import { getProviderCaps, makeTokenEstimator, type TokenCalibrationStore, type TokenEstimator } from "../utils/tokens.ts";
+import { getProviderCaps, makeTokenEstimator, safeContextPercent, type TokenCalibrationStore, type TokenEstimator } from "../utils/tokens.ts";
 import { MODE_POLICIES } from "./mode-policy.ts";
 import type { CompactionWindowPlan } from "./run-context.ts";
 import { estimateFinalSummaryAllowance, planCompactionWindow } from "./steps/window.ts";
@@ -21,7 +21,7 @@ export function preflightDamageMedian(cwd: string, config: CompactConfig): numbe
 export interface PreparedPreflightProfile {
   profileCfg: ProfileConfig;
   estimator: TokenEstimator;
-  providerCaps: ReturnType<typeof getProviderCaps>;
+  providerCaps: ProviderCapabilities;
   adapted: boolean;
   damageMedian: number;
 }
@@ -99,8 +99,9 @@ export function prepareManualPreflightContext(
   );
   const totalTokens = ctx.getContextUsage()?.tokens ?? 0;
   const modelContextWindow = ctx.model?.contextWindow;
-  const contextWindowTokens = modelContextWindow ?? 0;
-  const contextPercent = contextWindowTokens > 0 ? totalTokens / contextWindowTokens * 100 : 0;
+  const contextWindowTokens = Number.isFinite(modelContextWindow) && (modelContextWindow ?? 0) > 0
+    ? modelContextWindow as number : 0;
+  const contextPercent = safeContextPercent(totalTokens, modelContextWindow);
   const toolPercent = computeToolCharPercentage(branch);
   const overflowedContext = contextWindowTokens > 0 && totalTokens > contextWindowTokens;
   const estimator = makeTokenEstimator(summaryModel.provider, summaryModel.id, tokenCalibration);

--- a/src/app/run-smart-compact.ts
+++ b/src/app/run-smart-compact.ts
@@ -28,6 +28,7 @@ import type { CompactionMode, CompressionProfile } from "../types.ts";
 import { MODE_POLICIES, modeFromLegacyProfile, resolveMode } from "./mode-policy.ts";
 import { clearCompactProgress, showProgressOverlay, showResultScreen } from "../ui/overlays.ts";
 import * as log from "../utils/logger.ts";
+import { safeContextPercent } from "../utils/tokens.ts";
 
 import type {
   Notifier, RcBase, PendingRef, StatedRc,
@@ -131,7 +132,11 @@ function makeBase(opts: SmartCompactOptions): RcBase {
   const vlog = (msg: string) => { if (opts.verbose) log.info(msg); };
   const pipelineStart = Date.now();
   const requestedMode = opts.mode ?? modeFromLegacyProfile(opts.profile ?? "balanced");
-  const contextPercent = opts.ctx.getContextUsage()?.percent ?? 0;
+  const usage = opts.ctx.getContextUsage();
+  const reportedPercent = usage?.percent;
+  const contextPercent = Number.isFinite(reportedPercent) && (reportedPercent ?? 0) >= 0
+    ? reportedPercent as number
+    : safeContextPercent(usage?.tokens, opts.ctx.model?.contextWindow);
   const mode = resolveMode(requestedMode, contextPercent);
   const profile = opts.mode ? MODE_POLICIES[mode].profile : (opts.profile ?? MODE_POLICIES[mode].profile);
   return {
@@ -287,7 +292,7 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<Compac
     markPhase(stated, "state");
 
     if (stated.flags.dryRun) {
-      recordSuccessMetrics(stated, "dry-run");
+      await recordSuccessMetrics(stated, "dry-run");
       stated.ctx.ui.notify(
         "DRY RUN (" + stated.method + ", " + stated.mode + ") — " +
           stated.toCompact.length + " msgs, " + stated.llmCalls + " calls",
@@ -326,7 +331,7 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<Compac
       }
       if (decision !== "apply") {
         stated.pendingRef.clear(stated.sessionId);
-        recordSuccessMetrics(stated, "cancelled");
+        await recordSuccessMetrics(stated, "cancelled");
         stated.ctx.ui.notify("Compaction cancelled — current conversation unchanged", "info");
         return { kind: "cancelled", source: "user" };
       }
@@ -360,7 +365,7 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<Compac
     // The failure path may run before any step has populated stage data, so
     // we collect the few fields we need into a small bag. recordFailureMetrics
     // takes either a StatedRc (best case) or the partial bag.
-    recordFailureMetrics(finalRc ?? base, err, failureSummaryFields);
+    await recordFailureMetrics(finalRc ?? base, err, failureSummaryFields);
     throw err;
   } finally {
     opts.abortSignal?.removeEventListener("abort", abortFromHost);

--- a/src/app/session-run-lock.ts
+++ b/src/app/session-run-lock.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { Cell } from "../types.ts";
 import { runLocksDir } from "../infra/paths.ts";
+import { ONE_HOUR_MS } from "../constants.ts";
 
 export interface SessionRunLock extends Cell<boolean> {
   acquire(sessionId: string): boolean;
@@ -13,7 +14,7 @@ export interface SessionRunLock extends Cell<boolean> {
   size(): number;
 }
 
-interface FileLease { file: string; token: string; }
+interface FileLease { file: string; token: string; heartbeat?: NodeJS.Timeout; }
 interface RunLease { session?: FileLease; slot?: FileLease; }
 
 function processAlive(pid: number): boolean {
@@ -39,7 +40,18 @@ function acquireFileLease(file: string, staleMs: number): FileLease | null {
         try { fs.unlinkSync(file); } catch { /* best effort */ }
         throw error;
       } finally { fs.closeSync(fd); }
-      return { file, token };
+      const lease: FileLease = { file, token };
+      lease.heartbeat = setInterval(() => {
+        if (readLease(file)?.token !== token) {
+          if (lease.heartbeat) clearInterval(lease.heartbeat);
+          lease.heartbeat = undefined;
+          return;
+        }
+        try { fs.utimesSync(file, new Date(), new Date()); }
+        catch { /* release or another process won */ }
+      }, Math.max(10_000, Math.floor(staleMs / 3)));
+      lease.heartbeat.unref();
+      return lease;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       return null;
@@ -47,19 +59,35 @@ function acquireFileLease(file: string, staleMs: number): FileLease | null {
   };
   const first = create();
   if (first) return first;
+
   const current = readLease(file);
-  let observedAt = Number(current?.createdAt ?? 0);
-  if (!observedAt) {
-    try { observedAt = fs.statSync(file).mtimeMs; } catch { return null; }
-  }
+  let observedStat: fs.Stats;
+  try { observedStat = fs.statSync(file); } catch { return null; }
+  const observedAt = Math.max(Number(current?.createdAt ?? 0), observedStat.mtimeMs);
   const age = Date.now() - observedAt;
-  if ((current?.pid && processAlive(current.pid)) || age <= staleMs) return null;
+  const livePidCeiling = Math.max(ONE_HOUR_MS, staleMs * 4);
+  if (age <= staleMs || (current?.pid && processAlive(current.pid) && age <= livePidCeiling)) return null;
+
+  // Re-read both logical ownership and inode metadata immediately before
+  // reclaim. A release/reacquire that changed either must never be unlinked.
+  const latest = readLease(file);
+  let latestStat: fs.Stats;
+  try { latestStat = fs.statSync(file); } catch { return null; }
+  const latestAt = Math.max(Number(latest?.createdAt ?? 0), latestStat.mtimeMs);
+  const latestAge = Date.now() - latestAt;
+  if (latestAge <= staleMs || (latest?.pid && processAlive(latest.pid) && latestAge <= livePidCeiling)) return null;
+  if (current?.token
+    ? latest?.token !== current.token
+    : latestStat.dev !== observedStat.dev || latestStat.ino !== observedStat.ino
+      || latestStat.size !== observedStat.size || latestStat.mtimeMs !== observedStat.mtimeMs) return null;
   try { fs.unlinkSync(file); } catch { return null; }
   return create();
 }
 
 function releaseFileLease(lease?: FileLease): void {
   if (!lease) return;
+  clearInterval(lease.heartbeat);
+  lease.heartbeat = undefined;
   const current = readLease(lease.file);
   if (current?.token !== lease.token) return;
   try { fs.unlinkSync(lease.file); } catch { /* already removed */ }

--- a/src/app/steps/extract.ts
+++ b/src/app/steps/extract.ts
@@ -31,10 +31,11 @@ import { deriveProjectId, findGitRoot, loadProjectFingerprint, buildProjectConte
 import { getPreviousCompactionContext } from "../../utils/helpers.ts";
 import { isPrefixOf, legacyPrefixMatch } from "../../utils/id-fingerprint.ts";
 import { serializeConversation } from "@earendil-works/pi-coding-agent";
-import { asSerializableMessages } from "../../infra/ai-messages.ts";
+import { asSerializableMessages, scrubLlmMessages } from "../../infra/ai-messages.ts";
 import { prepareConversationBackup } from "../../utils/backups.ts";
 import { loadScopedCompactionState, renderContinuityCapsule } from "../../utils/state.ts";
 import { boundedBranchLineageIds, branchEntryIds } from "../../infra/session-identity.ts";
+import { EXTRACTION_LIMITS } from "../../constants.ts";
 
 export function extractWithCache(rc: TieredRc): ExtractedRc {
   const extractStepStart = Date.now();
@@ -47,6 +48,8 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
   // extractors to reuse.
   const selectedMessages = rc.llmMessages;
   const pruning = pruneRedundant(selectedMessages);
+  const pruningUnchanged = pruning.messages.length === selectedMessages.length
+    && pruning.messages.every((message, index) => message === selectedMessages[index]);
   const currentKeptEntryIds = pruning.keptIndices
     .map(i => rc.llmEntryIds[i])
     .filter((id): id is string => typeof id === "string");
@@ -58,22 +61,26 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
       "info",
     );
   }
-  rc.llmMessages = pruning.messages;
+  const scrubbedMessages = scrubLlmMessages(pruning.messages, rc.services.scrubber);
+  pruning.messages = scrubbedMessages;
+  rc.llmMessages = scrubbedMessages;
   const pruneEnd = Date.now();
   markMeasuredPhase(rc, "prune", extractStepStart, pruneEnd);
 
   const extractionStart = pruneEnd;
-  const convText = serializeConversation(asSerializableMessages(rc.llmMessages));
+  const convText = rc.services.scrubber.scrubText(
+    serializeConversation(asSerializableMessages(rc.llmMessages)),
+  ).value;
   const convTokens = rc.estimator.text(convText);
   let preparedBackup: PreparedConversationBackup | undefined;
   if (rc.config.backupEnabled) {
-    const unchanged = pruning.messages.length === selectedMessages.length
-      && pruning.messages.every((message, index) => message === selectedMessages[index]);
     // Keep only a deferred source while the candidate awaits native apply.
-    // Large unpruned conversations are serialized and scrubbed exactly once,
-    // after Pi confirms compaction, instead of doubling peak pipeline memory.
+    // Large unpruned conversations are serialized only after Pi confirms
+    // compaction; structured redaction still runs before that serialization.
     const materializeBackup = () => {
-      const backupText = unchanged ? convText : serializeConversation(asSerializableMessages(selectedMessages));
+      if (pruningUnchanged) return convText;
+      const safeMessages = scrubLlmMessages(selectedMessages, rc.services.scrubber);
+      const backupText = serializeConversation(asSerializableMessages(safeMessages));
       return rc.services.scrubber.scrubText(backupText).value;
     };
     preparedBackup = prepareConversationBackup(materializeBackup, rc.sessionId, {
@@ -95,6 +102,7 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
   //   * Legacy: full `entryIds` / `keptEntryIds` arrays from older versions.
   // We accept either so an in-place upgrade doesn't lose every running cache.
   let cacheUsable = false;
+  let cacheExact = false;
   let keptCount = 0;
   if (cachedExt) {
     const hasNewFp = !!(cachedExt.keptEntryIdsFp && cachedExt.entryIdsFp);
@@ -111,14 +119,27 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
       : (cachedExt.keptEntryIds?.length ?? 0);
 
     if (hasNewFp || hasLegacy) {
-      cacheUsable = branchPrefixMatch && prunedPrefixMatch &&
-        cachedExt.messageCount === keptCount &&
-        cachedExt.messageCount < rc.llmMessages.length;
+      const boundedCacheShape =
+        cachedExt.extraction.modifiedFiles.length <= EXTRACTION_LIMITS.MODIFIED_FILES
+        && (cachedExt.extraction.referencedFiles?.length ?? 0) <= EXTRACTION_LIMITS.REFERENCED_FILES
+        && cachedExt.extraction.readFiles.length <= EXTRACTION_LIMITS.READ_FILES
+        && cachedExt.extraction.deletedFiles.length <= EXTRACTION_LIMITS.DELETED_FILES
+        && cachedExt.extraction.errors.length <= EXTRACTION_LIMITS.ERRORS
+        && cachedExt.extraction.decisions.length <= EXTRACTION_LIMITS.DECISIONS
+        && cachedExt.extraction.constraints.length <= EXTRACTION_LIMITS.CONSTRAINTS
+        && cachedExt.extraction.topics.length <= EXTRACTION_LIMITS.TOPICS
+        && cachedExt.extraction.timeline.length <= EXTRACTION_LIMITS.TIMELINE
+        && (cachedExt.extraction.mediaAttachments?.length ?? 0) <= EXTRACTION_LIMITS.MEDIA_ATTACHMENTS;
+      cacheUsable = branchPrefixMatch && prunedPrefixMatch && boundedCacheShape
+        && cachedExt.messageCount === keptCount
+        && cachedExt.messageCount <= rc.llmMessages.length;
+      cacheExact = cacheUsable && cachedExt.messageCount === rc.llmMessages.length;
       if (!cacheUsable) {
         missReason = !branchPrefixMatch ? "entry-prefix-mismatch"
           : !prunedPrefixMatch ? "pruned-prefix-changed"
-            : cachedExt.messageCount !== keptCount ? "cache-shape-mismatch"
-              : "no-new-pruned-messages";
+            : !boundedCacheShape ? "cache-evidence-unbounded"
+              : cachedExt.messageCount !== keptCount ? "cache-shape-mismatch"
+                : "cache-domain-ahead";
       }
     } else {
       missReason = "legacy-no-kept-entryids";
@@ -127,21 +148,26 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
   }
 
   if (cacheUsable && cachedExt) {
-    const newMsgs = rc.llmMessages.slice(cachedExt.messageCount);
-    // Index over the suffix only — we can't reuse prunedTcIdx because its
-    // msgIndex values are absolute, while extractStructured against `newMsgs`
-    // expects offsets relative to newMsgs[0].
-    const deltaTcIdx = buildToolCallIndex(newMsgs);
-    const delta = extractStructured(newMsgs, rc.profileCfg, deltaTcIdx);
-    extraction = mergeExtractions(cachedExt.extraction, delta, cachedExt.messageCount, newMsgs, deltaTcIdx);
-    rc.notify(
-      "Phase 1 Incremental: " + cachedExt.messageCount + " cached + " + newMsgs.length + " new pruned messages",
-      "info",
-    );
-    rc.vlog(
-      "Incremental extraction — cached pruned messages: " + cachedExt.messageCount +
-        ", current pruned: " + rc.llmMessages.length,
-    );
+    if (cacheExact) {
+      extraction = cachedExt.extraction;
+      rc.notify("Phase 1 Cached: exact pruned conversation reused", "info");
+      rc.vlog("Exact extraction cache hit — " + cachedExt.messageCount + " pruned messages");
+    } else {
+      const newMsgs = rc.llmMessages.slice(cachedExt.messageCount);
+      // Index over the suffix only: its msgIndex values are relative to
+      // `newMsgs`, then mergeExtractions offsets every evidence position.
+      const deltaTcIdx = buildToolCallIndex(newMsgs);
+      const delta = extractStructured(newMsgs, rc.profileCfg, deltaTcIdx);
+      extraction = mergeExtractions(cachedExt.extraction, delta, cachedExt.messageCount, newMsgs, deltaTcIdx);
+      rc.notify(
+        "Phase 1 Incremental: " + cachedExt.messageCount + " cached + " + newMsgs.length + " new pruned messages",
+        "info",
+      );
+      rc.vlog(
+        "Incremental extraction — cached pruned messages: " + cachedExt.messageCount +
+          ", current pruned: " + rc.llmMessages.length,
+      );
+    }
     missReason = undefined;
     recordExtractionCacheHit(rc.services);
   } else {

--- a/src/app/steps/metrics.ts
+++ b/src/app/steps/metrics.ts
@@ -16,7 +16,7 @@
  */
 
 import type { RcBase, StatedRc } from "../run-context.ts";
-import type { MetricsSnapshot, VerificationGap } from "../../types.ts";
+import type { CompactionMode, MetricsSnapshot, VerificationGap } from "../../types.ts";
 import { aggregateProviderRoutes } from "../../domain/provider-evaluation.ts";
 import { classifyTelemetryFailure } from "../../domain/telemetry.ts";
 import { VERSION } from "../../constants.ts";
@@ -102,8 +102,8 @@ export function buildSuccessMetrics(
   };
 }
 
-export function recordSuccessMetrics(rc: StatedRc, status: "success" | "dry-run" | "cancelled"): void {
-  appendMetricsSnapshot(rc.sessionId, buildSuccessMetrics(rc, status));
+export async function recordSuccessMetrics(rc: StatedRc, status: "success" | "dry-run" | "cancelled"): Promise<void> {
+  await appendMetricsSnapshot(rc.sessionId, buildSuccessMetrics(rc, status));
   const ecs = getExtractionCacheStats(rc.services);
   const ms = getMetricsSummary(rc.services);
   if (status === "success" && ms.totalCalls > 0) {
@@ -134,14 +134,14 @@ export interface FailureSummaryFields {
   totalTokens?: number;
   methodForMetrics?: string;
   profile: string;
-  mode?: import("../../types.ts").CompactionMode;
+  mode?: CompactionMode;
 }
 
-export function recordFailureMetrics(
+export async function recordFailureMetrics(
   rc: RcBase | StatedRc,
   err: unknown,
   fields: FailureSummaryFields,
-): void {
+): Promise<void> {
   const releaseChannel = (rc as RcBase & { config?: { telemetryChannel?: "stable" | "canary" } }).config?.telemetryChannel
     ?? loadConfig().telemetryChannel;
   const failureKind = classifyTelemetryFailure(err, rc.cancellation.timedOut);
@@ -169,7 +169,7 @@ export function recordFailureMetrics(
   const verificationScore = typeof gate?.score === "number" && Number.isFinite(gate.score) ? gate.score : undefined;
   const initialVerificationScore = typeof gate?.initialScore === "number" && Number.isFinite(gate.initialScore) ? gate.initialScore : undefined;
   const verificationGaps = typeof gate?.gapCount === "number" && Number.isInteger(gate.gapCount) && gate.gapCount >= 0 ? gate.gapCount : undefined;
-  appendMetricsLog(fields.sessionId ?? "unknown", {
+  await appendMetricsLog(fields.sessionId ?? "unknown", {
     runId: rc.runId,
     metricsSchemaVersion: 2,
     version: VERSION,

--- a/src/app/steps/persist.ts
+++ b/src/app/steps/persist.ts
@@ -35,6 +35,7 @@ import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { asBranchMessage } from "../../infra/ai-messages.ts";
 import { clearCompactProgress } from "../../ui/overlays.ts";
 import { formatCompactErrorForUi } from "../../ui/error-format.ts";
+import { branchEntryIds } from "../../infra/session-identity.ts";
 
 import * as log from "../../utils/logger.ts";
 
@@ -68,7 +69,7 @@ export async function commitAppliedCompaction(pending: PendingCompaction): Promi
   const failures = await persistAppliedState(pending);
   if (pending.preparedBackup && !await commitPreparedConversationBackup(pending.preparedBackup)) failures.push("conversation backup");
   if (!pending.metricsSnapshot) return failures;
-  appendMetricsSnapshot(pending.sessionId, {
+  await appendMetricsSnapshot(pending.sessionId, {
     ...pending.metricsSnapshot,
     persistenceStatus: failures.length ? "partial" : "complete",
     persistenceFailures: failures.length ? failures : undefined,
@@ -124,13 +125,16 @@ export function runDamageDetection(rc: RunContext): void {
  * step decides otherwise).
  */
 export function stagePendingCompaction(rc: RunContext, metricsSnapshot?: MetricsSnapshot): PendingCompaction {
-  // All four fields are guaranteed by StatedRc, so the previous `!` casts go
-  // away. If a future refactor reorders steps the type system will catch it
-  // here instead of failing at runtime with a `Cannot read property` error.
+  // The producing branch head is immutable provenance. The consumer rejects
+  // this payload unless both it and the kept-entry boundary remain in the
+  // active branch ancestry.
+  const originBranchHeadId = branchEntryIds(rc.branch as Array<{ id?: unknown }>).at(-1);
+  if (!originBranchHeadId) throw new Error("Pending compaction requires an identifiable branch head");
   const pending: PendingCompaction = {
     runId: rc.runId,
     summary: rc.finalSummary,
     firstKeptEntryId: rc.firstKeptId,
+    originBranchHeadId,
     tokensBefore: rc.totalTokens,
     details: rc.details,
     metricsSnapshot,
@@ -163,7 +167,7 @@ export function applyCompaction(rc: StatedRc): void {
       rc.pendingRef.clear(rc.sessionId);
       const handled = rc.onNativeApplyError?.(rc.runId, e) ?? false;
       if (!handled) {
-        recordFailureMetrics(rc, e, {
+        void recordFailureMetrics(rc, e, {
           sessionId: rc.sessionId, tier: rc.tier, contextPercent: rc.contextPercent,
           toolPercent: rc.toolPercent, totalTokens: rc.totalTokens,
           methodForMetrics: rc.method, profile: rc.profile, mode: rc.mode,

--- a/src/app/steps/recover.ts
+++ b/src/app/steps/recover.ts
@@ -24,7 +24,7 @@ export async function recoverSessionLog(rc: WindowedRc): Promise<RecoveredRc> {
   });
 
   if (hasTruncatedMessages(resolved.map(item => item.message))) {
-    const fromLog = await resolveCompactionMessages(rc.sessionId, rc.toCompact);
+    const fromLog = await resolveCompactionMessages(rc.sessionId, rc.toCompact, rc.ctx.cwd);
     if (fromLog) {
       resolved = fromLog;
       rc.notify("Using untruncated session log (" + resolved.length + " msgs)", "info");

--- a/src/app/steps/synthesize.ts
+++ b/src/app/steps/synthesize.ts
@@ -307,27 +307,26 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
         generationFallbacks.push((totalBatches - batchCallLimit) + " synthesis batch budget fallback(s)");
       }
       let completed = totalBatches - batchCallLimit;
-      for (let wave = 0; wave < batchCallLimit; wave += concurrency) {
-        if (rc.services.budget.reason()) {
-          for (let index = wave; index < totalBatches; index++) {
-            results[index] = batches[index].map(chunk => failedChunkSummary(chunk));
-          }
-          rc.notify("Synthesis budget reached · remaining batches use deterministic fallback", "info");
-          cacheable = false;
-          generationFallbacks.push("synthesis budget exhausted during batch wave");
-          break;
-        }
-        const waveBatches = batches.slice(wave, Math.min(wave + concurrency, batchCallLimit));
-        const wavePromises = waveBatches.map(async (batch, i) => {
-          const idx = wave + i;
-          try {
-            results[idx] = await summarizeBatch(
-              batch, extraction, rc.summaryModel, summaryAuth, rc.cancellation.signal, rc.services,
-              batchOutputLimit(rc.mode, batch.length, rc.providerCaps.maxOutputTokens), rc.sessionId,
-            );
-          } catch (err) {
-            errors[idx] = err instanceof Error ? err : new Error(String(err));
-            results[idx] = batch.map(ch => failedChunkSummary(ch));
+      let nextBatch = 0;
+      let budgetStopped = false;
+      const runWorker = async (): Promise<void> => {
+        while (true) {
+          const idx = nextBatch++;
+          if (idx >= batchCallLimit) return;
+          if (budgetStopped || rc.services.budget.reason()) {
+            budgetStopped = true;
+            results[idx] = batches[idx].map(chunk => failedChunkSummary(chunk));
+          } else {
+            try {
+              const batch = batches[idx];
+              results[idx] = await summarizeBatch(
+                batch, extraction, rc.summaryModel, summaryAuth, rc.cancellation.signal, rc.services,
+                batchOutputLimit(rc.mode, batch.length, rc.providerCaps.maxOutputTokens), rc.sessionId,
+              );
+            } catch (err) {
+              errors[idx] = err instanceof Error ? err : new Error(String(err));
+              results[idx] = batches[idx].map(chunk => failedChunkSummary(chunk));
+            }
           }
           completed++;
           showProgressOverlay(rc.ctx, {
@@ -336,8 +335,14 @@ export async function summarizeConversation(rc: ExtractedRc): Promise<Synthesize
             model: rc.modelLabel, profile: rc.profile, extraction, explorationRounds,
             totalBatches, currentBatch: completed,
           });
-        });
-        await Promise.all(wavePromises);
+        }
+      };
+      const workerCount = Math.max(1, Math.min(concurrency, batchCallLimit));
+      await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+      if (budgetStopped) {
+        rc.notify("Synthesis budget reached · remaining batches use deterministic fallback", "info");
+        cacheable = false;
+        generationFallbacks.push("synthesis budget exhausted during batch pool");
       }
       for (const r of results) if (r) summaries.push(...r);
       const failedBatches = errors.filter(Boolean);

--- a/src/app/steps/window.ts
+++ b/src/app/steps/window.ts
@@ -6,10 +6,11 @@ import type {
 import { advance } from "../run-context.ts";
 import type { EffectiveCompactionMode, LlmMessage, ProfileConfig, ProviderCapabilities, SessionMessageEntry } from "../../types.ts";
 import { MODE_POLICIES, modeFromLegacyProfile } from "../mode-policy.ts";
-import { advancePastToolCallBoundary, guardToolCallBoundary, smartKeepBoundaryCandidates } from "../../utils/helpers.ts";
+import { advancePastToolCallBoundary, buildToolCallBoundaryIndex, guardToolCallBoundary, smartKeepBoundaryCandidates } from "../../utils/helpers.ts";
 import { resolveSessionId } from "../../infra/session-identity.ts";
 import { MAX_STATE_OPEN_LOOPS, MIN_COMPACTION_SAVING_RATIO, POST_SUMMARY_RESERVE_RATIO, TRUNC } from "../../constants.ts";
-import type { TokenEstimator } from "../../utils/tokens.ts";
+import { safeContextPercent, type TokenEstimator } from "../../utils/tokens.ts";
+import { isRecord } from "../../utils/type-guards.ts";
 
 export type { CompactionWindowPlan } from "../run-context.ts";
 
@@ -62,7 +63,12 @@ export function planCompactionWindow(input: CompactionWindowPlanInput): Compacti
     msgs, branch, messageTokens, totalTokens, modelContextWindow, mode, profileCfg, force, overflowedContext,
     finalSummaryAllowanceTokens,
   } = input;
-  const allMessageTokens = messageTokens.reduce((sum, tokens) => sum + tokens, 0);
+  const tokenPrefix = new Array<number>(messageTokens.length + 1);
+  tokenPrefix[0] = 0;
+  for (let index = 0; index < messageTokens.length; index++) {
+    tokenPrefix[index + 1] = tokenPrefix[index] + messageTokens[index];
+  }
+  const allMessageTokens = tokenPrefix[messageTokens.length];
   // Host usage can include system prompt, tool schemas, images, and provider
   // accounting that are absent from our message estimator. Treat any positive
   // remainder as uncompactable fixed context. Scaling message estimates up to
@@ -101,25 +107,31 @@ export function planCompactionWindow(input: CompactionWindowPlanInput): Compacti
   }
 
   const relaxedSoftBoundaries: RelaxedSoftBoundary[] = [];
-  const retainedAt = (from: number) => Math.round(messageTokens.slice(from).reduce((sum, tokens) => sum + tokens, 0) * messageScale);
+  const retainedAt = (from: number) => Math.round((allMessageTokens - tokenPrefix[from]) * messageScale);
+  const toolCallIndex = buildToolCallBoundaryIndex(msgs);
   // Message boundaries can overshoot the token ceiling by one message; that
   // baseline is the tightest plan this pipeline can represent.
   const effectiveRetentionCeiling = Math.max(retentionCeiling, retainedAt(keepFrom));
   let hardBoundaryAdjusted = false;
   const trySoftBoundary = (kind: RelaxedSoftBoundary, candidate: number | undefined) => {
     if (candidate === undefined || candidate >= keepFrom) return;
-    const guarded = guardToolCallBoundary(msgs, candidate);
+    const guarded = guardToolCallBoundary(msgs, candidate, toolCallIndex);
     if (retainedAt(guarded) <= effectiveRetentionCeiling) {
       keepFrom = guarded;
       hardBoundaryAdjusted ||= guarded !== candidate;
     } else relaxedSoftBoundaries.push(kind);
   };
 
-  const users = msgs
-    .map((entry, index) => ({ index, role: (entry.message as { role?: string })?.role }))
-    .filter(entry => entry.role === "user");
-  const protectedUser = users.at(users.length >= 2 ? -2 : -1);
-  trySoftBoundary("recent-user-turn", protectedUser?.index);
+  let userOrdinal = 0;
+  let protectedUserIndex: number | undefined;
+  for (let index = msgs.length - 1; index >= 0; index--) {
+    const message = msgs[index].message;
+    if (!isRecord(message) || message.role !== "user") continue;
+    userOrdinal++;
+    protectedUserIndex = index;
+    if (userOrdinal === 2) break;
+  }
+  trySoftBoundary("recent-user-turn", protectedUserIndex);
 
   const anchor = smartKeepBoundaryCandidates(msgs, keepFrom, branch).find(candidate => candidate.kind === "anchor");
   trySoftBoundary("anchor", anchor?.keepFrom);
@@ -127,15 +139,15 @@ export function planCompactionWindow(input: CompactionWindowPlanInput): Compacti
   trySoftBoundary("topical", topical?.keepFrom);
 
   const boundaryBeforeHardGuard = keepFrom;
-  const backwardBoundary = guardToolCallBoundary(msgs, keepFrom);
+  const backwardBoundary = guardToolCallBoundary(msgs, keepFrom, toolCallIndex);
   const forwardBoundary = retainedAt(backwardBoundary) > effectiveRetentionCeiling
-    ? advancePastToolCallBoundary(msgs, keepFrom)
+    ? advancePastToolCallBoundary(msgs, keepFrom, toolCallIndex)
     : keepFrom;
   keepFrom = forwardBoundary > keepFrom && forwardBoundary < msgs.length && retainedAt(forwardBoundary) <= effectiveRetentionCeiling
     ? forwardBoundary
     : backwardBoundary;
   hardBoundaryAdjusted ||= keepFrom !== boundaryBeforeHardGuard;
-  const compactTokens = Math.round(messageTokens.slice(0, keepFrom).reduce((sum, tokens) => sum + tokens, 0) * messageScale);
+  const compactTokens = Math.round(tokenPrefix[keepFrom] * messageScale);
   const retainedTokens = retainedAt(keepFrom);
   const projectedAfterTokens = fixedContextTokens + retainedTokens + finalSummaryAllowance;
   const projectedSavedTokens = Math.max(0, totalTokens - projectedAfterTokens);
@@ -145,7 +157,8 @@ export function planCompactionWindow(input: CompactionWindowPlanInput): Compacti
     : fixedContextTokens + effectiveRetentionCeiling + finalSummaryAllowance;
 
   let reason: CompactionPlanReason = "viable";
-  if ((msgs[keepFrom]?.message as { role?: string } | undefined)?.role === "toolResult") reason = "unsafe-tool-boundary";
+  const firstKeptMessage = msgs[keepFrom]?.message;
+  if (isRecord(firstKeptMessage) && firstKeptMessage.role === "toolResult") reason = "unsafe-tool-boundary";
   else if (keepFrom <= 0) reason = "no-eligible-prefix";
   else if (retainedTokens > effectiveRetentionCeiling) reason = "retention-target-exceeded";
   else if (!force && modelContextWindow && projectedAfterTokens > targetAfterTokens) reason = "mode-target-not-met";
@@ -183,7 +196,9 @@ export function resolveCompactionWindow(rc: PreparedRc): WindowedRc | null {
   }
 
   const mode = rc.mode ?? (rc.profile ? modeFromLegacyProfile(rc.profile) : "balanced");
-  const overflowedContext = !!rc.flags.overflowRecovery || (!!rc.ctx.model && totalTokens > rc.ctx.model.contextWindow);
+  const modelContextWindow = rc.ctx.model?.contextWindow;
+  const overflowedContext = !!rc.flags.overflowRecovery
+    || (Number.isFinite(modelContextWindow) && (modelContextWindow ?? 0) > 0 && totalTokens > (modelContextWindow as number));
   const plan = planCompactionWindow({
     msgs,
     branch: branch as unknown[],
@@ -213,7 +228,7 @@ export function resolveCompactionWindow(rc: PreparedRc): WindowedRc | null {
     );
   }
 
-  const contextPercent = rc.ctx.model && totalTokens ? totalTokens / rc.ctx.model.contextWindow * 100 : 0;
+  const contextPercent = safeContextPercent(totalTokens, modelContextWindow);
   if (rc.flags.force && rc.config.minContextPercent > 0 && contextPercent < rc.config.minContextPercent) {
     rc.notify(
       "Manual compaction override at " + Math.round(contextPercent) + "% (" + totalTokens.toLocaleString() +

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "9.0.0";
+export const VERSION = "9.1.0";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.10;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;
@@ -220,8 +220,10 @@ export const EXTRACTION_LIMITS = {
   ERRORS: 80,
   DECISIONS: 80,
   CONSTRAINTS: 80,
+  TOPICS: 80,
   TIMELINE: 120,
   MEDIA_ATTACHMENTS: 40,
+  REFERENCED_FILES: 200,
 } as const;
 export const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -289,6 +291,8 @@ export const DAMAGE_RECENT_MSG_WINDOW = 15;
 
 // ── Pruning ──
 export const MAX_TOOL_OUTPUT_CHARS = 800;
+/** Provider-visible output from one exploration tool invocation. */
+export const MAX_EXPLORER_OUTPUT_CHARS = 12_000;
 
 // ── Error detection (shared by pruning + extraction) ──
 /** Shell-output patterns signalling a likely error even in a non-`isError` result. */

--- a/src/domain/scrub.ts
+++ b/src/domain/scrub.ts
@@ -64,11 +64,13 @@ function mergeFindings(target: Map<string, number>, findings: RedactionFinding[]
   for (const finding of findings) target.set(finding.kind, (target.get(finding.kind) ?? 0) + finding.count);
 }
 
-const SECRET_KEY_NAMES = new Set([
-  "api_key", "apikey", "access_token", "auth_token", "authorization",
-  "password", "passwd", "secret", "secret_key", "secret_access_key",
-  "client_secret", "private_key", "database_url", "connection_string",
-]);
+const SECRET_KEY_NAMES: Readonly<Record<string, true>> = {
+  api_key: true, apikey: true, access_token: true, auth_token: true, authorization: true,
+  password: true, passwd: true, secret: true, secret_key: true, secret_access_key: true,
+  client_secret: true, private_key: true, database_url: true, connection_string: true,
+  token: true, refresh_token: true, session_token: true, credential: true, credentials: true,
+  cookie: true, set_cookie: true, otp: true, one_time_password: true, pin: true, passcode: true,
+};
 
 function normalizeObjectKey(key: string): string {
   return key
@@ -80,8 +82,8 @@ function normalizeObjectKey(key: string): string {
 
 function isSecretBearingKey(key: string): boolean {
   const normalized = normalizeObjectKey(key);
-  if (SECRET_KEY_NAMES.has(normalized)) return true;
-  return /(?:^|_)(?:api_key|access_token|auth_token|password|passwd|secret_access_key|client_secret|private_key)(?:_|$)/.test(normalized);
+  if (SECRET_KEY_NAMES[normalized]) return true;
+  return /(?:^|_)(?:api_key|access_token|auth_token|password|passwd|secret_access_key|client_secret|private_key|refresh_token|session_token|one_time_password|passcode)(?:_|$)/.test(normalized);
 }
 
 /** Run-scoped scrubber used at LLM, cache, backup and persistence boundaries. */
@@ -133,7 +135,8 @@ export class SecretScrubber {
       const output: Record<string, unknown> = {};
       seen.set(value, output);
       for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
-        if (this.secretsEnabled && isSecretBearingKey(key) && typeof item === "string" && item.length > 0) {
+        const carriesSecret = typeof item === "string" ? item.length > 0 : item != null;
+        if (this.secretsEnabled && isSecretBearingKey(key) && carriesSecret) {
           output[key] = "[REDACTED:credential]";
           recordCredential();
         } else {

--- a/src/domain/summary-parse.ts
+++ b/src/domain/summary-parse.ts
@@ -51,6 +51,7 @@ export function parseSummary(markdown: string): CanonicalSummary {
   let currentHeading = "";
   let currentKind: SectionKind = "unknown";
   let bodyLines: string[] = [];
+  let fence: { marker: "`" | "~"; length: number } | null = null;
   let started = false;
 
   const flush = () => {
@@ -62,17 +63,31 @@ export function parseSummary(markdown: string): CanonicalSummary {
   };
 
   for (const line of lines) {
-    const m = line.match(HEADING_RE);
-    if (m) {
-      const kind = classifyHeading(m[2]);
-      if (m[1].length <= 2 || kind !== "unknown") {
-        flush();
-        // Normalize heading depth while preserving the model's label.
-        currentHeading = "## " + m[2].trim();
-        currentKind = kind;
-        bodyLines = [];
-        started = true;
-        continue;
+    const fenceMatch = line.match(/^\s{0,3}(`{3,}|~{3,})(.*)$/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0] as "`" | "~";
+      const markerLength = fenceMatch[1].length;
+      if (!fence) {
+        fence = { marker, length: markerLength };
+      } else if (marker === fence.marker && markerLength >= fence.length && !fenceMatch[2].trim()) {
+        fence = null;
+      }
+      if (started) bodyLines.push(line);
+      continue;
+    }
+    if (!fence) {
+      const heading = line.match(HEADING_RE);
+      if (heading) {
+        const kind = classifyHeading(heading[2]);
+        if (heading[1].length <= 2 || kind !== "unknown") {
+          flush();
+          // Normalize heading depth while preserving the model's label.
+          currentHeading = "## " + heading[2].trim();
+          currentKind = kind;
+          bodyLines = [];
+          started = true;
+          continue;
+        }
       }
     }
     if (started) bodyLines.push(line);

--- a/src/domain/tool-semantics.ts
+++ b/src/domain/tool-semantics.ts
@@ -4,10 +4,10 @@
  * ambiguous `text` payloads). The broad `classifyTool(args)` API remains
  * name-agnostic for compatibility.
  *
- * Bash-style tools that take a free-text `command` remain opaque to file-path
- * tracking by construction. Pure: no I/O, no async, no globals.
+ * Shell command execution remains a distinct operation. A conservative parser
+ * exposes only explicit literal mutation targets for extraction provenance.
+ * Pure: no I/O, no async, no globals.
  */
-
 type Args = Record<string, unknown>;
 
 /**
@@ -52,6 +52,155 @@ export function extractToolPath(args: unknown): string | undefined {
     if (typeof v === "string" && v.length > 0) return v;
   }
   return undefined;
+}
+
+export interface ShellFileOperations {
+  modified: string[];
+  deleted: string[];
+}
+
+interface ShellToken {
+  kind: "word" | "separator" | "redirect";
+  value: string;
+}
+
+function tokenizeShell(command: string): ShellToken[] {
+  const tokens: ShellToken[] = [];
+  let word = "";
+  let quote: "'" | "\"" | null = null;
+  const flush = () => {
+    if (word) tokens.push({ kind: "word", value: word });
+    word = "";
+  };
+  for (let index = 0; index < command.length; index++) {
+    const char = command[index];
+    if (char === "\\" && quote !== "'" && index + 1 < command.length) {
+      word += command[++index];
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      if (!quote) quote = char;
+      else if (quote === char) quote = null;
+      else word += char;
+      continue;
+    }
+    if (quote) {
+      word += char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      flush();
+      if (char === "\n") tokens.push({ kind: "separator", value: char });
+      continue;
+    }
+    if (char === ">" || char === ";" || char === "|"
+      || (char === "&" && command[index + 1] === "&")) {
+      flush();
+      if (char === ">") {
+        const append = command[index + 1] === ">";
+        if (append) index++;
+        tokens.push({ kind: "redirect", value: append ? ">>" : ">" });
+      } else {
+        const paired = (char === "|" && command[index + 1] === "|")
+          || (char === "&" && command[index + 1] === "&");
+        if (paired) index++;
+        tokens.push({ kind: "separator", value: paired ? char + char : char });
+      }
+      continue;
+    }
+    word += char;
+  }
+  flush();
+  return tokens;
+}
+
+function literalShellPath(token: string | undefined): string | undefined {
+  if (!token || token.startsWith("-") || token === "/dev/null") return undefined;
+  if (/[\u0000$*?\[\]{}()<>|;&]/.test(token) || /^\d+$/.test(token)) return undefined;
+  return token;
+}
+
+function shellOperands(words: string[], start: number): string[] {
+  const operands: string[] = [];
+  let options = true;
+  for (let index = start; index < words.length; index++) {
+    const word = words[index];
+    if (options && word === "--") {
+      options = false;
+      continue;
+    }
+    if (options && word.startsWith("-")) continue;
+    const target = literalShellPath(word);
+    if (target) operands.push(target);
+  }
+  return operands;
+}
+
+function commandFileOperations(words: string[]): ShellFileOperations {
+  const modified: string[] = [];
+  const deleted: string[] = [];
+  let commandIndex = 0;
+  while (commandIndex < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[commandIndex])) commandIndex++;
+  while (commandIndex < words.length) {
+    const wrapper = words[commandIndex].split("/").pop()?.toLowerCase();
+    if (wrapper !== "env" && wrapper !== "sudo" && wrapper !== "command" && wrapper !== "nohup") break;
+    commandIndex++;
+    while (commandIndex < words.length && words[commandIndex].startsWith("-")) commandIndex++;
+  }
+  const command = words[commandIndex]?.split("/").pop()?.toLowerCase();
+  const operands = shellOperands(words, commandIndex + 1);
+  if (!command || !operands.length) return { modified, deleted };
+  if (command === "rm" || command === "unlink") {
+    deleted.push(...operands);
+  } else if (command === "touch" || command === "tee") {
+    modified.push(...operands);
+  } else if (command === "cp" || command === "install") {
+    modified.push(operands[operands.length - 1]);
+  } else if (command === "mv") {
+    deleted.push(...operands.slice(0, -1));
+    modified.push(operands[operands.length - 1]);
+  } else if (command === "sed" && words.slice(commandIndex + 1).some(word => /^-i|^--in-place/.test(word))) {
+    // The final operand is the edited file; earlier operands may be scripts or
+    // platform-specific empty backup suffixes.
+    modified.push(operands[operands.length - 1]);
+  }
+  return { modified, deleted };
+}
+
+/** Extract only explicit literal file targets from common mutating shell forms. */
+export function extractShellFileOperations(args: unknown): ShellFileOperations {
+  const record = args && typeof args === "object" ? args as Args : null;
+  const command = record
+    ? COMMAND_KEYS.map(key => record[key]).find((value): value is string => typeof value === "string")
+    : undefined;
+  if (!command) return { modified: [], deleted: [] };
+  const tokens = tokenizeShell(command);
+  const modified: string[] = [];
+  const deleted: string[] = [];
+  let words: string[] = [];
+  const flushCommand = () => {
+    const operations = commandFileOperations(words);
+    modified.push(...operations.modified);
+    deleted.push(...operations.deleted);
+    words = [];
+  };
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index];
+    if (token.kind === "separator") {
+      flushCommand();
+    } else if (token.kind === "redirect") {
+      const target = tokens[index + 1]?.kind === "word" ? literalShellPath(tokens[index + 1].value) : undefined;
+      if (target) modified.push(target);
+      if (target) index++;
+    } else {
+      words.push(token.value);
+    }
+  }
+  flushCommand();
+  return {
+    modified: Array.from(new Set(modified)),
+    deleted: Array.from(new Set(deleted.filter(file => !modified.includes(file)))),
+  };
 }
 
 export type ToolClass = "mutates" | "accesses" | "executes" | "other";

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import type { PendingCompaction } from "./types.ts";
 import { VERSION, MIN_TOKEN_THRESHOLD, CONFIG_KEY, CONFIG_KEY_ALT, FIVE_MINUTES_MS, BUDGET_LIMITS, AUTO_TRIGGER_MAX_LLM_CALLS, AUTO_TRIGGER_TIMEOUT_CAP_MS } from "./constants.ts";
 import { listBackups, readConversationBackup, buildRestoreMessage } from "./utils/backups.ts";
 import { loadConfig } from "./utils/helpers.ts";
-import { estimateTokens, getProviderCaps } from "./utils/tokens.ts";
+import { estimateTokens, getProviderCaps, safeContextPercent } from "./utils/tokens.ts";
 import { appendMetricsSnapshot, readMetricsLog } from "./utils/cache.ts";
 import { buildLocalDashboardInsights, buildMetricsReport, writeMetricsDashboard } from "./ui/metrics-report.ts";
 import { runSmartCompact } from "./app/run-smart-compact.ts";
@@ -47,10 +47,21 @@ import { SecretScrubber } from "./domain/scrub.ts";
  */
 function unwrapConsumed(result: ConsumeResult, ctx: ExtensionContext): PendingCompaction | null {
   switch (result.kind) {
-    case "ok":
-      // Consumption only stages a candidate. Pi can still abort or fail after
-      // this hook; durable commit happens on the correlated session_compact.
+    case "ok": {
+      // Same-session is necessary but insufficient: a fork can retain the
+      // session id while moving to a sibling branch. Both producer provenance
+      // and the replacement boundary must remain in active ancestry.
+      const activeEntryIds = new Set(branchEntryIds(
+        ctx.sessionManager.getBranch() as Array<{ id?: unknown }>,
+      ));
+      if (!activeEntryIds.has(result.pending.originBranchHeadId)
+        || !activeEntryIds.has(result.pending.firstKeptEntryId)) {
+        log.warn("Discarding pending smart compaction prepared for a divergent branch");
+        ctx.ui.notify("Divergent-branch pending smart compaction discarded", "warning");
+        return null;
+      }
       return result.pending;
+    }
     case "empty":
       return null;
     case "expired":
@@ -134,7 +145,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
   const recordApplyFailure = (pending: PendingCompaction, reason: CommitDiscardReason): void => {
     if (!pending.metricsSnapshot) return;
     const cancelled = reason === "aborted" || reason === "shutdown";
-    appendMetricsSnapshot(pending.sessionId, {
+    void appendMetricsSnapshot(pending.sessionId, {
       ...pending.metricsSnapshot,
       status: cancelled ? "cancelled" : "error",
       failureKind: cancelled ? "cancelled" : reason === "evicted" ? "internal" : "persistence",
@@ -264,10 +275,13 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
       await ctx.waitForIdle();
       try {
         const knownProviders = new Set(ctx.modelRegistry.getAvailable().map(model => model.provider));
-        const parsedInput = parseSmartCompactCommand(args, token =>
-          /^[a-z0-9_.-]+\/[a-z0-9_.:-]+$/i.test(token)
-          && Boolean(findModelById(ctx, token) || knownProviders.has(token.split("/")[0])),
-        );
+        const parsedInput = parseSmartCompactCommand(args, token => {
+          const [provider, ...modelPath] = token.split("/");
+          return /^[a-z0-9_.-]+$/i.test(provider)
+            && modelPath.length > 0
+            && modelPath.every(segment => /^[a-z0-9_.:-]+$/i.test(segment))
+            && Boolean(findModelById(ctx, token) || knownProviders.has(provider));
+        });
         if (!parsedInput.ok) {
           ctx.ui.notify(parsedInput.error, "error");
           return;
@@ -417,7 +431,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         if (!args.trim()) {
           const usage = ctx.getContextUsage();
           const totalTokens = usage?.tokens ?? 0;
-          const pct = ctx.model && totalTokens ? Math.round((totalTokens / ctx.model.contextWindow) * 100) : 0;
+          const pct = Math.round(safeContextPercent(totalTokens, ctx.model?.contextWindow));
           const cur = ctx.model;
           const initialRoutes = resolveModels(ctx, cur, config);
           if (!initialRoutes.sumModel) { ctx.ui.notify("Could not resolve model", "error"); return; }
@@ -474,7 +488,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
       // Threshold is advisory during overflow recovery: Pi already has a
       // rejected provider turn to rescue, even if model metadata understates
       // the backend's effective limit.
-      const pct = ctx.model && totalTokens ? (totalTokens / ctx.model.contextWindow) * 100 : 0;
+      const pct = safeContextPercent(totalTokens, ctx.model?.contextWindow);
       if (event.reason !== "overflow" && pct < config.minContextPercent) return;
       const cur = ctx.model;
       if (!cur) return;
@@ -522,6 +536,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
             overflowRecovery: event.reason === "overflow",
             maxLlmCalls: Math.min(config.maxLlmCalls, AUTO_TRIGGER_MAX_LLM_CALLS),
             timeoutMs: effectiveTimeoutMs,
+            abortSignal: event.signal,
             cancellationOut,
           });
         } catch (err) {
@@ -676,13 +691,13 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
       // Check context usage — skip if not enough tokens or context too small
       const usage = ctx.getContextUsage?.();
       const totalTokens = usage?.tokens ?? 0;
-      const rawPct = ctx.model && totalTokens ? (totalTokens / ctx.model.contextWindow) * 100 : 0;
-      const pct = Math.round(rawPct);
+      const contextPercent = safeContextPercent(totalTokens, ctx.model?.contextWindow);
+      const pct = Math.round(contextPercent);
       if (!totalTokens || totalTokens < MIN_TOKEN_THRESHOLD) {
         return { content: [{ type: "text", text: "Context is not large enough for compaction (" + totalTokens.toLocaleString() + " tokens, " + pct + "%). No action needed." }], details: undefined };
       }
       // Guard: don't compact if context is below threshold — tool=97% doesn't mean context is full
-      if (rawPct < config.minContextPercent) {
+      if (contextPercent < config.minContextPercent) {
         return { content: [{ type: "text", text: "Context is only " + pct + "% full (" + totalTokens.toLocaleString() + " tokens). Compaction is not needed yet. The tool=97% in status means tool output ratio, NOT context usage." }], details: undefined };
       }
 

--- a/src/infra/ai-messages.ts
+++ b/src/infra/ai-messages.ts
@@ -18,6 +18,7 @@
 
 import type { Message } from "@earendil-works/pi-ai";
 import type { LlmMessage } from "../types.ts";
+import type { SecretScrubber } from "../domain/scrub.ts";
 
 /**
  * Upcast a raw branch entry's `message` to a `Message` for `convertToLlm`.
@@ -43,4 +44,12 @@ export function asBranchMessage(message: unknown): Message {
  */
 export function asSerializableMessages(msgs: LlmMessage[]): Message[] {
   return msgs as unknown as Message[];
+}
+
+/**
+ * Clone and structurally redact messages before any host serializer flattens
+ * secret-bearing argument keys into ordinary text.
+ */
+export function scrubLlmMessages(msgs: LlmMessage[], scrubber: SecretScrubber): LlmMessage[] {
+  return scrubber.scrubValue(msgs).value;
 }

--- a/src/infra/context-graph.ts
+++ b/src/infra/context-graph.ts
@@ -14,7 +14,7 @@ const MAX_MANUAL_NODES = 500;
 const MAX_SESSION_NODES = 256;
 const MAX_QUERY_CANDIDATES = 80;
 const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1_000;
-const CONTEXT_GRAPH_SCHEMA_VERSION = 1;
+const CONTEXT_GRAPH_SCHEMA_VERSION = 2;
 
 export type ContextMemoryKind =
   | "goal" | "decision" | "constraint" | "error" | "loop"
@@ -117,6 +117,25 @@ interface NodeRow {
 
 interface EdgeRow { from_id: string; to_id: string; weight: number; }
 
+function bunSqliteAdapter(db: Pick<SqliteDatabase, "exec" | "query" | "close">): SqliteDatabase {
+  return {
+    exec: sql => db.exec(sql),
+    query: sql => db.query(sql),
+    transaction: fn => ((...args: never[]) => {
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        const result = fn(...args);
+        db.exec("COMMIT");
+        return result;
+      } catch (error) {
+        try { db.exec("ROLLBACK"); } catch { /* preserve the original failure */ }
+        throw error;
+      }
+    }) as typeof fn,
+    close: () => db.close(),
+  };
+}
+
 function nodeSqliteAdapter(db: NodeSqliteDatabase): SqliteDatabase {
   return {
     exec: sql => db.exec(sql),
@@ -142,7 +161,7 @@ function openDatabase(): SqliteDatabase {
   let db: SqliteDatabase;
   if ("bun" in process.versions) {
     const { Database } = require("bun:sqlite") as { Database: new (filename: string) => SqliteDatabase };
-    db = new Database(fp);
+    db = bunSqliteAdapter(new Database(fp));
   } else {
     const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: new (filename: string) => NodeSqliteDatabase };
     db = nodeSqliteAdapter(new DatabaseSync(fp));
@@ -168,6 +187,8 @@ function openDatabase(): SqliteDatabase {
     );
     CREATE INDEX IF NOT EXISTS context_nodes_project_status
       ON context_nodes(project_id, status, updated_at DESC);
+    CREATE INDEX IF NOT EXISTS context_nodes_lineage
+      ON context_nodes(project_id, session_id, source, branch_head_id, kind, fact_key, updated_at DESC);
     CREATE TABLE IF NOT EXISTS context_edges (
       project_id TEXT NOT NULL,
       from_id TEXT NOT NULL REFERENCES context_nodes(id) ON DELETE CASCADE,
@@ -184,7 +205,8 @@ function openDatabase(): SqliteDatabase {
     );
   `);
   const version = db.query("PRAGMA user_version").get() as { user_version: number } | null;
-  if (Number(version?.user_version ?? 0) < CONTEXT_GRAPH_SCHEMA_VERSION) {
+  const schemaVersion = Number(version?.user_version ?? 0);
+  if (schemaVersion < 1) {
     db.transaction(() => {
       db.exec(`
         DROP INDEX IF EXISTS context_nodes_fact;
@@ -193,6 +215,17 @@ function openDatabase(): SqliteDatabase {
         DELETE FROM context_nodes WHERE source = 'compaction';
         CREATE UNIQUE INDEX context_nodes_fact
           ON context_nodes(project_id, session_id, kind, fact_key, COALESCE(branch_head_id, ''));
+        PRAGMA user_version = 1;
+      `);
+    })();
+  }
+  if (schemaVersion < 2) {
+    db.transaction(() => {
+      db.exec(`
+        DELETE FROM context_nodes_fts;
+        INSERT INTO context_nodes_fts(rowid, node_id, title, content, kind)
+          SELECT rowid, id, title, content, kind FROM context_nodes
+          WHERE status = 'active' AND kind NOT IN ('project', 'session');
         PRAGMA user_version = ${CONTEXT_GRAPH_SCHEMA_VERSION};
       `);
     })();
@@ -208,11 +241,20 @@ function factKey(text: string): string {
   return normalizeFactKey(text) || text.trim().toLowerCase();
 }
 
+function removeFtsNode(db: SqliteDatabase, nodeId: string): void {
+  db.query(`
+    DELETE FROM context_nodes_fts
+    WHERE rowid = (SELECT rowid FROM context_nodes WHERE id = ?)
+  `).run(nodeId);
+}
+
 function syncFts(db: SqliteDatabase, node: GraphNode): void {
-  db.query("DELETE FROM context_nodes_fts WHERE node_id = ?").run(node.id);
+  const row = db.query("SELECT rowid FROM context_nodes WHERE id = ?").get(node.id) as { rowid: number } | null;
+  if (!row) return;
+  db.query("DELETE FROM context_nodes_fts WHERE rowid = ?").run(row.rowid);
   if (node.status === "active" && node.kind !== "project" && node.kind !== "session") {
-    db.query("INSERT INTO context_nodes_fts(node_id, title, content, kind) VALUES (?, ?, ?, ?)")
-      .run(node.id, node.title, node.content, node.kind);
+    db.query("INSERT INTO context_nodes_fts(rowid, node_id, title, content, kind) VALUES (?, ?, ?, ?, ?)")
+      .run(row.rowid, node.id, node.title, node.content, node.kind);
   }
 }
 
@@ -301,17 +343,21 @@ function branchLineage(scope: ContextGraphScope): string[] {
 function lineageFactRows(
   db: SqliteDatabase, scope: ContextGraphScope, kind?: string, key?: string,
 ): NodeRow[] {
-  const lineage = new Set(branchLineage(scope));
-  const rows = db.query(`
+  const lineage = branchLineage(scope);
+  const params: unknown[] = [scope.projectId, scope.sessionId];
+  let branchClause = "AND branch_head_id IS NULL";
+  if (lineage.length > 0) {
+    branchClause = "AND branch_head_id IN (" + lineage.map(() => "?").join(",") + ")";
+    params.push(...lineage);
+  }
+  if (kind) params.push(kind);
+  if (key) params.push(key);
+  return db.query(`
     SELECT * FROM context_nodes
     WHERE project_id = ? AND session_id = ? AND source = 'compaction'
-      ${kind ? "AND kind = ?" : ""} ${key ? "AND fact_key = ?" : ""}
-  `).all(scope.projectId, scope.sessionId, ...(kind ? [kind] : []), ...(key ? [key] : [])) as NodeRow[];
-  return rows.filter(row => lineage.size > 0
-    ? Boolean(row.branch_head_id && lineage.has(row.branch_head_id))
-    : row.branch_head_id == null);
+      ${branchClause} ${kind ? "AND kind = ?" : ""} ${key ? "AND fact_key = ?" : ""}
+  `).all(...params) as NodeRow[];
 }
-
 function latestLineageFact(
   db: SqliteDatabase, scope: ContextGraphScope, kind: string, key: string,
 ): NodeRow | null {
@@ -385,10 +431,9 @@ function pruneProject(db: SqliteDatabase, projectId: string): void {
     ORDER BY CASE WHEN status = 'active' THEN 1 ELSE 0 END, updated_at ASC
     LIMIT ?
   `).all(projectId, excess) as Array<{ id: string }> : [];
-  const removeFts = db.query("DELETE FROM context_nodes_fts WHERE node_id = ?");
   const removeNode = db.query("DELETE FROM context_nodes WHERE id = ?");
   for (const victim of victims) {
-    removeFts.run(victim.id);
+    removeFtsNode(db, victim.id);
     removeNode.run(victim.id);
   }
 
@@ -402,6 +447,10 @@ function pruneProject(db: SqliteDatabase, projectId: string): void {
   for (const session of staleSessions) removeNode.run(session.id);
 }
 
+// A synchronous drain borrows one connection across queued states; direct
+// callers still own and close their database immediately.
+let activeCompactionIndexDatabase: SqliteDatabase | null = null;
+
 /** Persist a scoped compaction state into the project context graph. Best-effort. */
 export function indexCompactionState(projectId: string, state: CompactionState): boolean {
   const sessionId = state.scope?.sessionId;
@@ -413,8 +462,9 @@ export function indexCompactionState(projectId: string, state: CompactionState):
     branchEntryIds: state.scope.branchAncestryIds,
   };
   let db: SqliteDatabase | null = null;
+  const ownsDatabase = activeCompactionIndexDatabase === null;
   try {
-    db = openDatabase();
+    db = activeCompactionIndexDatabase ?? openDatabase();
     const transaction = db.transaction(() => {
       const now = Date.now();
       const projectNode = makeNode({ ...scope, sessionId: "*", branchHeadId: undefined }, "project", "Project", projectId, { confidence: 1 });
@@ -484,7 +534,9 @@ export function indexCompactionState(projectId: string, state: CompactionState):
     log.warn("indexCompactionState failed", error);
     return false;
   } finally {
-    try { db?.close(); } catch { /* best effort */ }
+    if (ownsDatabase) {
+      try { db?.close(); } catch { /* best effort */ }
+    }
   }
 }
 
@@ -496,7 +548,17 @@ function drainCompactionIndexes(): void {
   compactionIndexTimer = null;
   const jobs = [...pendingCompactionIndexes.values()];
   pendingCompactionIndexes.clear();
-  for (const job of jobs) indexCompactionState(job.projectId, job.state);
+  let db: SqliteDatabase | null = null;
+  try {
+    db = openDatabase();
+    activeCompactionIndexDatabase = db;
+    for (const job of jobs) indexCompactionState(job.projectId, job.state);
+  } catch (error) {
+    log.warn("context graph index drain failed", error);
+  } finally {
+    activeCompactionIndexDatabase = null;
+    try { db?.close(); } catch { /* best effort */ }
+  }
   if (pendingCompactionIndexes.size) armCompactionIndexDrain();
 }
 
@@ -513,8 +575,9 @@ export function scheduleCompactionStateIndex(projectId: string, state: Compactio
   const branchHeadId = state.scope?.branchHeadId;
   if (!sessionId || !branchHeadId || state.scope?.projectId !== projectId) return false;
   const key = projectId + "\0" + sessionId + "\0" + branchHeadId;
-  if (!pendingCompactionIndexes.has(key) && pendingCompactionIndexes.size >= MAX_PENDING_COMPACTION_INDEXES) {
-    log.warn("context graph index queue full; newest derived update was rejected");
+  if (pendingCompactionIndexes.has(key)) pendingCompactionIndexes.delete(key);
+  if (pendingCompactionIndexes.size >= MAX_PENDING_COMPACTION_INDEXES) {
+    log.warn("context graph index queue full; new derived update was rejected");
     return false;
   }
   pendingCompactionIndexes.set(key, { projectId, state });
@@ -548,8 +611,7 @@ export function closeContextMemory(
         UPDATE context_nodes SET status = ?, updated_at = ?
         WHERE project_id = ? AND kind = ? AND fact_key = ? AND source = 'manual' AND status = 'active'
       `).run(status, Date.now(), projectId, kind, factKey(content));
-      const remove = db!.query("DELETE FROM context_nodes_fts WHERE node_id = ?");
-      for (const row of rows) remove.run(row.id);
+      for (const row of rows) removeFtsNode(db!, row.id);
     });
     transaction();
     return rows.length;
@@ -592,10 +654,9 @@ export function saveContextMemory(scope: ContextGraphScope, memory: Omit<SavedCo
         ...duplicates.flatMap(item => parsePaths(item.related_paths)),
       ])).slice(0, 20);
       upsertNode(db!, node, true);
-      const removeFts = db!.query("DELETE FROM context_nodes_fts WHERE node_id = ?");
       const removeNode = db!.query("DELETE FROM context_nodes WHERE id = ?");
       for (const duplicate of duplicates) {
-        removeFts.run(duplicate.id);
+        removeFtsNode(db!, duplicate.id);
         removeNode.run(duplicate.id);
       }
       for (const file of relatedPaths) {
@@ -621,7 +682,7 @@ function searchRows(db: SqliteDatabase, projectId: string, terms: string[]): Nod
   try {
     return db.query(`
       SELECT n.* FROM context_nodes_fts f
-      JOIN context_nodes n ON n.id = f.node_id
+      JOIN context_nodes n ON n.rowid = f.rowid
       WHERE context_nodes_fts MATCH ? AND n.project_id = ? AND n.status = 'active'
         AND n.kind NOT IN ('project', 'session')
       ORDER BY bm25(context_nodes_fts, 0.0, 3.0, 1.0, 0.5)

--- a/src/infra/fs.ts
+++ b/src/infra/fs.ts
@@ -194,6 +194,49 @@ export function appendLineLocked(target: string, line: string, maxBytes?: number
   }
 }
 
+/** Async append/retention variant for event-loop-sensitive telemetry paths. */
+export async function appendLineLockedAsync(target: string, line: string, maxBytes?: number): Promise<void> {
+  await ensureDirAsync(path.dirname(target));
+  const payload = Buffer.from(line.endsWith("\n") ? line : line + "\n");
+  if (maxBytes !== undefined && (!Number.isSafeInteger(maxBytes) || maxBytes <= 0)) {
+    throw new Error("maxBytes must be a positive safe integer");
+  }
+  if (maxBytes !== undefined && payload.length > maxBytes) {
+    throw new Error("Log entry exceeds retention cap for " + target);
+  }
+  const release = await acquireLock(target);
+  try {
+    let stat: Awaited<ReturnType<typeof fsp.stat>> | null = null;
+    try {
+      stat = await fsp.stat(target);
+    } catch (error) {
+      if (!error || typeof error !== "object" || !("code" in error) || error.code !== "ENOENT") throw error;
+    }
+    if (maxBytes !== undefined && stat && stat.size + payload.length > maxBytes) {
+      const retainedLength = Math.min(stat.size, Math.max(0, maxBytes - payload.length));
+      const buffer = Buffer.allocUnsafe(retainedLength);
+      if (retainedLength > 0) {
+        const handle = await fsp.open(target, "r");
+        try {
+          await handle.read(buffer, 0, retainedLength, stat.size - retainedLength);
+        } finally {
+          await handle.close();
+        }
+      }
+      let tail = buffer.toString("utf8");
+      if (retainedLength < stat.size) {
+        const firstNewline = tail.indexOf("\n");
+        tail = firstNewline >= 0 ? tail.slice(firstNewline + 1) : "";
+      }
+      await atomicWriteFile(target, tail);
+    }
+    await fsp.appendFile(target, payload, { mode: 0o600 });
+    await fsp.chmod(target, 0o600);
+  } finally {
+    release();
+  }
+}
+
 /** Read the newest valid JSONL records without loading an entire bounded log. */
 export function readJsonlTail<T>(target: string, limit: number, maxBytes = 512 * 1024): T[] {
   if (limit <= 0 || !fs.existsSync(target)) return [];

--- a/src/phases/explore.ts
+++ b/src/phases/explore.ts
@@ -6,7 +6,7 @@ import type { Model, Api, ToolCall, TextContent, Message, Tool, ProviderHeaders 
 import { Type } from "typebox";
 import type { LlmMessage, StructuredExtraction, ExplorationReport, TopicBoundary } from "../types.ts";
 import { getToolCallNames, filterToolCalls } from "../utils/type-guards.ts";
-import { COMPACT_SYSTEM_PREFIX, EXPLORER_SYSTEM_PROMPT, MAX_EXPLORATION_ROUNDS, TRUNC } from "../constants.ts";
+import { COMPACT_SYSTEM_PREFIX, EXPLORER_SYSTEM_PROMPT, MAX_EXPLORATION_ROUNDS, MAX_EXPLORER_OUTPUT_CHARS, TRUNC } from "../constants.ts";
 import { extractText, extractMainGoal, extractStructured } from "../utils/extraction.ts";
 import { classifyTool } from "../domain/tool-semantics.ts";
 import { trackedComplete } from "../utils/cache.ts";
@@ -16,6 +16,7 @@ import type { SmartCompactServices } from "../infra/services.ts";
 import { getDefaultServices } from "../infra/services.ts";
 import { buildExtractionContext } from "../utils/helpers.ts";
 import { classifyTelemetryFailure } from "../domain/telemetry.ts";
+import { SecretScrubber } from "../domain/scrub.ts";
 
 // Production services share bounded provider/model capability knowledge across
 // runs; tests keep isolated service bags. Only an explicit provider rejection
@@ -86,100 +87,165 @@ const EXPLORATION_TOOLS: Tool[] = [
   },
 ];
 
-export function executeExplorationTool(call: { name: string; arguments: Record<string, unknown> }, llmMessages: LlmMessage[]): string {
+function boundedExplorationValue(value: unknown, depth = 0): unknown {
+  if (typeof value === "string") {
+    return value.length > TRUNC.PREVIEW_XL ? value.slice(0, TRUNC.PREVIEW_XL) + "…" : value;
+  }
+  if (value == null || typeof value !== "object") return value;
+  if (depth >= 3) return "[bounded]";
+  if (Array.isArray(value)) return value.slice(0, 50).map(item => boundedExplorationValue(item, depth + 1));
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .slice(0, 16)
+      .map(([key, item]) => [key, boundedExplorationValue(item, depth + 1)]),
+  );
+}
+
+function serializeExplorationResult(value: unknown, scrubber: SecretScrubber): string {
+  const safe = boundedExplorationValue(scrubber.scrubValue(value).value);
+  const serialized = JSON.stringify(safe);
+  if (serialized.length <= MAX_EXPLORER_OUTPUT_CHARS) return serialized;
+
+  let excerptChars = Math.max(0, Math.floor((MAX_EXPLORER_OUTPUT_CHARS - 160) / 2));
+  for (;;) {
+    const result = JSON.stringify({
+      truncated: true,
+      originalChars: serialized.length,
+      head: serialized.slice(0, excerptChars),
+      tail: serialized.slice(-excerptChars),
+    });
+    if (result.length <= MAX_EXPLORER_OUTPUT_CHARS) return result;
+    if (excerptChars === 0) return JSON.stringify({ truncated: true, originalChars: serialized.length });
+    excerptChars = Math.max(0, excerptChars - Math.max(1, result.length - MAX_EXPLORER_OUTPUT_CHARS));
+  }
+}
+
+export function executeExplorationTool(
+  call: { name: string; arguments: Record<string, unknown> },
+  llmMessages: LlmMessage[],
+  scrubber = new SecretScrubber(),
+): string {
   const args = call.arguments ?? {};
   const boundedInteger = (value: unknown, fallback: number, min: number, max: number): number =>
     typeof value === "number" && Number.isFinite(value)
       ? Math.max(min, Math.min(max, Math.trunc(value)))
       : fallback;
+  let output: unknown;
   switch (call.name) {
     case "get_message_range": {
       const s = boundedInteger(args.start, 0, 0, llmMessages.length);
       const e = boundedInteger(args.end, llmMessages.length, s, llmMessages.length);
-      return JSON.stringify(llmMessages.slice(s, e).map((m, i) => ({
+      output = llmMessages.slice(s, e).map((m, i) => ({
         idx: s + i, role: m?.role,
         preview: extractText(m?.content).slice(0, TRUNC.PREVIEW),
         toolCalls: getToolCallNames(m?.content),
         isError: m?.isError,
-      })));
+      }));
+      break;
     }
     case "search_conversation": {
-      const q = ((args.query as string) ?? "").toLowerCase();
-      if (!q.trim()) return JSON.stringify([{ error: "query must be a non-empty string" }]);
+      const q = typeof args.query === "string" ? args.query.toLowerCase().trim() : "";
+      if (!q) {
+        output = [{ error: "query must be a non-empty string" }];
+        break;
+      }
       const matches: { idx: number; m: LlmMessage }[] = [];
       for (let i = 0; i < llmMessages.length && matches.length < 10; i++) {
         const m = llmMessages[i];
         const text = extractText(m?.content).toLowerCase();
-        if (text.includes(q)) { matches.push({ idx: i, m }); continue; }
-        // Also check tool call arguments for file paths
-        const tcs = filterToolCalls(m?.content);
-        if (tcs.some(tc => JSON.stringify(tc.arguments).toLowerCase().includes(q))) {
+        if (text.includes(q)) {
           matches.push({ idx: i, m });
+          continue;
         }
+        let argumentsMatch = false;
+        for (const tc of filterToolCalls(m?.content)) {
+          const stack: Array<{ value: unknown; depth: number }> = [{ value: tc.arguments, depth: 0 }];
+          let inspected = 0;
+          while (stack.length && inspected++ < 64 && !argumentsMatch) {
+            const current = stack.pop()!;
+            if (typeof current.value === "string") {
+              argumentsMatch = current.value.slice(0, 2_000).toLowerCase().includes(q);
+            } else if (current.value && typeof current.value === "object" && current.depth < 3) {
+              const values = Array.isArray(current.value)
+                ? current.value.slice(0, 16)
+                : Object.values(current.value as Record<string, unknown>).slice(0, 16);
+              for (const value of values) stack.push({ value, depth: current.depth + 1 });
+            }
+          }
+          if (argumentsMatch) break;
+        }
+        if (argumentsMatch) matches.push({ idx: i, m });
       }
-      return JSON.stringify(matches.map(({ idx, m }) => ({
+      output = matches.map(({ idx, m }) => ({
         idx, role: m?.role, preview: extractText(m?.content).slice(0, TRUNC.PREVIEW),
-      })));
+      }));
+      break;
     }
     case "get_recent_user_messages": {
       const count = boundedInteger(args.count, 10, 1, 50);
-      return JSON.stringify(llmMessages.filter((m) => m?.role === "user").slice(-count).map((m) => extractText(m.content)));
+      output = llmMessages
+        .filter((m) => m?.role === "user")
+        .slice(-count)
+        .map((m) => extractText(m.content).slice(0, TRUNC.PREVIEW_XL));
+      break;
     }
     case "get_context_around": {
       const idx = boundedInteger(args.index, 0, 0, Math.max(0, llmMessages.length - 1));
       const radius = boundedInteger(args.radius, 5, 0, 25);
       const s = Math.max(0, idx - radius), e = Math.min(llmMessages.length, idx + radius + 1);
-      return JSON.stringify(llmMessages.slice(s, e).map((m, i) => ({
+      output = llmMessages.slice(s, e).map((m, i) => ({
         idx: s + i, role: m?.role,
         text: extractText(m?.content).slice(0, TRUNC.DETAIL),
         toolCalls: getToolCallNames(m?.content),
         isError: m?.isError,
-      })));
+      }));
+      break;
     }
     case "get_file_changes": {
-      const target = ((args.path as string) ?? "").toLowerCase();
-      if (!target.trim()) return JSON.stringify([{ error: "path must be a non-empty string" }]);
+      const target = typeof args.path === "string" ? args.path.toLowerCase().trim() : "";
+      if (!target) {
+        output = [{ error: "path must be a non-empty string" }];
+        break;
+      }
       const results: unknown[] = [];
-      for (let i = 0; i < llmMessages.length; i++) {
-        const tcs = filterToolCalls(llmMessages[i]?.content);
-        for (const block of tcs) {
-          // Look up file path fields by name rather than stringifying the
-          // whole block: JSON.stringify doesn't guarantee key ordering, and
-          // values that happen to contain the target substring (e.g. inside
-          // a `content` field of a `write` call) would otherwise produce
-          // false positives.
+      for (let i = 0; i < llmMessages.length && results.length < TRUNC.EXPLORE_RESULTS; i++) {
+        for (const block of filterToolCalls(llmMessages[i]?.content)) {
           const a = (block.arguments ?? {}) as Record<string, unknown>;
           const fileFields = [a.path, a.file, a.filePath, a.file_path]
-            .filter((v): v is string => typeof v === "string").map(v => v.toLowerCase());
-          const matchesPath = fileFields.some(f => f.includes(target));
-          // Classify by argument shape, not name — see domain/tool-semantics.ts.
-          if (classifyTool(block.arguments) === "mutates" && matchesPath) {
-            // Surgical edits (oldText/newText/edits/patch) carry small, useful
-            // args; full-file writes carry large content, so omit args to keep
-            // the exploration result compact.
-            const surgical = a.oldText != null || a.newText != null || a.edits != null || a.patch != null;
-            const preview = extractText(llmMessages[i]?.content).slice(0, TRUNC.PREVIEW_LONG);
-            results.push(surgical
-              ? { idx: i, role: "assistant", toolCall: block.name ?? "mutates", args: block.arguments, preview }
-              : { idx: i, role: "assistant", toolCall: block.name ?? "mutates", preview });
-          }
+            .filter((value): value is string => typeof value === "string")
+            .map(value => value.toLowerCase());
+          if (classifyTool(block.arguments) !== "mutates" || !fileFields.some(file => file.includes(target))) continue;
+
+          const preview = extractText(llmMessages[i]?.content).slice(0, TRUNC.PREVIEW_LONG);
+          const surgicalKeys = ["path", "file", "filePath", "file_path", "oldText", "newText", "edits", "patch"] as const;
+          const argsPreview = Object.fromEntries(
+            surgicalKeys.filter(key => a[key] !== undefined).map(key => [key, a[key]]),
+          );
+          const surgical = a.oldText != null || a.newText != null || a.edits != null || a.patch != null;
+          results.push(surgical
+            ? { idx: i, role: "assistant", toolCall: block.name ?? "mutates", args: argsPreview, preview }
+            : { idx: i, role: "assistant", toolCall: block.name ?? "mutates", preview });
         }
       }
-      return JSON.stringify(results.slice(0, TRUNC.EXPLORE_RESULTS) || [{ info: "No edits found for: " + args.path }]);
+      output = results.length ? results : [{ info: "No edits found for: " + args.path }];
+      break;
     }
     case "get_error_chain": {
       const errIdx = boundedInteger(args.index, 0, 0, Math.max(0, llmMessages.length - 1));
       const ctxRadius = boundedInteger(args.context_radius, 8, 0, 25);
       const s = Math.max(0, errIdx - ctxRadius), e = Math.min(llmMessages.length, errIdx + ctxRadius + 1);
-      return JSON.stringify(llmMessages.slice(s, e).map((m, i) => ({
+      output = llmMessages.slice(s, e).map((m, i) => ({
         idx: s + i, role: m?.role,
         text: extractText(m?.content).slice(0, TRUNC.PREVIEW_XL),
         isError: m?.isError,
         toolCalls: getToolCallNames(m?.content),
-      })));
+      }));
+      break;
     }
-    default: return "Unknown tool: " + call.name;
+    default:
+      output = { error: "Unknown tool: " + call.name };
   }
+  return serializeExplorationResult(output, scrubber);
 }
 
 export function parseExplorationReport(text: string, llmMessages: LlmMessage[]): ExplorationReport {
@@ -378,7 +444,7 @@ export async function exploreConversation(
         probeResp,
       ];
       for (const tc of toolCalls) {
-        const result = executeExplorationTool({ name: tc.name, arguments: tc.arguments }, llmMessages);
+        const result = executeExplorationTool({ name: tc.name, arguments: tc.arguments }, llmMessages, svc.scrubber);
         messages.push({ role: "toolResult", toolCallId: tc.id, toolName: tc.name, content: [{ type: "text", text: result }], isError: false, timestamp: Date.now() });
       }
 
@@ -410,7 +476,7 @@ export async function exploreConversation(
 
         messages.push(response);
         for (const tc of nextToolCalls) {
-          const result = executeExplorationTool({ name: tc.name, arguments: tc.arguments }, llmMessages);
+          const result = executeExplorationTool({ name: tc.name, arguments: tc.arguments }, llmMessages, svc.scrubber);
           messages.push({ role: "toolResult", toolCallId: tc.id, toolName: tc.name, content: [{ type: "text", text: result }], isError: false, timestamp: Date.now() });
         }
       }

--- a/src/phases/synthesize.ts
+++ b/src/phases/synthesize.ts
@@ -56,7 +56,38 @@ function fitChunkBudget(messages: LlmMessage[], maxTokens: number, estimator: To
     if (!changed) break;
     estimate = estimateChunkTokens(fitted, estimator);
   }
-  return fitted;
+  if (estimate <= maxTokens) return fitted;
+
+  // Last-resort postcondition for a single giant assistant/tool-call payload
+  // or a delayed tool-result span whose structural overhead cannot be split.
+  const rendered = fitted.map(renderBatchMessage).join("\n");
+  const marker = "[…chunk evidence hard-bounded for synthesis…]";
+  const candidate = (chars: number): LlmMessage[] => {
+    if (chars <= 0) return [{ role: "user", content: marker }];
+    const head = Math.ceil(chars * 0.6);
+    return [{
+      role: "user",
+      content: rendered.slice(0, head) + "\n" + marker + "\n" + rendered.slice(-(chars - head)),
+    }];
+  };
+  let best = candidate(0);
+  if (estimateChunkTokens(best, estimator) > maxTokens) {
+    if (estimateChunkTokens([], estimator) <= maxTokens) return [];
+    throw new RangeError("Token estimator cannot represent a chunk within maxChunkTokens");
+  }
+  let low = 0;
+  let high = rendered.length;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const next = candidate(middle);
+    if (estimateChunkTokens(next, estimator) <= maxTokens) {
+      best = next;
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return best;
 }
 
 function extendThroughToolResults(messages: LlmMessage[], start: number, proposedEnd: number): number {
@@ -82,7 +113,9 @@ function splitOversizedChunk(ch: LlmChunk, maxTokens: number, estimator: TokenEs
   if (ch.tokenEstimate <= maxTokens) return [ch];
   if (ch.messages.length <= 1) {
     const messages = fitChunkBudget(ch.messages, maxTokens, estimator);
-    return [{ ...ch, tokenEstimate: estimateChunkTokens(messages, estimator), messages }];
+    const tokenEstimate = estimateChunkTokens(messages, estimator);
+    if (tokenEstimate > maxTokens) throw new RangeError("Chunk budget postcondition failed");
+    return [{ ...ch, tokenEstimate, messages }];
   }
   const parts: LlmChunk[] = [];
   let start = 0;
@@ -97,11 +130,13 @@ function splitOversizedChunk(ch: LlmChunk, maxTokens: number, estimator: TokenEs
     }
     const end = extendThroughToolResults(ch.messages, start, proposedEnd);
     const messages = fitChunkBudget(ch.messages.slice(start, end), maxTokens, estimator);
+    const tokenEstimate = estimateChunkTokens(messages, estimator);
+    if (tokenEstimate > maxTokens) throw new RangeError("Chunk budget postcondition failed");
     parts.push({
       ...ch,
       startIndex: ch.startIndex + start,
       endIndex: ch.startIndex + end - 1,
-      tokenEstimate: estimateChunkTokens(messages, estimator),
+      tokenEstimate,
       messages,
     });
     start = end;

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -5,7 +5,7 @@
  * boundary; repair logic switches on `kind` and never reparses its own prose.
  */
 
-import type { Model, Api, ProviderHeaders } from "@earendil-works/pi-ai";
+import type { Model, Api, ProviderHeaders, TextContent } from "@earendil-works/pi-ai";
 import type { CompactionState, StructuredExtraction, VerificationGap, VerificationResult, LlmMessage } from "../types.ts";
 import { COMPACT_SYSTEM_PREFIX, LIKELY_ERROR_RE, TRUNC } from "../constants.ts";
 import { trackedComplete } from "../utils/cache.ts";
@@ -17,6 +17,8 @@ import * as log from "../utils/logger.ts";
 import { parseSummary, findSection, appendToSection, renderSummary, summaryEvidenceLine, upsertSection } from "../domain/summary-parse.ts";
 import { canonicalHeading } from "../domain/summary-schema.ts";
 import type { CanonicalSummary } from "../domain/summary-schema.ts";
+import { classifyToolOperation, extractToolPath, normalizeToolName, type ToolOperation } from "../domain/tool-semantics.ts";
+import { lruGet, lruSet } from "../utils/lru.ts";
 import type { SmartCompactServices } from "../infra/services.ts";
 export interface VerificationEvidence {
   sourceMessages?: readonly LlmMessage[];
@@ -45,9 +47,44 @@ function classifyOutcomeClaim(claim: string): "test" | "build" | "release" | "er
   return "generic";
 }
 
+interface SuccessfulToolEvidence {
+  name: string;
+  operation: ToolOperation;
+  command: string;
+  path?: string;
+  result: string;
+}
+
+const successfulToolEvidenceCache = new WeakMap<readonly LlmMessage[], SuccessfulToolEvidence[]>();
+
+function successfulToolEvidence(messages: readonly LlmMessage[]): SuccessfulToolEvidence[] {
+  const cached = successfulToolEvidenceCache.get(messages);
+  if (cached) return cached;
+  const toolCalls = buildToolCallIndex(messages);
+  const evidence: SuccessfulToolEvidence[] = [];
+  for (const message of messages) {
+    if (message.role !== "toolResult" || message.isError) continue;
+    const call = toolCalls.get(message.toolCallId ?? "");
+    if (!call) continue;
+    const result = extractText(message.content).slice(0, 8_000);
+    if (!result.trim() || LIKELY_ERROR_RE.test(result)) continue;
+    const command = [call.arguments.command, call.arguments.cmd, call.arguments.script]
+      .find((value): value is string => typeof value === "string") ?? "";
+    evidence.push({
+      name: normalizeToolName(call.name),
+      operation: classifyToolOperation(call.arguments, call.name),
+      command,
+      path: extractToolPath(call.arguments),
+      result,
+    });
+  }
+  successfulToolEvidenceCache.set(messages, evidence);
+  return evidence;
+}
+
 function successfulToolSupportsClaim(
   claim: string,
-  messages: readonly LlmMessage[],
+  tools: readonly SuccessfulToolEvidence[],
   extraction: StructuredExtraction,
 ): boolean {
   const shape = semanticShape(claim);
@@ -56,23 +93,31 @@ function successfulToolSupportsClaim(
     && hasSemanticEvidence(claim, error.message))) return true;
   if (category === "file" && extraction.modifiedFiles.some(file => claim.toLowerCase().includes(file.path.toLowerCase()))) return true;
 
-  // Positive outcome claims require host/tool evidence. Assistant prose is an
-  // untrusted assertion even when it repeats the claim exactly.
-  for (const message of messages) {
-    if (message.role !== "toolResult" || message.isError) continue;
-    const bounded = extractText(message.content).slice(0, 8_000);
-    if (!bounded.trim() || LIKELY_ERROR_RE.test(bounded)) continue;
-    if (hasSemanticEvidence(claim, bounded)) return true;
-    const lower = bounded.toLowerCase();
+  // A result can prove only the operation that produced it. This rejects, for
+  // example, "All tests passed" text returned by a read/search tool.
+  for (const tool of tools) {
+    const operationText = tool.name + " " + tool.command;
+    const operationSupports = category === "test"
+      ? /\b(?:test|tests|pytest|jest|vitest|mocha|rspec)\b/i.test(operationText)
+      : category === "build"
+        ? /\b(?:build|compile|typecheck|tsc|check)\b/i.test(operationText)
+        : category === "release"
+          ? /\b(?:deploy|publish|release)\b/i.test(operationText)
+          : category === "file"
+            ? tool.operation === "mutate" || tool.operation === "delete"
+            : category === "error"
+              ? tool.operation === "execute" || tool.operation === "mutate" || tool.operation === "delete"
+              : tool.operation !== "read" && tool.operation !== "search" && tool.operation !== "list";
+    if (!operationSupports) continue;
+    if (hasSemanticEvidence(claim, tool.result)) return true;
+    const lower = tool.result.toLowerCase();
     if (category === "test" && /\b\d+\s+(?:tests?\s+)?pass(?:ed)?\b/.test(lower)
       && !/\b(?:fail(?:ed|ures?)?|errors?)\s*[:=]?\s*[1-9]\d*\b/.test(lower)) return true;
-    if (category === "build" && /\b(?:build|compile|typecheck)\b/.test(lower)
-      && /\b(?:succeeded|successful|passed|exit(?:ed)?\s+(?:code\s+)?0)\b/.test(lower)) return true;
-    if (category === "release" && /\b(?:publish|release|deploy)\b/.test(lower)
-      && /\b(?:succeeded|successful|completed|published|deployed|released)\b/.test(lower)) return true;
+    if (category === "build" && /\b(?:succeeded|successful|passed|exit(?:ed)?\s+(?:code\s+)?0)\b/.test(lower)) return true;
+    if (category === "release" && /\b(?:succeeded|successful|completed|published|deployed|released)\b/.test(lower)) return true;
     if (category === "error" && shape.concepts.length > 0
       && /\b(?:fixed|resolved|passed|succeeded|successful)\b/.test(lower)
-      && hasSemanticEvidence(claim, bounded)) return true;
+      && hasSemanticEvidence(claim, tool.result)) return true;
   }
   return false;
 }
@@ -166,10 +211,27 @@ function semanticTokens(text: string): string[] {
     .filter(token => token.length > 2);
 }
 
-function evidenceFragments(text: string): string[] {
-  const fragments = text.split(/\r?\n/).flatMap(line => [line, ...line.split(/[.;]/)])
-    .map(part => part.replace(/^\s*[-*\d.)]+\s*/, "").trim()).filter(Boolean);
-  return Array.from(new Set(fragments));
+interface SemanticShape {
+  sourceTokens: string[];
+  concepts: string[];
+  anchor: string;
+  negative: boolean;
+  conditional: boolean;
+}
+
+const semanticShapeCache = new Map<string, SemanticShape>();
+const semanticFragmentCache = new Map<string, string[][]>();
+
+function semanticFragments(text: string): string[][] {
+  const cached = lruGet(semanticFragmentCache, text);
+  if (cached) return cached;
+  const fragments = Array.from(new Set(text.split(/\r?\n/)
+    .flatMap(line => [line, ...line.split(/[.;]/)])
+    .map(part => part.replace(/^\s*[-*\d.)]+\s*/, "").trim())
+    .filter(Boolean)))
+    .map(semanticTokens);
+  lruSet(semanticFragmentCache, text, fragments, 256);
+  return fragments;
 }
 
 function hasNearbyMarker(tokens: string[], anchor: string, markers: Set<string>): boolean {
@@ -204,9 +266,9 @@ function hasEffectiveTargetNegation(tokens: string[], anchor: string): boolean {
 }
 
 /** Conservative deterministic semantic evidence for goals/constraints/decisions. */
-function semanticShape(source: string): {
-  sourceTokens: string[]; concepts: string[]; anchor: string; negative: boolean; conditional: boolean;
-} {
+function semanticShape(source: string): SemanticShape {
+  const cached = lruGet(semanticShapeCache, source);
+  if (cached) return cached;
   const sourceTokens = semanticTokens(source);
   const concepts = Array.from(new Set(sourceTokens.filter(token =>
     !/^\d+$/.test(token)
@@ -215,15 +277,16 @@ function semanticShape(source: string): {
   const negative = sourceTokens.some(token => NEGATION_MARKERS.has(token));
   const conditional = sourceTokens.some(token => CONDITION_MARKERS.has(token));
   const anchor = concepts.find(concept => hasNearbyMarker(sourceTokens, concept, NEGATION_MARKERS)) ?? concepts[0] ?? "";
-  return { sourceTokens, concepts, anchor, negative, conditional };
+  const shape = { sourceTokens, concepts, anchor, negative, conditional };
+  lruSet(semanticShapeCache, source, shape, 512);
+  return shape;
 }
 
 function hasSemanticEvidence(source: string, target: string): boolean {
   const { sourceTokens, concepts, anchor, negative, conditional } = semanticShape(source);
   if (!concepts.length) return true;
   const required = Math.min(concepts.length, Math.max(1, Math.ceil(concepts.length * 0.6)));
-  return evidenceFragments(target).some(fragment => {
-    const tokens = semanticTokens(fragment);
+  return semanticFragments(target).some(tokens => {
     const overlap = concepts.filter(concept => tokens.includes(concept)).length;
     if (overlap < required) return false;
     const targetNegative = hasEffectiveTargetNegation(tokens, anchor);
@@ -246,8 +309,7 @@ function hasSemanticContradiction(source: string, target: string): boolean {
   const { sourceTokens, concepts, anchor, negative, conditional } = semanticShape(source);
   if (!anchor) return false;
   const required = Math.min(concepts.length, Math.max(1, Math.ceil(concepts.length * 0.6)));
-  return evidenceFragments(target).some(fragment => {
-    const tokens = semanticTokens(fragment);
+  return semanticFragments(target).some(tokens => {
     if (!tokens.includes(anchor)) return false;
     const overlap = concepts.filter(concept => tokens.includes(concept)).length;
     // Sharing a generic anchor such as "release" or "file" is not enough:
@@ -454,15 +516,17 @@ export function verifySummary(
       gaps.push({ kind: "inconsistency", detail: "blocked-none: Blocked says none despite unresolved errors" });
       score -= 12;
     }
+    const doneRefs = new Set(extractFileRefs(doneSection).map(normalizePath));
     for (const file of extraction.modifiedFiles) {
-      const basename = file.path.split("/").pop() ?? "";
-      if (!doneSection.toLowerCase().includes(basename.toLowerCase())) continue;
+      const uniqueNeedles = buildUniquePathNeedles(file.path, modifiedPaths);
+      if (!uniqueNeedles.some(needle => doneRefs.has(normalizePath(needle)))) continue;
       const unresolved = unresolvedEvidence.find(error => {
         const firstLine = error.message.split(/\r?\n/, 1)[0] ?? "";
-        return extractFileRefs(firstLine).some(ref => isKnownPathReference(ref, [file.path]));
+        const errorRefs = extractFileRefs(firstLine).map(normalizePath);
+        return uniqueNeedles.some(needle => errorRefs.includes(normalizePath(needle)));
       });
       if (unresolved) {
-        gaps.push({ kind: "inconsistency", detail: basename + " marked Done but has unresolved error" });
+        gaps.push({ kind: "inconsistency", detail: file.path + " marked Done but has unresolved error" });
         score -= 5;
       }
     }
@@ -486,8 +550,9 @@ export function verifySummary(
     score -= 5;
   }
   if (evidence.sourceMessages) {
+    const tools = successfulToolEvidence(evidence.sourceMessages);
     for (const claim of outcomeClaims(summary)) {
-      if (!successfulToolSupportsClaim(claim, evidence.sourceMessages, extraction)) {
+      if (!successfulToolSupportsClaim(claim, tools, extraction)) {
         gaps.push({ kind: "unsupported-claim", claim });
         score -= 20;
       }
@@ -607,6 +672,34 @@ export function patchDeterministic(
   return renderSummary(canonical, { canonicalHeadings: true });
 }
 
+function hasUnclosedMarkdownFence(markdown: string): boolean {
+  let open: { marker: "`" | "~"; length: number } | null = null;
+  for (const line of markdown.split(/\r?\n/)) {
+    const match = line.match(/^\s{0,3}(`{3,}|~{3,})(.*)$/);
+    if (!match) continue;
+    const marker = match[1][0] as "`" | "~";
+    if (!open) {
+      open = { marker, length: match[1].length };
+    } else if (marker === open.marker && match[1].length >= open.length && !match[2].trim()) {
+      open = null;
+    }
+  }
+  return open !== null;
+}
+
+function patchResponseIsTruncated(patched: string, stopReason: unknown): boolean {
+  const reason = String(stopReason ?? "");
+  return /(?:length|truncat|max(?:imum)?[_ -]?(?:output[_ -]?)?tokens?|token[_ -]?limit)/i.test(reason)
+    || /…✂\d+\s*$/.test(patched)
+    || hasUnclosedMarkdownFence(patched);
+}
+
+function sectionIdentity(section: CanonicalSummary["sections"][number]): string {
+  return section.kind === "unknown"
+    ? "unknown:" + section.heading.trim().toLowerCase()
+    : section.kind;
+}
+
 export async function patchSummary(
   summary: string, gaps: VerificationGap[],
   model: Model<Api>, auth: { apiKey: string; headers?: ProviderHeaders }, signal?: AbortSignal,
@@ -623,8 +716,15 @@ export async function patchSummary(
       systemPrompt: COMPACT_SYSTEM_PREFIX,
       messages: [{ role: "user" as const, content: [{ type: "text" as const, text: patchPrompt }], timestamp: Date.now() }],
     }, { apiKey: auth.apiKey, headers: auth.headers, maxTokens, signal }, services);
-    const patched = response.content.filter((content): content is import("@earendil-works/pi-ai").TextContent => content.type === "text").map(content => content.text).join("\n").trim();
-    return patched.startsWith("##") ? patched : summary;
+    const patched = response.content.filter((content): content is TextContent => content.type === "text")
+      .map(content => content.text).join("\n").trim();
+    if (!patched.startsWith("##") || patchResponseIsTruncated(patched, response.stopReason)) return summary;
+    const originalSections = parseSummary(summary).sections;
+    const patchedSections = parseSummary(patched).sections;
+    const patchedBodies = new Map(patchedSections.map(section => [sectionIdentity(section), section.body.trim()]));
+    const preserved = originalSections.every(section =>
+      !section.body.trim() || Boolean(patchedBodies.get(sectionIdentity(section))));
+    return preserved ? patched : summary;
   } catch (error) {
     log.debug("patchSummary LLM failed", error);
     return summary;

--- a/src/types.ts
+++ b/src/types.ts
@@ -279,6 +279,8 @@ export interface PendingCompaction {
   runId: string;
   summary: string;
   firstKeptEntryId: string;
+  /** Branch head that produced this summary; must still be in active ancestry. */
+  originBranchHeadId: string;
   tokensBefore: number;
   details: SmartCompactDetails;
   /** Complete metrics payload, appended only after Pi emits session_compact. */
@@ -369,11 +371,13 @@ export interface MediaAttachment {
 }
 export interface ExtractionEvidenceOverflow {
   modifiedFiles?: number;
+  referencedFiles?: number;
   readFiles?: number;
   deletedFiles?: number;
   errors?: number;
   decisions?: number;
   constraints?: number;
+  topics?: number;
   timeline?: number;
   mediaAttachments?: number;
 }
@@ -529,6 +533,8 @@ export interface ContinuityScope {
 /** Structured machine-readable compaction state */
 export interface CompactionState {
   goal: string | null;
+  /** Deterministic extraction identity; unlike `goal`, never stores an LLM paraphrase. */
+  goalKey?: string;
   decisions: Array<{ id: string; summary: string; userResponse?: string; type: "explicit" | "implicit" }>;
   constraints: Array<{ id: string; text: string; category: "requirement" | "preference" | "prohibition"; confidence: number }>;
   modifiedFiles: string[];

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -11,14 +11,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
-import type { LLMCallMetric, StructuredExtraction, CachedExtraction, CacheAwareOptions, CompactMetricsEntry, LlmMessage } from "../types.ts";
+import type { LLMCallMetric, StructuredExtraction, ExtractionEvidenceOverflow, CachedExtraction, CacheAwareOptions, CompactMetricsEntry, LlmMessage } from "../types.ts";
 import { flattenToolCallBlock, isTransientToolDiagnostic, type ToolCallIndex } from "./extraction.ts";
 import { estimateTokens, calibrateFromResponse, getProviderCaps } from "./tokens.ts";
 import * as log from "./logger.ts";
 import type { Model, Api, AssistantMessage, Context } from "@earendil-works/pi-ai";
 import { extractionCacheFile, metricsLogFile } from "../infra/paths.ts";
-import { appendLineLocked, readJsonSync, writeJsonSync } from "../infra/fs.ts";
-import { ONE_HOUR_MS, SEVEN_DAYS_MS, EXTRACTION_CACHE_PREFIX, RUNTIME_LOG_MAX_BYTES, ERROR_RETRY_WINDOW, ERROR_RESOLVE_WINDOW } from "../constants.ts";
+import { appendLineLockedAsync, readJsonSync, writeJsonSync } from "../infra/fs.ts";
+import { ONE_HOUR_MS, SEVEN_DAYS_MS, EXTRACTION_CACHE_PREFIX, RUNTIME_LOG_MAX_BYTES, ERROR_RETRY_WINDOW, ERROR_RESOLVE_WINDOW, EXTRACTION_LIMITS } from "../constants.ts";
 import { buildEntryIdFingerprint } from "./id-fingerprint.ts";
 import { getDefaultServices, type SmartCompactServices } from "../infra/services.ts";
 import { toolOperationSignature } from "../domain/tool-semantics.ts";
@@ -331,6 +331,32 @@ export function reconcileCachedErrors(
   });
 }
 
+interface BoundedEvidence<T> {
+  values: T[];
+  dropped: number;
+}
+
+function boundedTail<T>(items: T[], limit: number): BoundedEvidence<T> {
+  const dropped = Math.max(0, items.length - limit);
+  return { values: dropped ? items.slice(-limit) : items, dropped };
+}
+
+/** Keep the most recent occurrence of every identity while bounding memory. */
+function recentUnique(items: string[], limit: number): BoundedEvidence<string> {
+  const seen = new Set<string>();
+  const newestFirst: string[] = [];
+  for (let index = items.length - 1; index >= 0; index--) {
+    const item = items[index];
+    if (seen.has(item)) continue;
+    seen.add(item);
+    if (newestFirst.length < limit) newestFirst.push(item);
+  }
+  return {
+    values: newestFirst.reverse(),
+    dropped: Math.max(0, seen.size - limit),
+  };
+}
+
 export function mergeExtractions(
   base: StructuredExtraction,
   delta: StructuredExtraction,
@@ -338,93 +364,143 @@ export function mergeExtractions(
   deltaMessages: LlmMessage[] = [],
   deltaToolCalls: ToolCallIndex = new Map(),
 ): StructuredExtraction {
-  // ── Offset every index-bearing field in delta ──
-  const offsetErrors = delta.errors.map(e => ({ ...e, index: e.index + baseMsgCount }));
-  const offsetDecisions = delta.decisions.map(d => ({ ...d, index: d.index + baseMsgCount }));
-  const offsetConstraints = delta.constraints.map(c => ({ ...c, index: c.index + baseMsgCount }));
-  const offsetTopics = delta.topics.map(t => ({
-    ...t,
-    startIndex: t.startIndex + baseMsgCount,
-    endIndex: t.endIndex + baseMsgCount,
+  // Offset every index-bearing field in the suffix into the cached domain.
+  const offsetErrors = delta.errors.map(error => ({ ...error, index: error.index + baseMsgCount }));
+  const offsetDecisions = delta.decisions.map(decision => ({ ...decision, index: decision.index + baseMsgCount }));
+  const offsetConstraints = delta.constraints.map(constraint => ({ ...constraint, index: constraint.index + baseMsgCount }));
+  const offsetTopics = delta.topics.map(topic => ({
+    ...topic,
+    startIndex: topic.startIndex + baseMsgCount,
+    endIndex: topic.endIndex + baseMsgCount,
   }));
-  const offsetTimeline = delta.timeline.map(t => ({ ...t, index: t.index + baseMsgCount }));
-  const offsetModifiedFiles = delta.modifiedFiles.map(f => ({
-    ...f,
-    lastModifiedIndex: f.lastModifiedIndex + baseMsgCount,
+  const offsetTimeline = delta.timeline.map(event => ({ ...event, index: event.index + baseMsgCount }));
+  const offsetModifiedFiles = delta.modifiedFiles.map(file => ({
+    ...file,
+    lastModifiedIndex: file.lastModifiedIndex + baseMsgCount,
   }));
-  const offsetMedia = (delta.mediaAttachments ?? []).map(a => ({ ...a, index: a.index + baseMsgCount }));
+  const offsetMedia = (delta.mediaAttachments ?? []).map(attachment => ({
+    ...attachment,
+    index: attachment.index + baseMsgCount,
+  }));
 
   const modified = new Map(base.modifiedFiles.map(file => [file.path, { ...file }]));
   for (const file of offsetModifiedFiles) {
     const previous = modified.get(file.path);
     modified.set(file.path, previous
-      ? { ...file, toolCalls: previous.toolCalls + file.toolCalls, lastModifiedIndex: Math.max(previous.lastModifiedIndex, file.lastModifiedIndex) }
+      ? {
+          ...file,
+          toolCalls: previous.toolCalls + file.toolCalls,
+          lastModifiedIndex: Math.max(previous.lastModifiedIndex, file.lastModifiedIndex),
+        }
       : file);
   }
   const deltaPresent = new Set([...offsetModifiedFiles.map(file => file.path), ...delta.readFiles]);
   const deltaDeleted = new Set(delta.deletedFiles);
   for (const file of deltaDeleted) modified.delete(file);
-  const readFiles = new Set([...base.readFiles, ...delta.readFiles]);
-  for (const file of deltaDeleted) readFiles.delete(file);
-  const deletedFiles = new Set([...base.deletedFiles, ...delta.deletedFiles]);
-  for (const file of deltaPresent) deletedFiles.delete(file);
 
+  const modifiedFiles = boundedTail(
+    [...modified.values()].sort((a, b) => a.lastModifiedIndex - b.lastModifiedIndex),
+    EXTRACTION_LIMITS.MODIFIED_FILES,
+  );
+  const readFiles = recentUnique(
+    [...base.readFiles, ...delta.readFiles].filter(file => !deltaDeleted.has(file)),
+    EXTRACTION_LIMITS.READ_FILES,
+  );
+  const deletedFiles = recentUnique(
+    [...base.deletedFiles, ...delta.deletedFiles].filter(file => !deltaPresent.has(file)),
+    EXTRACTION_LIMITS.DELETED_FILES,
+  );
+  const referencedFiles = recentUnique(
+    [...(base.referencedFiles ?? []), ...(delta.referencedFiles ?? [])],
+    EXTRACTION_LIMITS.REFERENCED_FILES,
+  );
+  const mediaAttachments = boundedTail(
+    [...(base.mediaAttachments ?? []), ...offsetMedia],
+    EXTRACTION_LIMITS.MEDIA_ATTACHMENTS,
+  );
   const reconciledBaseErrors = reconcileCachedErrors(base.errors, deltaMessages, deltaToolCalls, baseMsgCount);
-  const mergedErrors = [...reconciledBaseErrors, ...offsetErrors]
-    .filter(error => !isTransientToolDiagnostic(error.message));
+  const errors = boundedTail(
+    [...reconciledBaseErrors, ...offsetErrors].filter(error => !isTransientToolDiagnostic(error.message)),
+    EXTRACTION_LIMITS.ERRORS,
+  );
+  const decisions = boundedTail([...base.decisions, ...offsetDecisions], EXTRACTION_LIMITS.DECISIONS);
+  const constraints = boundedTail([...base.constraints, ...offsetConstraints], EXTRACTION_LIMITS.CONSTRAINTS);
+  const topics = boundedTail([...base.topics, ...offsetTopics], EXTRACTION_LIMITS.TOPICS);
+  const timeline = boundedTail([...base.timeline, ...offsetTimeline], EXTRACTION_LIMITS.TIMELINE);
+
+  const dropped: Partial<Record<keyof ExtractionEvidenceOverflow, number>> = {
+    modifiedFiles: modifiedFiles.dropped,
+    referencedFiles: referencedFiles.dropped,
+    readFiles: readFiles.dropped,
+    deletedFiles: deletedFiles.dropped,
+    errors: errors.dropped,
+    decisions: decisions.dropped,
+    constraints: constraints.dropped,
+    topics: topics.dropped,
+    timeline: timeline.dropped,
+    mediaAttachments: mediaAttachments.dropped,
+  };
+  const evidenceOverflow: ExtractionEvidenceOverflow = {};
+  for (const key of Object.keys(dropped) as Array<keyof ExtractionEvidenceOverflow>) {
+    const total = (base.evidenceOverflow?.[key] ?? 0)
+      + (delta.evidenceOverflow?.[key] ?? 0)
+      + (dropped[key] ?? 0);
+    if (total > 0) Object.assign(evidenceOverflow, { [key]: total });
+  }
 
   return {
-    modifiedFiles: [...modified.values()],
-    readFiles: [...readFiles],
-    deletedFiles: [...deletedFiles],
-    referencedFiles: [...new Set([...(base.referencedFiles ?? []), ...(delta.referencedFiles ?? [])])].slice(0, 200),
-    mediaAttachments: [...(base.mediaAttachments ?? []), ...offsetMedia],
-    errors: mergedErrors,
-    decisions: [...base.decisions, ...offsetDecisions],
-    constraints: [...base.constraints, ...offsetConstraints],
-    topics: [...base.topics, ...offsetTopics],
-    timeline: [...base.timeline, ...offsetTimeline],
-    // The latest substantive user request is the active goal; a suffix with no
-    // real request (tool-only work or an acknowledgement) leaves the base intact.
+    modifiedFiles: modifiedFiles.values,
+    readFiles: readFiles.values,
+    deletedFiles: deletedFiles.values,
+    referencedFiles: referencedFiles.values,
+    mediaAttachments: mediaAttachments.values,
+    errors: errors.values,
+    decisions: decisions.values,
+    constraints: constraints.values,
+    topics: topics.values,
+    timeline: timeline.values,
     mainGoal: delta.mainGoal ?? base.mainGoal,
-    // "last N" must span the cache boundary: the suffix alone is incomplete
-    // when it carries fewer than N user messages / errors.
     lastUserMessages: [...base.lastUserMessages, ...delta.lastUserMessages].slice(-5),
-    lastErrors: mergedErrors.filter(error => !error.resolved).map(error => error.message).slice(-3),
+    lastErrors: errors.values.filter(error => !error.resolved).map(error => error.message).slice(-3),
     messageCount: baseMsgCount + delta.messageCount,
+    ...(Object.keys(evidenceOverflow).length ? { evidenceOverflow } : {}),
   };
 }
 
 // ── Metrics log ──
 /** Extended metrics entry including pipeline context for regression detection. */
-function appendMetricsEntry(entry: CompactMetricsEntry): void {
+async function appendMetricsEntry(entry: CompactMetricsEntry): Promise<void> {
   const logPath = metricsLogFile();
-  appendLineLocked(logPath, JSON.stringify(entry), RUNTIME_LOG_MAX_BYTES);
+  await appendLineLockedAsync(logPath, JSON.stringify(entry), RUNTIME_LOG_MAX_BYTES);
 }
 
 /** Append a fully materialized payload after an external lifecycle commits. */
-export function appendMetricsSnapshot(
+export async function appendMetricsSnapshot(
   sessionId: string,
   snapshot: Omit<CompactMetricsEntry, "ts" | "sessionId">,
-): void {
+): Promise<void> {
   try {
-    appendMetricsEntry({ ts: new Date().toISOString(), sessionId, ...snapshot });
-  } catch (e) { log.warn("appendMetricsSnapshot failed", e); }
+    await appendMetricsEntry({ ts: new Date().toISOString(), sessionId, ...snapshot });
+  } catch (error) {
+    log.warn("appendMetricsSnapshot failed", error);
+  }
 }
 
-export function appendMetricsLog(
+export async function appendMetricsLog(
   sessionId: string,
   extra: Partial<Omit<CompactMetricsEntry, "ts" | "sessionId" | "totalCalls" | "totalInput" | "totalOutput" | "totalCacheHit" | "totalCacheWrite" | "avgLatency" | "cacheHitRate">> | undefined,
   services: SmartCompactServices,
-): void {
+): Promise<void> {
   try {
-    appendMetricsEntry({
+    await appendMetricsEntry({
       ts: new Date().toISOString(),
       sessionId,
       ...getMetricsSummary(services),
       ...extra,
     });
-  } catch (e) { log.warn("appendMetricsLog failed", e); }
+  } catch (error) {
+    log.warn("appendMetricsLog failed", error);
+  }
 }
 
 /**
@@ -456,8 +532,8 @@ export function readMetricsLog(limit = 100): CompactMetricsEntry[] {
     const fd = fs.openSync(logPath, "r");
     try {
       const buf = Buffer.alloc(wantBytes);
-      fs.readSync(fd, buf, 0, wantBytes, startPos);
-      let text = buf.toString("utf8");
+      const bytesRead = fs.readSync(fd, buf, 0, wantBytes, startPos);
+      let text = buf.subarray(0, bytesRead).toString("utf8");
       // Drop the (potentially) partial first line when we didn't start at
       // byte 0; otherwise we'd half-parse it and emit a corrupt warning.
       if (startPos > 0) {

--- a/src/utils/extraction.ts
+++ b/src/utils/extraction.ts
@@ -8,7 +8,7 @@ import { NO_OP_RE, SHIFT_RE, CHOICE_RE, LIKELY_ERROR_RE, ERROR_RETRY_WINDOW, ERR
 import { estimateTokens } from "./tokens.ts";
 import { isToolCallBlock, isTextBlock } from "../utils/type-guards.ts";
 import { buildPathNeedles } from "./file-needles.ts";
-import { classifyToolOperation, extractToolPath, sameToolOperation, toolOperationSignature } from "../domain/tool-semantics.ts";
+import { classifyToolOperation, extractShellFileOperations, extractToolPath, sameToolOperation, toolOperationSignature } from "../domain/tool-semantics.ts";
 import { extractFileRefs } from "./file-ref-detect.ts";
 import { findSection, summaryEvidenceLine } from "../domain/summary-parse.ts";
 
@@ -108,7 +108,7 @@ export function extractMediaAttachments(msgs: LlmMessage[]): MediaAttachment[] {
   return out;
 }
 
-export function buildToolCallIndex(msgs: LlmMessage[]): ToolCallIndex {
+export function buildToolCallIndex(msgs: readonly LlmMessage[]): ToolCallIndex {
   const idx = new Map<string, { name: string; arguments: Record<string, unknown>; msgIndex: number }>();
   for (let i = 0; i < msgs.length; i++) {
     const m = msgs[i];
@@ -135,21 +135,46 @@ export function buildToolCallIndex(msgs: LlmMessage[]): ToolCallIndex {
   return idx;
 }
 
-export function trackFileOps(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): { modified: StructuredExtraction["modifiedFiles"]; read: string[]; deleted: string[] } {
+export function trackFileOps(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): {
+  modified: StructuredExtraction["modifiedFiles"];
+  read: string[];
+  deleted: string[];
+  referenced: string[];
+} {
   const tcIdx = _tcIdx ?? buildToolCallIndex(msgs);
   const modMap = new Map<string, { toolCalls: number; lastIdx: number }>();
-  const readSet = new Set<string>();
-  const delSet = new Set<string>();
+  const readAt = new Map<string, number>();
+  const deletedAt = new Map<string, number>();
+  const referencedAt = new Map<string, number>();
 
   for (let i = 0; i < msgs.length; i++) {
     const m = msgs[i];
+    for (const ref of extractFileRefs((JSON.stringify(m.content) ?? "").replace(/\\[nrt]/g, " "))) {
+      referencedAt.set(ref, i);
+    }
     if (m.role !== "toolResult" || m.isError) continue;
     const tc = tcIdx.get(m.toolCallId ?? "");
     if (!tc) continue;
+    const operation = classifyToolOperation(tc.arguments, tc.name);
+    if (operation === "execute") {
+      const resultText = extractText(m.content);
+      if (hasCommandFailureSignal(resultText)) continue;
+      const shell = extractShellFileOperations(tc.arguments);
+      for (const file of shell.modified) {
+        const existing = modMap.get(file);
+        modMap.set(file, { toolCalls: (existing?.toolCalls ?? 0) + 1, lastIdx: i });
+        deletedAt.delete(file);
+      }
+      for (const file of shell.deleted) {
+        deletedAt.set(file, i);
+        modMap.delete(file);
+        readAt.delete(file);
+      }
+      continue;
+    }
+
     const filePath = extractToolPath(tc.arguments);
     if (!filePath) continue;
-
-    const operation = classifyToolOperation(tc.arguments, tc.name);
     if (operation === "mutate") {
       // pi-toolkit truncation hides whether a write was a no-op, so a truncated
       // result is treated as modified (safe default); otherwise skip true no-ops.
@@ -157,23 +182,25 @@ export function trackFileOps(msgs: LlmMessage[], _tcIdx?: ToolCallIndex): { modi
       if (isTruncated(resultText) || !NO_OP_RE.test(resultText)) {
         const existing = modMap.get(filePath);
         modMap.set(filePath, { toolCalls: (existing?.toolCalls ?? 0) + 1, lastIdx: i });
-        delSet.delete(filePath);
+        deletedAt.delete(filePath);
       }
     } else if (operation === "delete") {
-      delSet.add(filePath);
+      deletedAt.set(filePath, i);
       modMap.delete(filePath);
-      readSet.delete(filePath);
+      readAt.delete(filePath);
     } else if (operation === "read" || operation === "search" || operation === "list") {
-      // A successful access proves the path is present now. Never infer a
-      // deletion from source/search prose merely containing "removed".
-      readSet.add(filePath);
-      delSet.delete(filePath);
+      // A successful access proves the path is present now. Record the latest
+      // access index so tail caps preserve recently re-read files.
+      readAt.set(filePath, i);
+      deletedAt.delete(filePath);
     }
   }
 
   return {
     modified: [...modMap.entries()].map(([p, d]) => ({ path: p, toolCalls: d.toolCalls, lastModifiedIndex: d.lastIdx })),
-    read: [...readSet], deleted: [...delSet],
+    read: [...readAt.entries()].sort((a, b) => a[1] - b[1]).map(([file]) => file),
+    deleted: [...deletedAt.entries()].sort((a, b) => a[1] - b[1]).map(([file]) => file),
+    referenced: [...referencedAt.entries()].sort((a, b) => a[1] - b[1]).map(([file]) => file),
   };
 }
 
@@ -485,6 +512,15 @@ export function extractMainGoal(msgs: LlmMessage[]): string | null {
   return null;
 }
 
+const FOLLOWUP_COMPLETION_RE = /\b(?:done|completed?|finished|implemented|fixed|resolved|updated|added|removed|shipped|tamamland[ıi]|tamamlad[ıi]m|bitti|[çc][öo]z[üu]ld[üu])\b/iu;
+const NEGATED_COMPLETION_RE = /\b(?:not|isn['’]?t|wasn['’]?t|hen[üu]z|de[ğg]il)\b.{0,20}\b(?:done|complete|finished|fixed|resolved|bitti)\b/iu;
+const FOLLOWUP_TOKEN_STOP: Readonly<Record<string, true>> = {
+  next: true, step: true, thing: true, todo: true, action: true, item: true,
+  follow: true, still: true, need: true, have: true, gotta: true,
+  eklenecek: true, duzeltilecek: true, düzeltilecek: true, gerekiyor: true,
+  yapalim: true, yapalım: true, kaldi: true, kaldı: true,
+};
+
 /** Extract open loops — unresolved tasks from the conversation */
 export function extractOpenLoops(msgs: LlmMessage[], extraction: StructuredExtraction): OpenLoop[] {
   const loops: OpenLoop[] = [];
@@ -590,6 +626,28 @@ export function extractOpenLoops(msgs: LlmMessage[], extraction: StructuredExtra
       });
     }
   }
+  // A follow-up is closed only by later, task-specific completion evidence in
+  // the same user turn. Generic "done" text cannot retire an unrelated loop.
+  for (const loop of loops) {
+    if (loop.type !== "follow-up" || loop.sourceIndex == null) continue;
+    const taskTokens = (loop.summary.toLowerCase().match(/[\p{L}\p{N}_-]{4,}/gu) ?? [])
+      .filter(token => !FOLLOWUP_TOKEN_STOP[token]);
+    if (!taskTokens.length) continue;
+    const end = Math.min(msgs.length, loop.sourceIndex + 50);
+    for (let index = loop.sourceIndex + 1; index < end; index++) {
+      const message = msgs[index];
+      if (message?.role === "user") break;
+      if (message?.role !== "assistant") continue;
+      const response = extractText(message.content);
+      const normalized = response.toLowerCase();
+      if (!FOLLOWUP_COMPLETION_RE.test(response) || NEGATED_COMPLETION_RE.test(response)) continue;
+      if (taskTokens.some(token => normalized.includes(token))) {
+        loop.status = "resolved";
+        break;
+      }
+    }
+  }
+
 
   return loops;
 }
@@ -623,29 +681,32 @@ export function extractStructured(msgs: LlmMessage[], pc: ProfileConfig, precomp
   const errors = recent(allErrors, EXTRACTION_LIMITS.ERRORS);
   const decisions = recent(allDecisions, EXTRACTION_LIMITS.DECISIONS);
   const constraints = recent(allConstraints, EXTRACTION_LIMITS.CONSTRAINTS);
+  const boundedTopics = recent(topics, EXTRACTION_LIMITS.TOPICS);
   const timeline = recent(allTimeline, EXTRACTION_LIMITS.TIMELINE);
   const mediaAttachments = recent(allMediaAttachments, EXTRACTION_LIMITS.MEDIA_ATTACHMENTS);
+  const allReferencedFiles = tracked.referenced;
+  const referencedFiles = recent(allReferencedFiles, EXTRACTION_LIMITS.REFERENCED_FILES);
   const overflow = {
     modifiedFiles: tracked.modified.length - modifiedFiles.length,
+    referencedFiles: allReferencedFiles.length - referencedFiles.length,
     readFiles: tracked.read.length - readFiles.length,
     deletedFiles: tracked.deleted.length - deletedFiles.length,
     errors: allErrors.length - errors.length,
     decisions: allDecisions.length - decisions.length,
     constraints: allConstraints.length - constraints.length,
+    topics: topics.length - boundedTopics.length,
     timeline: allTimeline.length - timeline.length,
     mediaAttachments: allMediaAttachments.length - mediaAttachments.length,
   };
   const evidenceOverflow = Object.fromEntries(
     Object.entries(overflow).filter(([, count]) => count > 0),
   );
-  const referencedFiles = Array.from(new Set(msgs
-    .flatMap(message => extractFileRefs((JSON.stringify(message.content) ?? "").replace(/\\[nrt]/g, " "))))).slice(0, 200);
   const mainGoal = extractMainGoal(msgs);
   const lastUserMessages = msgs.filter(m => m.role === "user").slice(-5).map(m => extractText(m.content));
   const lastErrors = errors.slice(-3).map(e => e.message);
   return {
     modifiedFiles, readFiles, deletedFiles, referencedFiles,
-    errors, decisions, constraints, topics, timeline, mediaAttachments,
+    errors, decisions, constraints, topics: boundedTopics, timeline, mediaAttachments,
     mainGoal, lastUserMessages, lastErrors, messageCount: msgs.length,
     ...(Object.keys(evidenceOverflow).length ? { evidenceOverflow } : {}),
   };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -9,6 +9,7 @@ import * as log from "./logger.ts";
 import { settingsFile, defaultBackupDir } from "../infra/paths.ts";
 import { flattenToolCallBlock } from "./extraction.ts";
 import { extractToolPath } from "../domain/tool-semantics.ts";
+import { isRecord } from "./type-guards.ts";
 
 const VALID_PROFILES = ["light", "balanced", "aggressive"] as const;
 const VALID_MODES = ["auto", "fast", "balanced", "thorough"] as const;
@@ -326,22 +327,14 @@ export function smartKeepBoundary(
  * Handles top-level toolCall blocks and nested multi_tool_use.parallel wrappers.
  */
 function collectToolCallIds(blocks: unknown[], msgIndex: number, out: Map<string, number>): void {
-  for (const b of blocks) {
-    const block = b as Record<string, unknown>;
-    if (block?.type === "toolCall") {
-      if (typeof block.id === "string") {
-        out.set(block.id, msgIndex);
-      }
-      // Flatten nested tool calls inside multi_tool_use.parallel
-      const args = block.arguments as Record<string, unknown> | undefined;
-      if (block.name === "multi_tool_use.parallel" && args && Array.isArray(args.tool_uses)) {
-        for (const nested of args.tool_uses as unknown[]) {
-          const n = nested as Record<string, unknown>;
-          if (typeof n.id === "string") {
-            out.set(n.id, msgIndex);
-          }
-        }
-      }
+  for (const block of blocks) {
+    if (!isRecord(block) || block.type !== "toolCall") continue;
+    if (typeof block.id === "string") out.set(block.id, msgIndex);
+    // Flatten nested tool calls inside multi_tool_use.parallel.
+    const args = block.arguments;
+    if (block.name !== "multi_tool_use.parallel" || !isRecord(args) || !Array.isArray(args.tool_uses)) continue;
+    for (const nested of args.tool_uses) {
+      if (isRecord(nested) && typeof nested.id === "string") out.set(nested.id, msgIndex);
     }
   }
 }
@@ -356,21 +349,25 @@ function collectToolCallIds(blocks: unknown[], msgIndex: number, out: Map<string
  * Also handles multi_tool_use.parallel wrappers where the actual tool call IDs are nested
  * inside arguments.tool_uses rather than on the wrapper block itself.
  */
-function toolCallIndexMap(msgs: SessionMessageEntry[]): Map<string, number> {
+export type ToolCallBoundaryIndex = ReadonlyMap<string, number>;
+
+export function buildToolCallBoundaryIndex(msgs: SessionMessageEntry[]): ToolCallBoundaryIndex {
   const map = new Map<string, number>();
   for (let i = 0; i < msgs.length; i++) {
-    const m = msgs[i].message as Record<string, unknown>;
-    if (m?.role !== "assistant") continue;
-    const blocks = Array.isArray(m?.content) ? m.content : [];
+    const message = msgs[i].message;
+    if (!isRecord(message) || message.role !== "assistant") continue;
+    const blocks = Array.isArray(message.content) ? message.content : [];
     collectToolCallIds(blocks, i, map);
   }
   return map;
 }
 
-export function guardToolCallBoundary(msgs: SessionMessageEntry[], keepFrom: number): number {
+export function guardToolCallBoundary(
+  msgs: SessionMessageEntry[],
+  keepFrom: number,
+  tcMap: ToolCallBoundaryIndex = buildToolCallBoundaryIndex(msgs),
+): number {
   if (keepFrom <= 0 || keepFrom >= msgs.length) return keepFrom;
-
-  const tcMap = toolCallIndexMap(msgs);
   let adjusted = keepFrom;
   let changed = true;
   // Bound the transitive walk. Each iteration MUST shrink `adjusted` (we
@@ -389,9 +386,9 @@ export function guardToolCallBoundary(msgs: SessionMessageEntry[], keepFrom: num
     }
     changed = false;
     for (let i = adjusted; i < msgs.length; i++) {
-      const m = msgs[i].message as Record<string, unknown>;
-      if (m?.role !== "toolResult") continue;
-      const tcId = m?.toolCallId as string | undefined;
+      const message = msgs[i].message;
+      if (!isRecord(message) || message.role !== "toolResult") continue;
+      const tcId = typeof message.toolCallId === "string" ? message.toolCallId : undefined;
       if (!tcId) continue;
       const tcIdx = tcMap.get(tcId);
       if (tcIdx !== undefined && tcIdx < adjusted) {
@@ -410,17 +407,19 @@ export function guardToolCallBoundary(msgs: SessionMessageEntry[], keepFrom: num
  * would exceed the retention target. Returns msgs.length when no later kept
  * message exists; callers can then retain the pair or reject the plan.
  */
-export function advancePastToolCallBoundary(msgs: SessionMessageEntry[], keepFrom: number): number {
+export function advancePastToolCallBoundary(
+  msgs: SessionMessageEntry[],
+  keepFrom: number,
+  tcMap: ToolCallBoundaryIndex = buildToolCallBoundaryIndex(msgs),
+): number {
   if (keepFrom <= 0 || keepFrom >= msgs.length) return keepFrom;
-
-  const tcMap = toolCallIndexMap(msgs);
   let adjusted = keepFrom;
   for (let iter = 0; iter <= msgs.length; iter++) {
     let next = adjusted;
     for (let i = adjusted; i < msgs.length; i++) {
-      const m = msgs[i].message as Record<string, unknown>;
-      if (m?.role !== "toolResult") continue;
-      const tcIdx = typeof m.toolCallId === "string" ? tcMap.get(m.toolCallId) : undefined;
+      const message = msgs[i].message;
+      if (!isRecord(message) || message.role !== "toolResult") continue;
+      const tcIdx = typeof message.toolCallId === "string" ? tcMap.get(message.toolCallId) : undefined;
       if ((i === adjusted && tcIdx === undefined) || (tcIdx !== undefined && tcIdx < adjusted)) {
         next = i + 1;
         break;

--- a/src/utils/session-log.ts
+++ b/src/utils/session-log.ts
@@ -135,6 +135,22 @@ export function __resetSessionLogCachesForTests(): void {
   messageMapCache.clear();
 }
 
+function sessionDirectoryForCwd(cwd: string): string {
+  const safeCwd = path.resolve(cwd).replace(/^[/\\]/, "").replace(/[:/\\]/g, "-");
+  return path.join(getSessionsDir(), "--" + safeCwd + "--");
+}
+
+function findLogInDirectory(directory: string, sessionId: string): string | null {
+  if (!fs.existsSync(directory)) return null;
+  if (/^[a-zA-Z0-9_-]+$/.test(sessionId)) {
+    const exact = path.join(directory, sessionId + ".jsonl");
+    if (fs.existsSync(exact)) return exact;
+  }
+  const match = fs.readdirSync(directory, { withFileTypes: true })
+    .find(entry => entry.isFile() && entry.name.endsWith("_" + sessionId + ".jsonl"));
+  return match ? path.join(directory, match.name) : null;
+}
+
 /**
  * Find the session .jsonl log file for a given session ID.
  *
@@ -142,37 +158,36 @@ export function __resetSessionLogCachesForTests(): void {
  * with filenames like 2026-05-19T12-34-56_abc123.jsonl.
  * We try the bare id first, then the glob suffix pattern.
  */
-function findSessionLogFile(sessionId: string): string | null {
+function findSessionLogFile(sessionId: string, cwd?: string): string | null {
   const home = process.env.HOME ?? "/tmp";
   const now = Date.now();
-  const remember = (path: string | null) => {
-    lruSet(logPathCache, sessionId, { path, expiresAt: now + LOG_PATH_CACHE_TTL_MS, home }, getMaxEntries());
-    return path;
+  const directDirectory = cwd ? sessionDirectoryForCwd(cwd) : null;
+  const cacheKey = sessionId + "\0" + (directDirectory ?? "*");
+  const remember = (foundPath: string | null) => {
+    lruSet(logPathCache, cacheKey, { path: foundPath, expiresAt: now + LOG_PATH_CACHE_TTL_MS, home }, getMaxEntries());
+    return foundPath;
   };
 
   try {
-    const cached = lruGet(logPathCache, sessionId);
+    const cached = lruGet(logPathCache, cacheKey);
     if (cached && cached.home === home && cached.expiresAt > now) return cached.path;
 
     const sessionsDir = getSessionsDir();
     if (!fs.existsSync(sessionsDir)) return remember(null);
-
-    for (const subdir of fs.readdirSync(sessionsDir)) {
-      const subdirPath = path.join(sessionsDir, subdir);
-      const stat = fs.statSync(subdirPath);
-      if (!stat.isDirectory()) continue;
-
-      // Try exact match first (future / alternative layout)
-      const exact = path.join(subdirPath, sessionId + ".jsonl");
-      if (fs.existsSync(exact)) return remember(exact);
-
-      // Try glob suffix: *_<sessionId>.jsonl
-      const files = fs.readdirSync(subdirPath);
-      const match = files.find(f => f.endsWith("_" + sessionId + ".jsonl"));
-      if (match) return remember(path.join(subdirPath, match));
+    if (directDirectory) {
+      const direct = findLogInDirectory(directDirectory, sessionId);
+      if (direct) return remember(direct);
     }
-  } catch (e) {
-    log.debug("findSessionLogFile failed", e);
+
+    for (const subdir of fs.readdirSync(sessionsDir, { withFileTypes: true })) {
+      if (!subdir.isDirectory()) continue;
+      const subdirPath = path.join(sessionsDir, subdir.name);
+      if (subdirPath === directDirectory) continue;
+      const found = findLogInDirectory(subdirPath, sessionId);
+      if (found) return remember(found);
+    }
+  } catch (error) {
+    log.debug("findSessionLogFile failed", error);
   }
   return remember(null);
 }
@@ -222,8 +237,9 @@ export function hasTruncatedMessages(msgs: LlmMessage[]): boolean {
 async function readOriginalMessageMap(
   sessionId: string,
   wantedIds: ReadonlySet<string>,
+  cwd?: string,
 ): Promise<Map<string, LlmMessage> | null> {
-  const logPath = findSessionLogFile(sessionId);
+  const logPath = findSessionLogFile(sessionId, cwd);
   if (!logPath) {
     log.debug("Session log not found for " + sessionId);
     return null;
@@ -289,9 +305,10 @@ export interface ResolvedCompactionMessage {
 export async function resolveCompactionMessages(
   sessionId: string,
   toCompactEntries: SessionMessageEntry[],
+  cwd?: string,
 ): Promise<ResolvedCompactionMessage[] | null> {
   const wantedIds = new Set(toCompactEntries.flatMap(entry => entry.id ? [entry.id] : []));
-  const logMap = await readOriginalMessageMap(sessionId, wantedIds);
+  const logMap = await readOriginalMessageMap(sessionId, wantedIds, cwd);
   if (!logMap) return null;
 
   let restoredCount = 0;

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -5,11 +5,12 @@
  */
 
 import fs from "node:fs";
+import path from "node:path";
 import type {
   StructuredExtraction, OpenLoop, CompactionState, ExplorationReport, SessionType,
   LoopOverride, ContinuityOverride, ContinuityScope,
 } from "../types.ts";
-import { VERSION, SEVEN_DAYS_MS, TRUNC, ID_PREFIX, MAX_STATE_OPEN_LOOPS } from "../constants.ts";
+import { VERSION, SEVEN_DAYS_MS, STATE_SNAPSHOT_MAX_FILES, TRUNC, ID_PREFIX, MAX_STATE_OPEN_LOOPS } from "../constants.ts";
 import { inferSessionType, normalizeFactKey } from "./helpers.ts";
 import { isCompactionStatusText, isDiagnosticConstraintText, isTransientToolDiagnostic } from "./extraction.ts";
 import * as log from "./logger.ts";
@@ -58,6 +59,26 @@ function freshState(fp: string, data: CompactionState | null): CompactionState |
   return sanitizeCompactionStateEvidence(data);
 }
 
+function pruneScopedStateSnapshots(target: string): void {
+  try {
+    const dir = path.dirname(target);
+    const snapshots = fs.readdirSync(dir, { withFileTypes: true })
+      .filter(entry => entry.isFile() && entry.name.endsWith(".json"))
+      .map(entry => {
+        const file = path.join(dir, entry.name);
+        return { file, mtimeMs: fs.statSync(file).mtimeMs };
+      })
+      .filter(entry => entry.file !== target)
+      .sort((a, b) => b.mtimeMs - a.mtimeMs || b.file.localeCompare(a.file));
+    for (const snapshot of snapshots.slice(Math.max(0, STATE_SNAPSHOT_MAX_FILES - 1))) {
+      try { fs.unlinkSync(snapshot.file); }
+      catch (error) { log.debug("state snapshot cleanup failed", error); }
+    }
+  } catch (error) {
+    log.debug("state snapshot retention failed", error);
+  }
+}
+
 /**
  * Persist compaction state for cross-compaction tracking.
  *
@@ -67,7 +88,9 @@ function freshState(fp: string, data: CompactionState | null): CompactionState |
  */
 export function saveCompactionState(projectId: string, state: CompactionState): boolean {
   try {
-    writeJsonSync(getStatePath(projectId, state), sanitizeCompactionStateEvidence(state), true);
+    const target = getStatePath(projectId, state);
+    writeJsonSync(target, sanitizeCompactionStateEvidence(state), true);
+    if (state.scope) pruneScopedStateSnapshots(target);
     return true;
   } catch (error) {
     log.warn("saveCompactionState failed", error);
@@ -87,6 +110,15 @@ export function loadScopedCompactionState(
   scope: Pick<ContinuityScope, "projectId" | "sessionId"> & Partial<Pick<ContinuityScope, "branchHeadId">>,
   branchEntryIds: readonly string[] = [],
 ): CompactionState | null {
+  const snapshotProbe = scopedCompactionStateFile(scope.projectId, scope.sessionId, "__snapshot__");
+  let availableSnapshots = new Set<string>();
+  try {
+    availableSnapshots = new Set(fs.readdirSync(path.dirname(snapshotProbe), { withFileTypes: true })
+      .filter(entry => entry.isFile() && entry.name.endsWith(".json"))
+      .map(entry => entry.name));
+  } catch {
+    // No branch snapshot directory yet; legacy migration below may still apply.
+  }
   const ancestry = Array.from(new Set([
     ...branchEntryIds,
     ...(scope.branchHeadId ? [scope.branchHeadId] : []),
@@ -105,6 +137,7 @@ export function loadScopedCompactionState(
 
   for (const branchHeadId of ancestry) {
     const fp = scopedCompactionStateFile(scope.projectId, scope.sessionId, branchHeadId);
+    if (!availableSnapshots.has(path.basename(fp))) continue;
     const state = freshState(fp, readJsonSync<CompactionState>(fp));
     if (valid(state, branchHeadId)) return state;
   }
@@ -205,6 +238,7 @@ export function buildCompactionState(
 
   return {
     goal: extraction.mainGoal,
+    goalKey: extraction.mainGoal ? normalizeFactKey(extraction.mainGoal) : undefined,
     decisions: extraction.decisions.map(d => ({
       id: ID_PREFIX.DECISION + (++decisionId),
       summary: d.summary.slice(0, TRUNC.DECISION_SUMMARY),
@@ -305,12 +339,19 @@ export function mergeCompactionStates(previous: CompactionState | null, current:
     15,
   ).map((item, index) => ({ ...item, id: ID_PREFIX.ERROR + (index + 1) }));
   const openLoops = mergeOpenLoops(activeCurrent.openLoops, activePrevious.openLoops);
-  const oldGoal = activePrevious.goal && activeCurrent.goal && normalizeFactKey(activePrevious.goal) !== normalizeFactKey(activeCurrent.goal)
+  const currentGoalKey = activeCurrent.goalKey
+    ?? (activeCurrent.goal ? normalizeFactKey(activeCurrent.goal) : "");
+  const previousGoalKey = activePrevious.goalKey
+    ?? (activePrevious.goal ? normalizeFactKey(activePrevious.goal) : "");
+  const oldGoal = previousGoalKey && currentGoalKey && previousGoalKey !== currentGoalKey
     ? ["Previous goal: " + activePrevious.goal]
     : [];
   return applyContinuityOverrides({
     ...activeCurrent,
     goal: activeCurrent.goal ?? activePrevious.goal,
+    goalKey: activeCurrent.goal
+      ? currentGoalKey || undefined
+      : (activePrevious.goalKey ?? previousGoalKey) || undefined,
     decisions,
     constraints,
     modifiedFiles: mergeBy(
@@ -463,8 +504,11 @@ export function computeDelta(prev: CompactionState, current: CompactionState): C
     .filter(e => !prevErrorMsgs.has(normalizeFactKey(e.message)))
     .map(e => e.message);
 
-  // Goal change
-  const goalChanged = prev.goal !== current.goal && prev.goal !== null && current.goal !== null;
+  const previousGoalKey = prev.goalKey ?? (prev.goal ? normalizeFactKey(prev.goal) : "");
+  const currentGoalKey = current.goalKey ?? (current.goal ? normalizeFactKey(current.goal) : "");
+  const goalChanged = Boolean(
+    previousGoalKey && currentGoalKey && previousGoalKey !== currentGoalKey,
+  );
 
   return {
     newDecisions, removedDecisions,

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -111,6 +111,13 @@ export function getProviderCaps(provider: string): ProviderCapabilities {
   return DEFAULT_CAPS;
 }
 
+/** Finite context usage percentage; invalid/unknown window metadata is 0%. */
+export function safeContextPercent(totalTokens: number | null | undefined, contextWindow: number | null | undefined): number {
+  if (!Number.isFinite(totalTokens) || !Number.isFinite(contextWindow)) return 0;
+  if ((totalTokens ?? 0) <= 0 || (contextWindow ?? 0) <= 0) return 0;
+  return (totalTokens as number) / (contextWindow as number) * 100;
+}
+
 /**
  * Bounded per-(provider,model) calibration factors smoothed by EMA.
  * Provider/model tokenization is process-wide knowledge rather than session

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -3,14 +3,19 @@
  * Extracted from types.ts to keep type definitions pure.
  */
 
+/** Narrow an unknown object before reading keyed fields. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 /** Type guard for text content blocks */
 export function isTextBlock(c: unknown): c is { type: "text"; text: string } {
-  return typeof c === "object" && c !== null && (c as { type?: string }).type === "text" && typeof (c as { text?: unknown }).text === "string";
+  return isRecord(c) && c.type === "text" && typeof c.text === "string";
 }
 
 /** Type guard for tool call content blocks */
 export function isToolCallBlock(c: unknown): c is { type: "toolCall"; id?: string; name: string; arguments: Record<string, unknown> } {
-  return typeof c === "object" && c !== null && (c as { type?: string }).type === "toolCall" && typeof (c as { name?: unknown }).name === "string";
+  return isRecord(c) && c.type === "toolCall" && typeof c.name === "string" && isRecord(c.arguments);
 }
 
 /** Get tool call names from unknown content */

--- a/test/infra-fs.test.ts
+++ b/test/infra-fs.test.ts
@@ -10,7 +10,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import {
-  atomicWriteFile, atomicWriteFileSync, appendLineLocked, readJsonSync, writeJsonSync,
+  atomicWriteFile, atomicWriteFileSync, appendLineLocked, appendLineLockedAsync, readJsonSync, writeJsonSync,
   ensureDir, acquireLockSync, trimFileTailLocked,
 } from "../src/infra/fs.ts";
 
@@ -103,6 +103,15 @@ describe("appendLineLocked", () => {
   it("fails closed instead of appending through a non-directory parent", () => {
     expect(() => appendLineLocked(path.join("/dev/null", "log.jsonl"), "unsafe")).toThrow();
   });
+  it("serializes concurrent asynchronous appends into complete JSONL records", async () => {
+    const target = path.join(tmp, "async-log.jsonl");
+    await Promise.all(Array.from({ length: 20 }, (_, index) =>
+      appendLineLockedAsync(target, JSON.stringify({ index }))));
+    const records = fs.readFileSync(target, "utf8").trim().split("\n").map(line => JSON.parse(line));
+    expect(records.map(record => record.index).sort((a, b) => a - b))
+      .toEqual(Array.from({ length: 20 }, (_, index) => index));
+  });
+
 });
 
   it("keeps post-trim records from concurrent processes", async () => {

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -24,10 +24,10 @@ describe("metrics reporting", () => {
     home = await loadWithHome();
   });
 
-  it("writes and summarizes profile/provider comparisons", () => {
+  it("writes and summarizes profile/provider comparisons", async () => {
     const svc = services.createServices();
-    cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", model: "openai/gpt", method: "single-pass", status: "success", durationMs: 1000, tokensSaved: 5000, verificationScore: 95 }, svc);
-    cache.appendMetricsLog("s2", { profile: "aggressive", provider: "anthropic", model: "anthropic/claude", method: "eesv", status: "timeout", durationMs: 2000, tokensSaved: 9000, verificationScore: 90 }, svc);
+    await cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", model: "openai/gpt", method: "single-pass", status: "success", durationMs: 1000, tokensSaved: 5000, verificationScore: 95 }, svc);
+    await cache.appendMetricsLog("s2", { profile: "aggressive", provider: "anthropic", model: "anthropic/claude", method: "eesv", status: "timeout", durationMs: 2000, tokensSaved: 9000, verificationScore: 90 }, svc);
     const report = metricsReport.buildMetricsReport(cache.readMetricsLog());
     expect(report).toContain("Profile comparison");
     expect(report).toContain("balanced: n=1");
@@ -74,9 +74,9 @@ describe("metrics reporting", () => {
     expect(snapshot.providerRoutes?.find(route => route.stage === "verify")?.qualityScore).toBeUndefined();
   });
 
-  it("persists schema-v2 failure taxonomy without error text", () => {
+  it("persists schema-v2 failure taxonomy without error text", async () => {
     const svc = services.createServices();
-    recordFailureMetrics({
+    await recordFailureMetrics({
       services: svc,
       cancellation: { timedOut: false },
       flags: { autoTriggered: true },
@@ -92,13 +92,13 @@ describe("metrics reporting", () => {
     expect(JSON.stringify(entry)).not.toContain("secret provider body");
   });
 
-  it("persists content-free verification diagnostics for pre-state failures", () => {
+  it("persists content-free verification diagnostics for pre-state failures", async () => {
     const svc = services.createServices();
     const error = Object.assign(new Error("Verification gate rejected summary: secret evidence"), {
       name: "VerificationGateError", score: 92, initialScore: 64, gapCount: 3,
       gapKinds: ["inconsistency", "fabricated-file", "unsupported-claim"],
     });
-    recordFailureMetrics({
+    await recordFailureMetrics({
       services: svc,
       cancellation: { timedOut: false },
       flags: { autoTriggered: false },
@@ -115,7 +115,7 @@ describe("metrics reporting", () => {
     expect(JSON.stringify(entry)).not.toContain("secret evidence");
   });
 
-  it("persists content-free yield-gate diagnostics without summary text", () => {
+  it("persists content-free yield-gate diagnostics without summary text", async () => {
     const svc = services.createServices();
     const error = Object.assign(new Error("Final summary estimate misses target"), {
       name: "YieldGateError", plannedAfterTokens: 500, plannedSavedTokens: 500, plannedYield: 0.5,
@@ -123,7 +123,7 @@ describe("metrics reporting", () => {
       retainedTailTokens: 400, summaryTokens: 300, summaryBudgetTokens: 100,
       targetAfterTokens: 600, relaxedSoftBoundaries: ["anchor"], hardBoundaryAdjusted: true,
     });
-    recordFailureMetrics({
+    await recordFailureMetrics({
       services: svc, cancellation: { timedOut: false }, flags: { autoTriggered: false },
       summaryModel: { provider: "openai", id: "gpt" }, profile: "balanced", mode: "balanced",
       modelLabel: "openai/gpt", pipelineStart: Date.now(),
@@ -136,8 +136,8 @@ describe("metrics reporting", () => {
     expect(JSON.stringify(entry)).not.toContain("Final summary estimate");
   });
 
-  it("writes a local html dashboard", () => {
-    cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", status: "success", durationMs: 1000 }, services.createServices());
+  it("writes a local html dashboard", async () => {
+    await cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", status: "success", durationMs: 1000 }, services.createServices());
     const fp = metricsReport.writeMetricsDashboard(cache.readMetricsLog());
     expect(fp).toBeTruthy();
     expect(fs.existsSync(fp!)).toBe(true);
@@ -148,10 +148,10 @@ describe("metrics reporting", () => {
     expect(html).toContain("Quality drilldown");
   });
 
-  it("renders >=85 Data Confidence, canary deltas, and stage provider evidence", () => {
+  it("renders >=85 Data Confidence, canary deltas, and stage provider evidence", async () => {
     const svc = services.createServices();
     for (let index = 0; index < 40; index++) {
-      cache.appendMetricsLog("trust-" + index, {
+      await cache.appendMetricsLog("trust-" + index, {
         runId: "run-dashboard-" + index,
         metricsSchemaVersion: 2, version: VERSION, releaseChannel: index < 20 ? "stable" : "canary",
         status: "success", provider: "openai", model: "openai/gpt", method: "eesv",
@@ -207,18 +207,41 @@ describe("metrics reporting", () => {
     expect(summary.cacheHitRate).toBeCloseTo(40_000 / 110_000);
   });
 
-  it("skips corrupt jsonl rows instead of dropping all metrics", () => {
+  it("skips corrupt jsonl rows instead of dropping all metrics", async () => {
     const svc = services.createServices();
-    cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", status: "success" }, svc);
+    await cache.appendMetricsLog("s1", { profile: "balanced", provider: "openai", status: "success" }, svc);
     const logPath = path.join(home, ".pi", "agent", ".cache", "compact-metrics.jsonl");
     fs.appendFileSync(logPath, "{not-json}\n");
-    cache.appendMetricsLog("s2", { profile: "aggressive", provider: "anthropic", status: "error" }, svc);
+    await cache.appendMetricsLog("s2", { profile: "aggressive", provider: "anthropic", status: "error" }, svc);
     const entries = cache.readMetricsLog();
     expect(entries.map(e => e.sessionId)).toEqual(["s1", "s2"]);
   });
 
-  it("escapes dashboard table values", () => {
-    cache.appendMetricsLog("s1", { profile: "<script>alert(1)</script>", provider: "openai", status: "success" }, services.createServices());
+  it("honors readSync bytesRead when the metrics file shrinks during a tail read", () => {
+    const logPath = path.join(home, ".pi", "agent", ".cache", "compact-metrics.jsonl");
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.writeFileSync(logPath, "x".repeat(128));
+    const payload = Buffer.from('{"ts":"now","sessionId":"short-read"}\n');
+    const originalReadSync = fs.readSync;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(fs, "readSync");
+    Object.defineProperty(fs, "readSync", {
+      configurable: true,
+      writable: true,
+      value: (_fd: number, buffer: Buffer) => {
+        payload.copy(buffer);
+        return payload.length;
+      },
+    });
+    try {
+      expect(cache.readMetricsLog().map(entry => entry.sessionId)).toEqual(["short-read"]);
+    } finally {
+      if (originalDescriptor) Object.defineProperty(fs, "readSync", originalDescriptor);
+      else Object.defineProperty(fs, "readSync", { configurable: true, writable: true, value: originalReadSync });
+    }
+  });
+
+  it("escapes dashboard table values", async () => {
+    await cache.appendMetricsLog("s1", { profile: "<script>alert(1)</script>", provider: "openai", status: "success" }, services.createServices());
     const fp = metricsReport.writeMetricsDashboard(cache.readMetricsLog());
     const html = fs.readFileSync(fp!, "utf8");
     expect(html).not.toContain("<script>alert(1)</script>");

--- a/test/pipeline-integration.test.ts
+++ b/test/pipeline-integration.test.ts
@@ -44,6 +44,8 @@ import { makeTokenEstimator } from "../src/utils/tokens.ts";
 import { resetConfigCache } from "../src/utils/helpers.ts";
 import { MAX_TOOL_OUTPUT_CHARS } from "../src/constants.ts";
 import { commitPreparedConversationBackup } from "../src/utils/backups.ts";
+import { saveCachedExtraction } from "../src/utils/cache.ts";
+import { extractionCacheFile } from "../src/infra/paths.ts";
 
 /**
  * Build a TieredRc with the minimum fields synthesizeConversation +
@@ -162,18 +164,56 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
     expect(ancestry.at(-1)).toBe("entry-1001");
   });
 
-  it("skips backup serialization and scrubbing when backups are disabled", () => {
+  it("reuses the exact pruned extraction instead of recomputing full history", () => {
+    const messages = [userMsg("Preserve exact cache evidence"), assistantMsg("Working on it")];
+    const sessionId = "exact-cache-" + Date.now() + "-" + Math.random().toString(36).slice(2);
+    try {
+      const firstRc = makeTieredRc(messages);
+      firstRc.sessionId = sessionId;
+      const first = extractWithCache(firstRc);
+      const cached = { ...first.extraction, mainGoal: "Exact cached extraction sentinel" };
+      saveCachedExtraction(
+        sessionId,
+        cached,
+        first.llmMessages.length,
+        first.currentEntryIds[0],
+        first.currentEntryIds.at(-1),
+        first.currentEntryIds,
+        first.currentKeptEntryIds,
+      );
+
+      const notices: string[] = [];
+      const secondRc = makeTieredRc(messages);
+      secondRc.sessionId = sessionId;
+      secondRc.notify = message => { notices.push(message); };
+      const second = extractWithCache(secondRc);
+
+      expect(second.extraction.mainGoal).toBe("Exact cached extraction sentinel");
+      expect(second.services.extractionCacheStats.snapshot().hits).toBe(1);
+      expect(notices).toContain("Phase 1 Cached: exact pruned conversation reused");
+    } finally {
+      try { fs.unlinkSync(extractionCacheFile(sessionId)); } catch {}
+    }
+  });
+
+  it("skips backup materialization while preserving mandatory extraction scrubbing", () => {
     const tiered = makeTieredRc([
       userMsg("Start"), assistantMsg("I'll be pruned"), userMsg("Continue"),
       assistantMsg("Substantive evidence"), userMsg("Finish"),
     ]);
+    const scrubber = tiered.services.scrubber;
+    let textScrubs = 0;
+    let valueScrubs = 0;
+    // Instrument the existing scrubber without changing its boundary behavior.
     tiered.services.scrubber = {
-      scrubText: () => { throw new Error("backup scrub should not run"); },
-      scrubValue: <T>(value: T) => ({ value, findings: [] }),
-      count: () => 0,
-    } as any;
+      scrubText: (text: string) => { textScrubs++; return scrubber.scrubText(text); },
+      scrubValue: <T>(value: T) => { valueScrubs++; return scrubber.scrubValue(value); },
+      count: () => scrubber.count(),
+    } as unknown as typeof tiered.services.scrubber;
 
     expect(extractWithCache(tiered).backupPath).toBeNull();
+    expect(textScrubs).toBe(1);
+    expect(valueScrubs).toBeGreaterThanOrEqual(2);
   });
 
   it("backs up the full selected span while synthesis keeps substantive assistant evidence", async () => {
@@ -197,7 +237,7 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
       userMsg("Continue"), assistantMsg("Substantive synthesis evidence"), userMsg("Finish"),
     ];
     let request = "";
-    setLlmClient({ complete: async (...args: any[]) => {
+    setLlmClient({ complete: async (...args: Parameters<LlmClient["complete"]>) => {
       request = JSON.stringify(args);
       return makeSummaryResponse("## Goal\nPreserve evidence\n## Progress\n### Done\n- done\n### In Progress\n- none\n### Blocked\n- none\n## Critical Context\n- context");
     } });
@@ -207,6 +247,7 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
       tiered.config.backupEnabled = true;
       const scrubber = tiered.services.scrubber;
       let backupScrubs = 0;
+      // Instrument only text scrubbing; the production scrubber still performs every redaction.
       tiered.services.scrubber = {
         scrubText: (text: string) => {
           backupScrubs++;
@@ -214,16 +255,16 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
         },
         scrubValue: <T>(value: T) => scrubber.scrubValue(value),
         count: () => scrubber.count(),
-      } as any;
+      } as unknown as typeof tiered.services.scrubber;
       const extracted = extractWithCache(tiered);
       expect(extracted.convText).toContain(removedEvidence);
       expect(extracted.convText).not.toContain(truncatedEvidence);
       expect(fs.existsSync(extracted.backupPath!)).toBe(false);
       expect(extracted.preparedBackup?.content).toBeUndefined();
       expect(extracted.preparedBackup?.materialize).toBeFunction();
-      expect(backupScrubs).toBe(0);
-      await commitPreparedConversationBackup(extracted.preparedBackup!);
       expect(backupScrubs).toBe(1);
+      await commitPreparedConversationBackup(extracted.preparedBackup!);
+      expect(backupScrubs).toBe(2);
       expect(fs.readFileSync(extracted.backupPath!, "utf8")).toContain(truncatedEvidence);
       await summarizeConversation(extracted);
       expect(request).toContain(removedEvidence);

--- a/test/resolve-models.test.ts
+++ b/test/resolve-models.test.ts
@@ -3,7 +3,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Model, Api } from "@earendil-works/pi-ai";
 import type { CompactConfig } from "../src/types.ts";
 import { DEFAULT_CONFIG } from "../src/constants.ts";
-import { resolveModels } from "../src/index.ts";
+import { findModelById, resolveModels } from "../src/index.ts";
 
 // Minimal mock: resolveModels only touches modelRegistry.find,
 // modelRegistry.getAvailable and ctx.model, so we cast a stub.
@@ -78,4 +78,10 @@ describe("resolveModels precedence", () => {
       sumModel: OPENAI, segModel: OPENAI, verifyModel: OPENAI,
     });
   });
+  it("preserves slashes inside nested provider model identifiers", () => {
+    const nested = mkModel("openrouter", "google/gemini-2.5-pro");
+    const ctx = mkCtx({ models: [nested], session: nested });
+    expect(findModelById(ctx, "openrouter/google/gemini-2.5-pro")).toBe(nested);
+  });
+
 });

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/utils/state.ts";
 import { scopedCompactionStateFile } from "../src/infra/paths.ts";
 import type { LlmMessage, StructuredExtraction, OpenLoop, ExplorationReport, CompactionState } from "../src/types.ts";
+import { STATE_SNAPSHOT_MAX_FILES } from "../src/constants.ts";
 
 function makeExtraction(partial: Partial<StructuredExtraction> = {}): StructuredExtraction {
   return {
@@ -60,6 +61,27 @@ describe("extractOpenLoops", () => {
     ];
     const loops = extractOpenLoops(msgs, extraction);
     expect(loops.some(l => l.type === "follow-up")).toBe(true);
+  });
+
+  it("closes only task-specific follow-ups with positive completion evidence", () => {
+    const extraction = makeExtraction({ errors: [] });
+    const resolved = extractOpenLoops([
+      { role: "user", content: "next step is to add regression tests" },
+      { role: "assistant", content: "Added the regression tests and they pass." },
+    ], extraction).find(loop => loop.type === "follow-up");
+    expect(resolved?.status).toBe("resolved");
+
+    const unrelated = extractOpenLoops([
+      { role: "user", content: "next step is to add regression tests" },
+      { role: "assistant", content: "Documentation is done." },
+    ], extraction).find(loop => loop.type === "follow-up");
+    expect(unrelated?.status).toBe("open");
+
+    const negated = extractOpenLoops([
+      { role: "user", content: "next step is to add regression tests" },
+      { role: "assistant", content: "The regression tests are not done." },
+    ], extraction).find(loop => loop.type === "follow-up");
+    expect(negated?.status).toBe("open");
   });
 
   it("uses actual iteration indexes for repeated message object references", () => {
@@ -517,6 +539,15 @@ describe("computeDelta", () => {
     expect(delta.previousGoal).toBe("Build API");
   });
 
+  it("uses normalized goal identity instead of formatting-sensitive text equality", () => {
+    const delta = computeDelta(
+      makeFullState({ goal: "Build API" }),
+      makeFullState({ goal: "  build   api  " }),
+    );
+    expect(delta.goalChanged).toBe(false);
+    expect(delta.previousGoal).toBeNull();
+  });
+
   it("returns empty delta for identical states", () => {
     const state = makeFullState({
       decisions: [{ id: "decision-1", summary: "Use JWT", type: "explicit" }],
@@ -654,6 +685,26 @@ describe("saveCompactionState / loadCompactionState", () => {
     expect(loadCompactionState(testId)).toBeNull();
     expect(fs.existsSync(file)).toBe(false);
   });
+
+  it("bounds immutable branch snapshots per session", () => {
+    const projectId = "retention-" + Date.now();
+    const sessionId = "session-retention";
+    const sample = scopedCompactionStateFile(projectId, sessionId, "head-0");
+    const projectDir = path.dirname(path.dirname(sample));
+    try {
+      for (let index = 0; index < STATE_SNAPSHOT_MAX_FILES + 3; index++) {
+        expect(saveCompactionState(projectId, makeFullState({
+          scope: { schemaVersion: 2, projectId, sessionId, branchHeadId: "head-" + index },
+        }))).toBe(true);
+      }
+      const snapshots = fs.readdirSync(path.dirname(sample)).filter(file => file.endsWith(".json"));
+      expect(snapshots).toHaveLength(STATE_SNAPSHOT_MAX_FILES);
+      expect(snapshots).toContain("head-" + (STATE_SNAPSHOT_MAX_FILES + 2) + ".json");
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
 
   it("returns null for non-existent state", () => {
     expect(loadCompactionState("nonexistent-" + Date.now())).toBeNull();

--- a/test/summary-parse.test.ts
+++ b/test/summary-parse.test.ts
@@ -50,6 +50,15 @@ describe("parseSummary", () => {
     const parsed = parseSummary("## Some Other Heading\nbody");
     expect(parsed.sections[0].kind).toBe("unknown");
   });
+  it("treats headings inside fenced code as section body text", () => {
+    const parsed = parseSummary(
+      "## Goal\nPreserve parser evidence\n```md\n## Progress\n- not a real section\n```\n## Progress\n- real progress\n",
+    );
+    expect(parsed.sections.map(section => section.kind)).toEqual(["goal", "progress"]);
+    expect(findSection(parsed, "goal")?.body).toContain("## Progress");
+    expect(findSection(parsed, "progress")?.body).toBe("- real progress");
+  });
+
 });
 
 describe("findSection / hasSection", () => {

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { estimateTokens, calibrateFromResponse, getProviderCaps, makeTokenEstimator, TokenCalibrationStore } from "../src/utils/tokens.ts";
+import { estimateTokens, calibrateFromResponse, getProviderCaps, makeTokenEstimator, safeContextPercent, TokenCalibrationStore } from "../src/utils/tokens.ts";
 
 describe("estimateTokens", () => {
   it("estimates based on char length", () => {
@@ -121,5 +121,15 @@ describe("getProviderCaps", () => {
       expect(["native", "metadata-only"]).toContain(caps.multimodal);
       expect(["anthropic", "openai", "none"]).toContain(caps.cacheStrategy);
     }
+  });
+});
+
+describe("safeContextPercent", () => {
+  it("returns a finite zero for missing or invalid context-window metadata", () => {
+    expect(safeContextPercent(50_000, undefined)).toBe(0);
+    expect(safeContextPercent(50_000, null)).toBe(0);
+    expect(safeContextPercent(50_000, 0)).toBe(0);
+    expect(safeContextPercent(Number.NaN, 100_000)).toBe(0);
+    expect(safeContextPercent(50_000, 100_000)).toBe(50);
   });
 });

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "bun:test";
-import { verifySummary, patchDeterministic, repairSummaryDeterministically, formatVerificationGap } from "../src/phases/verify.ts";
+import { verifySummary, patchDeterministic, repairSummaryDeterministically, formatVerificationGap, patchSummary } from "../src/phases/verify.ts";
 import { verifyAndPatch } from "../src/app/steps/verify.ts";
 import type { CompactionState, StructuredExtraction } from "../src/types.ts";
 import { createServices } from "../src/infra/services.ts";
 import { assembleFallback } from "../src/phases/synthesize.ts";
+import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai";
 
 function makeExtraction(partial: Partial<StructuredExtraction> = {}): StructuredExtraction {
   return {
@@ -570,6 +571,31 @@ describe("verifyAndPatch", () => {
       expect(result.verificationProvenance.deterministicPatched).toHaveLength(1);
       expect(result.verificationScore).toBe(100);
     }
+  });
+});
+
+describe("patchSummary", () => {
+  it("rejects an otherwise plausible verifier patch with an unclosed Markdown fence", async () => {
+    const original = "## Goal\nBuild auth\n## Progress\n- working\n## Critical Context\n- stable";
+    // Minimal in-process provider fixture; patchSummary reads only content, usage, and stopReason.
+    const response = {
+      role: "assistant",
+      content: [{ type: "text", text: "## Goal\nBuild auth\n## Progress\n- fixed\n```ts\nconst incomplete = true;" }],
+      usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+      stopReason: "endTurn",
+    } as unknown as AssistantMessage;
+    const services = createServices({ llm: { complete: async () => response } });
+    // Minimal model fixture; routing only needs provider/id/context metadata.
+    const model = { provider: "openai", id: "verifier", contextWindow: 128_000 } as unknown as Model<Api>;
+    const patched = await patchSummary(
+      original,
+      [{ kind: "missing-section", section: "files-modified" }],
+      model,
+      { apiKey: "test" },
+      undefined,
+      services,
+    );
+    expect(patched).toBe(original);
   });
 });
 


### PR DESCRIPTION
## Summary

- ship the audited security, lifecycle, extraction, verification, and performance hardening set
- bump the package and embedded runtime version to 9.1.0
- publish the verified artifact to npm under the `next` dist-tag

## Verification

- `bun install --frozen-lockfile`
- `bun run release:check` — 843 tests and 324 adversarial-gate tests passed
- Pi compatibility checks passed against 0.84.0 and latest (0.84.1)
- `bun audit` — no vulnerabilities
- registry install smoke registered `smart_compact`, `smart_recall`, and `smart_save_memory`
- published npm integrity: `sha512-yT0da4KJBRSOmc54pvdOSoIgjR5SAKcM+o/qfyw5f5g3ynSOqNyEDJL2u8Oa2j9AojuQUJ2dAi3UZ0vaC88XhQ==`