### PR TITLE
release: v9.2.0 safe proactive triggering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,12 +23,21 @@ section is about lifecycle.
 | --- | --- |
 | `/smart-compact` | Manual command. Explainable target-first preflight or direct args. Bypasses the adaptive pressure gate, not yield/verification gates. |
 | `session_before_compact` | Auto hook. Returns/stages a pending summary or runs under pressure; durable commit waits for matching `session_compact`. |
+| `agent_settled` | Opt-in pressure monitor. Requests `ctx.compact()` only; it never runs EESV or consumes/stages pending state. |
 | `smart_compact` tool | Agent-callable. Prepares a pending summary; never compacts mid-turn. |
 | `smart_recall` tool | Searches only the current project's bounded context graph; same session/branch ranks first. |
 | `smart_save_memory` tool | Persists one explicit user-confirmed project fact after secret/PII scrubbing. |
 
 A short-lived pending compaction is staged in the [`PendingSlot`](#pending-compaction-slot)
 and handed to Pi when compaction is applied.
+
+With `autoTriggerStrategy: "settled"`, the idle hook applies finite
+token/percentage, queue, in-flight, and per-session cooldown guards, then asks
+Pi for a normal host compaction. Pi re-enters `session_before_compact`, which
+reuses an already tool-staged summary or runs EESV exactly once under the
+host's signal and timeout. The matching `session_compact` event remains the
+only durable commit authority. This keeps proactive triggering out of the
+pending/commit state machine and preserves branch-provenance checks.
 
 ### Host dependency boundary
 
@@ -206,6 +215,11 @@ prose is never an input to the quality floor.
 Final verification runs again after continuity injection. The final scalar is
 reported as repaired **verification coverage**, alongside the pre-repair source
 score and fallback provenance; it is not labeled as raw synthesis quality.
+Verification failures retain only exhaustive content-free gap kinds and the
+rejecting gate (`post-synthesis` or `post-state`) in local telemetry. Summary
+evidence is never copied into failure metrics. Both gates remain mandatory:
+summary-derived continuity fields cannot become evidence for their own initial
+verification.
 Polarity checks are symmetric: adding negation to a positive fact is rejected
 just as removing negation from a prohibition is. Unresolved-error source
 snippets and fallback-rendered evidence share `summaryEvidenceLine()`, so
@@ -420,7 +434,7 @@ The code is organized into six layers, each with a single responsibility.
 
 | File | Responsibility |
 | --- | --- |
-| `src/index.ts` | extension registration, command parsing, auto-trigger hook |
+| `src/index.ts` | extension registration, command parsing, and host lifecycle hooks |
 | `src/constants.ts` | version, thresholds, prompts, config keys |
 | `src/types.ts` | shared types and discriminated unions |
 | `domain/provider-evaluation.ts` | advisory provider scenario matrix and route telemetry aggregation |
@@ -434,6 +448,7 @@ The code is organized into six layers, each with a single responsibility.
 | `app/run-context.ts` | typed stage chain (`RcBase → … → StatedRc`) |
 | `app/mode-policy.ts` | Auto selector and finite Fast/Balanced/Thorough policies; legacy Aggressive maps to Fast |
 | `app/pending-slot.ts` | encapsulated pending-compaction state cell |
+| `app/settled-auto-trigger.ts` | guarded proactive host compact requests; no EESV or pending-state ownership |
 | `app/steps/prepare.ts` | resolve config, provider caps, budgets, and cancellation; stage auth resolves lazily |
 | `app/steps/window.ts` | pick the prefix using provider-calibrated synthesis and deterministic post-processing bounds |
 | `app/steps/recover.ts` | recover full content for log-truncated messages |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [9.2.0] - 2026-08-11
+
+### Added
+
+- `autoTriggerStrategy: "settled"` can proactively request Pi's normal compact flow after an idle high-pressure agent run. The opt-in handler is session-scoped, queue-aware, deduplicated, and cooled down; it never runs EESV or mutates pending/commit state outside the correlated host lifecycle.
+
+### Fixed
+
+- Settled-triggered compaction reuses tool-staged summaries or runs the existing `session_before_compact` pipeline exactly once, preserving host cancellation, branch provenance, bounded auto budgets, native fallback, and apply-confirmed persistence.
+- Verification failures now record the rejecting `post-synthesis` or `post-state` gate and every typed content-free gap kind, including missing read/deleted files. Invalid and prototype-inherited values are rejected; summary evidence remains absent from telemetry.
+
 ## [9.1.0] - 2026-08-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ words such as `fast`, `balanced`, and paths such as `src/auth.ts` remain note
 content. Use `--note=...` or `--` when the boundary should be explicit. Invalid
 tool modes and budgets return an error instead of silently using defaults.
 
-At 60% context usage by default, the extension also participates in Pi's native
-compaction flow. Long-running agents can call `smart_compact`, `smart_recall`,
-and `smart_save_memory` directly.
+By default, at 60% context usage the extension participates when Pi starts its
+native compaction flow. Set `autoTriggerStrategy` to `settled` to additionally
+request that same host flow after an idle agent run crosses the pressure gate.
+Long-running agents can also call `smart_compact`, `smart_recall`, and
+`smart_save_memory` directly.
 
 > [!IMPORTANT]
 > The tool path only stages a verified pending summary for Pi's next natural
@@ -377,6 +379,7 @@ Add `smartCompact` to `~/.pi/agent/settings.json`:
     "summaryThinkingLevel": "minimal",
     "segmentationThinkingLevel": "minimal",
     "autoTrigger": true,
+    "autoTriggerStrategy": "native-hook",
     "minContextPercent": 60,
     "backupEnabled": true,
     "scrubSecrets": true,
@@ -396,6 +399,27 @@ Add `smartCompact` to `~/.pi/agent/settings.json`:
   }
 }
 ```
+
+`native-hook` preserves the existing passive behavior. The opt-in proactive
+strategy is:
+
+```json
+{
+  "smartCompact": {
+    "autoTrigger": true,
+    "autoTriggerStrategy": "settled",
+    "minContextPercent": 80
+  }
+}
+```
+
+`settled` requires a Pi host that emits `agent_settled`; the release boundary is
+verified against Pi 0.84.0 and 0.84.1.
+The settled handler never runs EESV or mutates pending state itself: after
+checking finite context pressure, idle/queue state, per-session in-flight
+deduplication, and cooldown, it asks Pi to compact. The existing
+`session_before_compact` and correlated `session_compact` handlers still own
+summary generation, cancellation, apply, and durable commit.
 
 ### Per-phase reasoning
 
@@ -447,8 +471,9 @@ the run fails closed before staging or apply.
 | `verificationModel` | `string \| null` | `null` | Optional explicit model for LLM verification repair |
 | `summaryThinkingLevel` | `minimal \| low \| medium \| high \| xhigh \| max \| null` | `minimal` | Reasoning level for synthesis and repair; provider default when null |
 | `segmentationThinkingLevel` | `minimal \| low \| medium \| high \| xhigh \| max \| null` | `minimal` | Reasoning level for exploration; provider default when null |
-| `autoTrigger` | `boolean` | `true` | Participate in Pi's native compact hook |
-| `autoTriggerTimeoutMs` | `number` | `120000` | Requested auto cancellation deadline; the synchronous hook clamps it to 60s and four LLM calls, shows live phase progress, then safely unwinds to native recovery |
+| `autoTrigger` | `boolean` | `true` | Allow smart compaction in Pi's native hook and the selected trigger strategy |
+| `autoTriggerStrategy` | `native-hook \| settled` | `native-hook` | `settled` additionally requests Pi's normal compact flow after an idle high-pressure agent run; verified with Pi 0.84.0+ |
+| `autoTriggerTimeoutMs` | `number` | `120000` | Requested auto cancellation deadline; the host hook clamps it to 60s and four LLM calls, shows live phase progress, then safely unwinds to native recovery |
 | `minContextPercent` | `number` | `60` | Auto/tool context gate; manual `/smart-compact` warns and bypasses it |
 | `backupEnabled` | `boolean` | `true` | Prepare a scrubbed pre-compaction backup; write it only after confirmed apply |
 | `backupDir` | `string` | `~/.pi/agent/compact-backups` | Empty config value uses this path |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "engines": {

--- a/src/app/settled-auto-trigger.ts
+++ b/src/app/settled-auto-trigger.ts
@@ -1,0 +1,91 @@
+/** Proactive auto-compaction request that delegates all EESV work to Pi's host lifecycle. */
+
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { CompactConfig } from "../types.ts";
+import { MIN_TOKEN_THRESHOLD, SETTLED_TRIGGER_COOLDOWN_MS } from "../constants.ts";
+import { isUnresolvedSessionId, resolveSessionId } from "../infra/session-identity.ts";
+import { safeContextPercent } from "../utils/tokens.ts";
+import * as log from "../utils/logger.ts";
+
+export interface SettledAutoTrigger {
+  request(ctx: ExtensionContext, config: CompactConfig): Promise<void>;
+  noteCompaction(sessionId: string): void;
+  clear(sessionId: string): void;
+}
+
+export interface SettledAutoTriggerOptions {
+  now?: () => number;
+  cooldownMs?: number;
+}
+
+/**
+ * Keep proactive triggering deliberately thin: it requests a normal host
+ * compaction and never runs EESV, consumes a pending summary, or stages a
+ * commit itself. The existing session_before_compact/session_compact pair
+ * therefore remains the only correlated apply path.
+ */
+export function createSettledAutoTrigger(
+  options: SettledAutoTriggerOptions = {},
+): SettledAutoTrigger {
+  const now = options.now ?? Date.now;
+  const cooldownMs = Math.max(0, options.cooldownMs ?? SETTLED_TRIGGER_COOLDOWN_MS);
+  const active = new Map<string, symbol>();
+  const lastCompactionAt = new Map<string, number>();
+
+  const noteCompaction = (sessionId: string): void => {
+    if (!isUnresolvedSessionId(sessionId)) lastCompactionAt.set(sessionId, now());
+  };
+
+  const clear = (sessionId: string): void => {
+    active.delete(sessionId);
+    lastCompactionAt.delete(sessionId);
+  };
+
+  const request = async (ctx: ExtensionContext, config: CompactConfig): Promise<void> => {
+    if (!config.autoTrigger || config.autoTriggerStrategy !== "settled") return;
+
+    const sessionId = resolveSessionId(ctx);
+    if (isUnresolvedSessionId(sessionId) || active.has(sessionId)) return;
+
+    const usage = ctx.getContextUsage();
+    const totalTokens = usage?.tokens;
+    if (typeof totalTokens !== "number" || !Number.isFinite(totalTokens)
+      || totalTokens < MIN_TOKEN_THRESHOLD || !ctx.model) return;
+
+    const contextPercent = safeContextPercent(totalTokens, ctx.model.contextWindow);
+    if (contextPercent < config.minContextPercent) return;
+
+    const lastCompaction = lastCompactionAt.get(sessionId);
+    if (lastCompaction !== undefined && now() - lastCompaction < cooldownMs) return;
+    if (!ctx.isIdle() || ctx.hasPendingMessages()) return;
+
+    const requestToken = Symbol(sessionId);
+    active.set(sessionId, requestToken);
+    await new Promise<void>(resolve => {
+      let finished = false;
+      const finish = (): void => {
+        if (finished) return;
+        finished = true;
+        if (active.get(sessionId) === requestToken) active.delete(sessionId);
+        resolve();
+      };
+      try {
+        ctx.compact({
+          onComplete: () => {
+            if (active.get(sessionId) === requestToken) noteCompaction(sessionId);
+            finish();
+          },
+          onError: error => {
+            log.debugError("Settled smart compact request failed", error);
+            finish();
+          },
+        });
+      } catch (error) {
+        log.debugError("Settled smart compact request failed", error);
+        finish();
+      }
+    });
+  };
+
+  return { request, noteCompaction, clear };
+}

--- a/src/app/steps/metrics.ts
+++ b/src/app/steps/metrics.ts
@@ -16,7 +16,7 @@
  */
 
 import type { RcBase, StatedRc } from "../run-context.ts";
-import type { CompactionMode, MetricsSnapshot, VerificationGap } from "../../types.ts";
+import type { CompactionMode, MetricsSnapshot, VerificationGap, VerificationGateStage } from "../../types.ts";
 import { aggregateProviderRoutes } from "../../domain/provider-evaluation.ts";
 import { classifyTelemetryFailure } from "../../domain/telemetry.ts";
 import { VERSION } from "../../constants.ts";
@@ -25,6 +25,21 @@ import {
   appendMetricsLog, appendMetricsSnapshot, getMetricsSummary, getExtractionCacheStats,
   effectivePromptInputTokens,
 } from "../../utils/cache.ts";
+
+const KNOWN_VERIFICATION_GAP_KINDS = {
+  "missing-section": true,
+  "missing-file": true,
+  "missing-read-file": true,
+  "missing-deleted-file": true,
+  "missing-error": true,
+  "missing-constraint": true,
+  "missing-decision": true,
+  "missing-goal": true,
+  "fabricated-file": true,
+  "inconsistency": true,
+  "missing-open-loops": true,
+  "unsupported-claim": true,
+} as const satisfies Record<VerificationGap["kind"], true>;
 
 function runType(rc: RcBase): "manual" | "auto" | "tool" {
   return rc.flags.skipCompact ? "tool" : rc.flags.autoTriggered ? "auto" : "manual";
@@ -147,7 +162,7 @@ export async function recordFailureMetrics(
   const failureKind = classifyTelemetryFailure(err, rc.cancellation.timedOut);
   const gate = err && typeof err === "object"
     ? err as {
-      score?: unknown; initialScore?: unknown; gapCount?: unknown; gapKinds?: unknown;
+      score?: unknown; initialScore?: unknown; gapCount?: unknown; gapKinds?: unknown; stage?: unknown;
       plannedAfterTokens?: unknown; plannedSavedTokens?: unknown; plannedYield?: unknown;
       estimatedAfterTokens?: unknown; estimatedSavedTokens?: unknown; estimatedYield?: unknown;
       retainedTailTokens?: unknown; summaryTokens?: unknown; summaryBudgetTokens?: unknown;
@@ -159,13 +174,12 @@ export async function recordFailureMetrics(
   const relaxedSoftBoundaries = Array.isArray(gate?.relaxedSoftBoundaries)
     ? gate.relaxedSoftBoundaries.filter((kind): kind is "recent-user-turn" | "anchor" | "topical" => typeof kind === "string" && softKinds.has(kind))
     : undefined;
-  const knownGapKinds = new Set<VerificationGap["kind"]>([
-    "missing-section", "missing-file", "missing-error", "missing-constraint", "missing-decision",
-    "missing-goal", "fabricated-file", "inconsistency", "missing-open-loops", "unsupported-claim",
-  ]);
   const gapKinds = Array.isArray(gate?.gapKinds)
-    ? gate.gapKinds.filter((kind): kind is VerificationGap["kind"] => typeof kind === "string" && knownGapKinds.has(kind as VerificationGap["kind"]))
+    ? gate.gapKinds.filter((kind): kind is VerificationGap["kind"] =>
+      typeof kind === "string" && Object.hasOwn(KNOWN_VERIFICATION_GAP_KINDS, kind))
     : undefined;
+  const verificationStage: VerificationGateStage | undefined =
+    gate?.stage === "post-synthesis" || gate?.stage === "post-state" ? gate.stage : undefined;
   const verificationScore = typeof gate?.score === "number" && Number.isFinite(gate.score) ? gate.score : undefined;
   const initialVerificationScore = typeof gate?.initialScore === "number" && Number.isFinite(gate.initialScore) ? gate.initialScore : undefined;
   const verificationGaps = typeof gate?.gapCount === "number" && Number.isInteger(gate.gapCount) && gate.gapCount >= 0 ? gate.gapCount : undefined;
@@ -205,6 +219,7 @@ export async function recordFailureMetrics(
     verificationGaps,
     remainingVerificationGaps: verificationGaps,
     verificationGapKinds: gapKinds,
+    verificationStage,
     phaseTimings: rc.phaseTimings,
     durationMs: Date.now() - rc.pipelineStart,
   }, rc.services);

--- a/src/app/steps/state.ts
+++ b/src/app/steps/state.ts
@@ -140,7 +140,7 @@ export function buildState(rc: VerifiedRc): StatedRc {
     remainingGaps: postVerification.gaps,
   };
   const failure = verificationFailureMessage(postVerification);
-  if (failure) throw new VerificationGateError(postVerification, postInitialScore);
+  if (failure) throw new VerificationGateError(postVerification, postInitialScore, "post-state");
 
   const detModified = extraction.modifiedFiles.map(f => f.path);
   const detRead = extraction.readFiles;

--- a/src/app/steps/verify.ts
+++ b/src/app/steps/verify.ts
@@ -99,7 +99,7 @@ export async function verifyAndPatch(rc: SynthesizedRc): Promise<VerifiedRc> {
   }
 
   const failure = verificationFailureMessage(verification);
-  if (failure) throw new VerificationGateError(verification, initialScore);
+  if (failure) throw new VerificationGateError(verification, initialScore, "post-synthesis");
   showProgressOverlay(rc.ctx, {
     phase: 4, phaseName: "Verify", detail: "Passed " + verification.score + "/100 · 0 unresolved gaps",
     explorationRounds: rc.explorationRounds,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "9.1.0";
+export const VERSION = "9.2.0";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.10;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;
@@ -22,6 +22,8 @@ export const MAX_STATE_OPEN_LOOPS = 25;
 export const AUTO_TRIGGER_TIMEOUT_CAP_MS = 60_000;
 /** Provider-call ceiling for the synchronous session_before_compact hook. */
 export const AUTO_TRIGGER_MAX_LLM_CALLS = 4;
+/** Suppress proactive settled-trigger churn after any confirmed compaction. */
+export const SETTLED_TRIGGER_COOLDOWN_MS = 10 * 60_000;
 
 /** Positive per-run bounds shared by CLI and tool arguments; config separately allows 0 as a mode-derived sentinel. */
 export const BUDGET_LIMITS = {
@@ -74,6 +76,7 @@ export const DEFAULT_CONFIG = {
   summaryThinkingLevel: "minimal" as const,
   segmentationThinkingLevel: "minimal" as const,
   autoTrigger: true,
+  autoTriggerStrategy: "native-hook" as const,
   autoTriggerTimeoutMs: 120000,
   backupEnabled: true,
   backupDir: "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import * as log from "./utils/logger.ts";
 import { deriveProjectIdFromCwd } from "./utils/fingerprint.ts";
 import { applyLoopOverrides, loadScopedCompactionState, renderContinuityCapsule, saveCompactionState } from "./utils/state.ts";
 import { createNativeContinuityBridge } from "./app/native-continuity-bridge.ts";
+import { createSettledAutoTrigger } from "./app/settled-auto-trigger.ts";
 import {
   closeContextMemory, formatRecallResults, recallContext, saveContextMemory,
   scheduleCompactionStateIndex, type ContextGraphScope, type ContextMemoryKind,
@@ -139,6 +140,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
   const pendingRef: PendingSlot = createPendingSlot({ ttlMs: PENDING_TTL_MS });
   const isRunning = createSessionRunLock();
   const damageMonitor = new OnlineDamageMonitor();
+  const settledAutoTrigger = createSettledAutoTrigger();
   // Filesystem-backed, one-shot handoff survives extension reloads/process
   // restarts while project/session/branch scope prevents sibling leakage.
   const nativeContinuity = createNativeContinuityBridge();
@@ -474,6 +476,14 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
     },
   });
 
+  pi.on("agent_settled", async (_event, ctx) => {
+    try {
+      await settledAutoTrigger.request(ctx, loadConfig());
+    } catch (error) {
+      log.debugError("Settled smart compact trigger stopped", error);
+    }
+  });
+
   pi.on("session_before_compact", async (event, ctx) => {
     const consumed = unwrapConsumed(pendingRef.consume(ctx), ctx);
     if (consumed && stageForNativeApply(consumed, event.signal)) {
@@ -558,6 +568,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
 
   pi.on("session_compact", async (event, ctx) => {
     const sessionId = resolveSessionId(ctx);
+    settledAutoTrigger.noteCompaction(sessionId);
     if (event.fromExtension) {
       const details = event.compactionEntry.details as { runId?: unknown } | undefined;
       const runId = typeof details?.runId === "string" ? details.runId : null;
@@ -638,6 +649,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
     damageMonitor.clear(sessionId);
     pendingRef.clear(sessionId);
     commitCandidates.clearSession(sessionId, "shutdown");
+    settledAutoTrigger.clear(sessionId);
     // Native continuity is deliberately not cleared here: shutdown/reload is
     // the process gap the branch-scoped filesystem handoff must survive.
   });

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Model, Api, ProviderHeaders, TextContent } from "@earendil-works/pi-ai";
-import type { CompactionState, StructuredExtraction, VerificationGap, VerificationResult, LlmMessage } from "../types.ts";
+import type { CompactionState, StructuredExtraction, VerificationGap, VerificationGateStage, VerificationResult, LlmMessage } from "../types.ts";
 import { COMPACT_SYSTEM_PREFIX, LIKELY_ERROR_RE, TRUNC } from "../constants.ts";
 import { trackedComplete } from "../utils/cache.ts";
 import { getProviderCaps } from "../utils/tokens.ts";
@@ -167,13 +167,15 @@ export class VerificationGateError extends Error {
   readonly score: number;
   readonly initialScore: number;
   readonly gapKinds: VerificationGap["kind"][];
+  readonly stage: VerificationGateStage;
   readonly gapCount: number;
 
-  constructor(result: VerificationResult, initialScore: number) {
+  constructor(result: VerificationResult, initialScore: number, stage: VerificationGateStage) {
     super(verificationFailureMessage(result) ?? "Verification gate rejected summary");
     this.name = "VerificationGateError";
     this.score = result.score;
     this.initialScore = initialScore;
+    this.stage = stage;
     this.gapKinds = Array.from(new Set(result.gaps.map(gap => gap.kind)));
     this.gapCount = result.gaps.length;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type CompressionProfile = "light" | "balanced" | "aggressive";
 export type EffectiveCompactionMode = "fast" | "balanced" | "thorough";
 /** `aggressive` is accepted only as a legacy input and resolves to Fast. */
 export type CompactionMode = "auto" | EffectiveCompactionMode | "aggressive";
+export type AutoTriggerStrategy = "native-hook" | "settled";
 
 export interface ProfileConfig {
   summaryBudgetTokens: number;
@@ -33,6 +34,8 @@ export interface CompactConfig {
   summaryThinkingLevel: ThinkingLevel | null;
   segmentationThinkingLevel: ThinkingLevel | null;
   autoTrigger: boolean;
+  /** Native hook participation, or an opt-in proactive request after an idle agent run. */
+  autoTriggerStrategy: AutoTriggerStrategy;
   autoTriggerTimeoutMs: number;
   backupEnabled: boolean;
   backupDir: string;
@@ -112,6 +115,8 @@ export type TelemetryFailureKind =
   | "cancelled" | "timeout" | "rate-limit" | "authentication"
   | "budget" | "output-limit" | "provider" | "persistence"
   | "validation" | "verification" | "yield" | "internal";
+export type VerificationGateStage = "post-synthesis" | "post-state";
+
 
 export interface CompactMetricsEntry {
   ts: string;
@@ -170,6 +175,8 @@ export interface CompactMetricsEntry {
   remainingVerificationGaps?: number;
   /** Content-free kinds retained when verification fails before state commit. */
   verificationGapKinds?: VerificationGap["kind"][];
+  /** Which fail-closed gate rejected the candidate; no summary content is retained. */
+  verificationStage?: VerificationGateStage;
   phaseTimings?: PipelinePhaseTiming[];
   durationMs?: number;
   redactions?: number;

--- a/src/ui/dashboard-format.ts
+++ b/src/ui/dashboard-format.ts
@@ -69,6 +69,7 @@ export function formatRunDetails(entry: CompactMetricsEntry | undefined, title: 
     lines.push("Repair: deterministic " + (entry.deterministicPatchCount ?? 0) + " | LLM " + (entry.llmPatched ? "yes" : "no") + " | quality floor " + (entry.qualityFloorUsed ? "yes" : "no"));
   }
   if (entry.failureKind) lines.push("Failure kind: " + entry.failureKind);
+  if (entry.verificationStage) lines.push("Verification gate: " + entry.verificationStage);
   if (entry.extractionCacheMissReason) lines.push("Extraction miss reason: " + entry.extractionCacheMissReason);
   if (entry.fallbackReason) lines.push("Reason: " + entry.fallbackReason);
   if (entry.phaseTimings?.length) {

--- a/src/ui/error-format.ts
+++ b/src/ui/error-format.ts
@@ -13,7 +13,7 @@ function compactText(error: unknown): string {
 export function formatCompactErrorForUi(error: unknown): string {
   if (error instanceof VerificationGateError) {
     const kinds = error.gapKinds.slice(0, 4).join(", ") || "unknown";
-    return "Verification stopped apply: " + error.score + "/100, " + error.gapCount +
+    return "Verification stopped apply at the " + error.stage + " gate: " + error.score + "/100, " + error.gapCount +
       (error.gapCount === 1 ? " unresolved gap [" : " unresolved gaps [") + kinds + "]. " + DEBUG_HINT;
   }
   if (error instanceof YieldGateError) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -13,6 +13,7 @@ import { isRecord } from "./type-guards.ts";
 
 const VALID_PROFILES = ["light", "balanced", "aggressive"] as const;
 const VALID_MODES = ["auto", "fast", "balanced", "thorough"] as const;
+const VALID_AUTO_TRIGGER_STRATEGIES = ["native-hook", "settled"] as const;
 const VALID_THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const PROFILE_NUMERIC_KEYS = ["summaryBudgetTokens", "keepRecentTokens", "minChunkTokens", "maxChunkTokens", "singlePassMaxTokens", "batchMaxTokens"] as const;
 const PROFILE_NUMERIC_BOUNDS: Record<(typeof PROFILE_NUMERIC_KEYS)[number], readonly [number, number]> = {
@@ -51,6 +52,14 @@ export function validateSmartCompactConfig(sc: Record<string, unknown>): void {
   if ("autoTrigger" in sc && typeof sc.autoTrigger !== "boolean") {
     log.warn("smart-compact config: autoTrigger must be boolean, got " + typeof sc.autoTrigger);
     delete sc.autoTrigger;
+  }
+  if ("autoTriggerStrategy" in sc
+    && !(VALID_AUTO_TRIGGER_STRATEGIES as readonly unknown[]).includes(sc.autoTriggerStrategy)) {
+    log.warn(
+      "smart-compact config: autoTriggerStrategy must be native-hook|settled, got "
+        + String(sc.autoTriggerStrategy) + ". Using default '" + DEFAULT_CONFIG.autoTriggerStrategy + "'.",
+    );
+    delete sc.autoTriggerStrategy;
   }
   if ("backupEnabled" in sc && typeof sc.backupEnabled !== "boolean") {
     log.warn("smart-compact config: backupEnabled must be boolean, got " + typeof sc.backupEnabled);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -68,6 +68,18 @@ describe("validateSmartCompactConfig", () => {
     expect("autoTrigger" in sc).toBe(false);
   });
 
+  it("validates the opt-in settled auto-trigger strategy", () => {
+    expect(DEFAULT_CONFIG.autoTriggerStrategy).toBe("native-hook");
+    for (const strategy of ["native-hook", "settled"]) {
+      const valid: Record<string, unknown> = { autoTriggerStrategy: strategy };
+      validateSmartCompactConfig(valid);
+      expect(valid.autoTriggerStrategy).toBe(strategy);
+    }
+    const invalid: Record<string, unknown> = { autoTriggerStrategy: "background" };
+    validateSmartCompactConfig(invalid);
+    expect(invalid.autoTriggerStrategy).toBeUndefined();
+  });
+
   it("deletes invalid autoTriggerTimeoutMs (string)", () => {
     const sc = { autoTriggerTimeoutMs: "45000" };
     validateSmartCompactConfig(sc);

--- a/test/dashboard-format.test.ts
+++ b/test/dashboard-format.test.ts
@@ -55,11 +55,13 @@ describe("dashboard format helpers", () => {
     const lines = formatRunDetails(entry({
       version: "8.0.0", releaseChannel: "canary", initialVerificationScore: 80,
       deterministicPatchCount: 2, qualityFloorUsed: true, remainingVerificationGaps: 0,
+      verificationStage: "post-state",
       providerRoutes: [{ stage: "verify", provider: "anthropic", model: "v", calls: 1, successes: 1, avgLatencyMs: 10, inputTokens: 10, outputTokens: 2 }],
     }), "Latest run details").join("\n");
     expect(lines).toContain("Version/channel: 8.0.0 / canary");
     expect(lines).toContain("Routes: verify=anthropic/v");
     expect(lines).toContain("quality floor yes");
+    expect(lines).toContain("Verification gate: post-state");
   });
 
   it("uses compact latest-run menu descriptions", () => {

--- a/test/error-format.test.ts
+++ b/test/error-format.test.ts
@@ -12,11 +12,12 @@ describe("bounded Smart Compact error UX", () => {
         { kind: "missing-error", message: "SECRET_EVIDENCE\n" + "x".repeat(2_000) },
         { kind: "missing-file", path: "private/path.ts" },
       ],
-    }, 18);
+    }, 18, "post-synthesis");
 
     const text = formatCompactErrorForUi(error);
 
     expect(text).toContain("42/100, 2 unresolved gaps");
+    expect(text).toContain("post-synthesis gate");
     expect(text).toContain("missing-error, missing-file");
     expect(text).not.toContain("SECRET_EVIDENCE");
     expect(text).not.toContain("private/path.ts");

--- a/test/lifecycle-e2e.test.ts
+++ b/test/lifecycle-e2e.test.ts
@@ -176,4 +176,151 @@ describe("extension lifecycle end to end", () => {
     const shutdown = handlers.get("session_shutdown")![0];
     await shutdown({}, ctx);
   });
+
+  it("requests proactive compaction through the existing correlated host lifecycle", async () => {
+    const settingsFile = path.join(home, ".pi", "agent", "settings.json");
+    const settings = JSON.parse(fs.readFileSync(settingsFile, "utf8"));
+    settings.smartCompact.autoTriggerStrategy = "settled";
+    fs.writeFileSync(settingsFile, JSON.stringify(settings));
+    resetConfigCache();
+
+    const handlers = new Map<string, Array<(event: any, ctx: any) => unknown>>();
+    const tools = new Map<string, any>();
+    const extensionApi = new Proxy({
+      on: (name: string, handler: (event: any, ctx: any) => unknown) => {
+        const list = handlers.get(name) ?? [];
+        list.push(handler);
+        handlers.set(name, list);
+      },
+      registerCommand: () => {},
+      registerTool: (tool: any) => { tools.set(tool.name, tool); },
+    }, {
+      get(target, key) {
+        return key in target ? target[key as keyof typeof target] : () => {};
+      },
+    });
+    smartCompactExtension(extensionApi as any);
+
+    const branch = activeBranch();
+    const estimator = makeTokenEstimator("openai", "lifecycle-settled", new TokenCalibrationStore());
+    const totalTokens = branch.reduce((sum, entry) => sum + estimator.message(entry.message as any), 0);
+    const model = { provider: "openai", id: "lifecycle-settled", contextWindow: 300_000, maxTokens: 16_384 };
+    const appliedRunIds: string[] = [];
+    const notifications: string[] = [];
+    let compactRequests = 0;
+    let llmCalls = 0;
+    let sessionId = "settled-lifecycle-session";
+    let ctx: any;
+
+    ctx = {
+      hasUI: true,
+      model,
+      modelRegistry: {
+        getAvailable: () => [model],
+        find: () => model,
+        getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-key", headers: {} }),
+      },
+      sessionManager: {
+        getBranch: () => branch,
+        buildContextEntries: () => branch,
+        getSessionId: () => sessionId,
+      },
+      getContextUsage: () => ({
+        tokens: totalTokens,
+        contextWindow: model.contextWindow,
+        percent: totalTokens / model.contextWindow * 100,
+      }),
+      isIdle: () => true,
+      hasPendingMessages: () => false,
+      compact: (options: any) => {
+        compactRequests++;
+        void (async () => {
+          try {
+            const before = handlers.get("session_before_compact")![0];
+            const response = await before(
+              { reason: "manual", signal: new AbortController().signal },
+              ctx,
+            ) as any;
+            if (!response?.compaction) throw new Error("settled host request returned no compaction");
+            appliedRunIds.push(response.compaction.details.runId);
+            const applied = handlers.get("session_compact")![0];
+            await applied({
+              fromExtension: true,
+              compactionEntry: {
+                id: "settled-compaction-entry",
+                details: response.compaction.details,
+              },
+            }, ctx);
+            options?.onComplete?.(response.compaction);
+          } catch (error) {
+            options?.onError?.(error instanceof Error ? error : new Error(String(error)));
+          }
+        })();
+      },
+      ui: {
+        notify: (message: string) => notifications.push(message),
+        setWidget: () => {},
+        setStatus: () => {},
+        custom: async () => null,
+      },
+    };
+    setLlmClient({
+      complete: async () => {
+        llmCalls++;
+        return {
+          role: "assistant",
+          content: [{ type: "text", text:
+            "## Goal\nPreserve lifecycle continuity\n\n" +
+            "## Progress\n### Done\n- No completion claimed\n### In Progress\n- Preserve lifecycle continuity\n### Blocked\n- None\n\n" +
+            "## Key Decisions\n- Use SQLite\n\n" +
+            "## Critical Context\n- Lifecycle evidence remains active" }],
+          usage: { inputTokens: 100, outputTokens: 100, totalTokens: 200 },
+          stopReason: "endTurn",
+        } as any;
+      },
+    });
+
+    const settled = handlers.get("agent_settled")![0];
+    await settled({ type: "agent_settled" }, ctx);
+
+    expect(compactRequests).toBe(1);
+    expect(llmCalls).toBe(1);
+    expect(appliedRunIds).toHaveLength(1);
+    expect(readMetricsLog().filter(entry =>
+      entry.sessionId === "settled-lifecycle-session"
+        && entry.status === "success"
+        && entry.runId === appliedRunIds[0]
+    )).toHaveLength(1);
+    expect(notifications.some(message => message.toLowerCase().includes("applied"))).toBe(true);
+
+    await settled({ type: "agent_settled" }, ctx);
+    expect(compactRequests).toBe(1);
+    expect(llmCalls).toBe(1);
+
+    sessionId = "settled-tool-session";
+    const callsBeforeTool = llmCalls;
+    const toolResult = await tools.get("smart_compact").execute(
+      "tool-call",
+      { mode: "fast" },
+      new AbortController().signal,
+      () => {},
+      ctx,
+    );
+    const stagedRunId = toolResult.details?.runId;
+    expect(stagedRunId).toBeString();
+    expect(llmCalls).toBe(callsBeforeTool + 1);
+
+    await settled({ type: "agent_settled" }, ctx);
+    expect(compactRequests).toBe(2);
+    expect(llmCalls).toBe(callsBeforeTool + 1);
+    expect(appliedRunIds.at(-1)).toBe(stagedRunId);
+    expect(readMetricsLog().filter(entry =>
+      entry.sessionId === "settled-tool-session"
+        && entry.status === "success"
+        && entry.runId === stagedRunId
+    )).toHaveLength(1);
+
+    const shutdown = handlers.get("session_shutdown")![0];
+    await shutdown({ type: "session_shutdown", reason: "quit" }, ctx);
+  }, 15_000);
 });

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -96,7 +96,8 @@ describe("metrics reporting", () => {
     const svc = services.createServices();
     const error = Object.assign(new Error("Verification gate rejected summary: secret evidence"), {
       name: "VerificationGateError", score: 92, initialScore: 64, gapCount: 3,
-      gapKinds: ["inconsistency", "fabricated-file", "unsupported-claim"],
+      stage: "post-synthesis",
+      gapKinds: ["missing-read-file", "missing-deleted-file", "inconsistency", "not-a-real-gap", "toString"],
     });
     await recordFailureMetrics({
       services: svc,
@@ -110,7 +111,8 @@ describe("metrics reporting", () => {
     expect(entry).toMatchObject({
       failureKind: "verification", verificationScore: 92, initialVerificationScore: 64,
       verificationGaps: 3, remainingVerificationGaps: 3,
-      verificationGapKinds: ["inconsistency", "fabricated-file", "unsupported-claim"],
+      verificationGapKinds: ["missing-read-file", "missing-deleted-file", "inconsistency"],
+      verificationStage: "post-synthesis",
     });
     expect(JSON.stringify(entry)).not.toContain("secret evidence");
   });

--- a/test/settled-auto-trigger.test.ts
+++ b/test/settled-auto-trigger.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import { createSettledAutoTrigger } from "../src/app/settled-auto-trigger.ts";
+import { DEFAULT_CONFIG, MIN_TOKEN_THRESHOLD, SETTLED_TRIGGER_COOLDOWN_MS } from "../src/constants.ts";
+import type { CompactConfig } from "../src/types.ts";
+
+function config(overrides: Partial<CompactConfig> = {}): CompactConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    autoTriggerStrategy: "settled",
+    minContextPercent: 80,
+    ...overrides,
+  } as CompactConfig;
+}
+
+function context(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionManager: { getSessionId: () => "settled-session" },
+    model: { provider: "openai", id: "test", contextWindow: 100_000 },
+    getContextUsage: () => ({ tokens: 85_000, contextWindow: 100_000, percent: 85 }),
+    isIdle: () => true,
+    hasPendingMessages: () => false,
+    compact: () => {},
+    ...overrides,
+  } as any;
+}
+
+describe("settled auto-trigger host handoff", () => {
+  it("does not request compaction when pressure or lifecycle guards fail", async () => {
+    const cases: Array<{ name: string; cfg?: Partial<CompactConfig>; ctx?: Record<string, unknown> }> = [
+      { name: "disabled", cfg: { autoTrigger: false } },
+      { name: "native hook strategy", cfg: { autoTriggerStrategy: "native-hook" } },
+      { name: "unknown usage", ctx: { getContextUsage: () => ({ tokens: null, contextWindow: 100_000, percent: null }) } },
+      { name: "below absolute floor", ctx: { getContextUsage: () => ({ tokens: MIN_TOKEN_THRESHOLD - 1, contextWindow: 100_000, percent: 4 }) } },
+      { name: "below relative floor", ctx: { getContextUsage: () => ({ tokens: 79_000, contextWindow: 100_000, percent: 79 }) } },
+      { name: "busy", ctx: { isIdle: () => false } },
+      { name: "queued", ctx: { hasPendingMessages: () => true } },
+      { name: "unresolved session", ctx: { sessionManager: { getSessionId: () => undefined } } },
+    ];
+
+    for (const candidate of cases) {
+      let requests = 0;
+      const trigger = createSettledAutoTrigger();
+      await trigger.request(context({ ...candidate.ctx, compact: () => { requests++; } }), config(candidate.cfg));
+      expect(requests, candidate.name).toBe(0);
+    }
+  });
+
+  it("deduplicates concurrent requests and cools down only after success", async () => {
+    let now = 1_000;
+    const callbacks: Array<{ onComplete?: (result: unknown) => void; onError?: (error: Error) => void }> = [];
+    const ctx = context({ compact: (options: any) => callbacks.push(options) });
+    const trigger = createSettledAutoTrigger({ now: () => now });
+
+    const first = trigger.request(ctx, config());
+    const duplicate = trigger.request(ctx, config());
+    expect(callbacks).toHaveLength(1);
+    callbacks[0].onComplete?.({});
+    await Promise.all([first, duplicate]);
+
+    await trigger.request(ctx, config());
+    expect(callbacks).toHaveLength(1);
+
+    now += SETTLED_TRIGGER_COOLDOWN_MS;
+    const afterCooldown = trigger.request(ctx, config());
+    expect(callbacks).toHaveLength(2);
+    callbacks[1].onComplete?.({});
+    await afterCooldown;
+  });
+
+  it("releases a failed request for the next settled event", async () => {
+    const callbacks: Array<{ onComplete?: (result: unknown) => void; onError?: (error: Error) => void }> = [];
+    const ctx = context({ compact: (options: any) => callbacks.push(options) });
+    const trigger = createSettledAutoTrigger();
+
+    const failed = trigger.request(ctx, config());
+    callbacks[0].onError?.(new Error("host rejected compaction"));
+    await failed;
+
+    const retry = trigger.request(ctx, config());
+    expect(callbacks).toHaveLength(2);
+    callbacks[1].onComplete?.({});
+    await retry;
+  });
+
+  it("uses confirmed host compaction as cooldown and clears session state on shutdown", async () => {
+    const callbacks: Array<{ onComplete?: (result: unknown) => void }> = [];
+    const ctx = context({ compact: (options: any) => callbacks.push(options) });
+    const trigger = createSettledAutoTrigger();
+
+    trigger.noteCompaction("settled-session");
+    await trigger.request(ctx, config());
+    expect(callbacks).toHaveLength(0);
+
+    trigger.clear("settled-session");
+    const request = trigger.request(ctx, config());
+    expect(callbacks).toHaveLength(1);
+    callbacks[0].onComplete?.({});
+    await request;
+  });
+});

--- a/test/state-step-continuity.test.ts
+++ b/test/state-step-continuity.test.ts
@@ -71,7 +71,8 @@ describe("buildState continuity integration", () => {
       topics: [], timeline: [], mainGoal: "Release", lastUserMessages: [], lastErrors: [], messageCount: 2,
     };
     const services = createServices();
-    expect(() => buildState({
+    try {
+      buildState({
       extraction,
       finalSummary: "## Goal\nRelease\n## Constraints & Preferences\n- Must publish stable now\n## Progress\n- working\n## Critical Context\n- none",
       projectId, continuityScope: { schemaVersion: 2, projectId, sessionId: "s", branchHeadId: "b" }, previousState: previous,
@@ -88,7 +89,14 @@ describe("buildState continuity integration", () => {
       backupPath: null, verified: true, verificationGaps: [], verificationScore: 100,
       verificationProvenance: { initialScore: 100, deterministicPatched: [], llmPatched: false, finalScore: 100, remainingGaps: [] },
       explorationRounds: 0, modelLabel: "openai/test", notify: () => {},
-    } as any)).toThrow("Verification gate rejected summary");
+      } as any);
+      throw new Error("expected VerificationGateError");
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: "VerificationGateError",
+        stage: "post-state",
+      });
+    }
   });
 
   it("rejects an oversized verified final state before details can exist", () => {

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -535,7 +535,7 @@ describe("verifyAndPatch", () => {
     const extraction = makeExtraction({
       constraints: [{ index: 1, text: "Must publish stable now", category: "requirement", confidence: 1 }],
     });
-    await expect(verifyAndPatch({
+    const rejection = verifyAndPatch({
       finalSummary: "## Goal\nRelease\n## Constraints & Preferences\n- undecided\n## Progress\n- working\n## Critical Context\n- none",
       extraction,
       summaries: [],
@@ -551,7 +551,11 @@ describe("verifyAndPatch", () => {
       flags: { autoTriggered: true },
       notify: (message: string, type: string) => { if (type === "error") uiErrors.push(message); },
       vlog: () => {},
-    } as any)).rejects.toThrow("Verification gate rejected summary");
+    } as any);
+    await expect(rejection).rejects.toMatchObject({
+      name: "VerificationGateError",
+      stage: "post-synthesis",
+    });
     expect(uiErrors).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
- add opt-in `autoTriggerStrategy: "settled"` without changing the default native-hook behavior
- request Pi's normal compact lifecycle from `agent_settled`; EESV, pending consumption, branch validation, cancellation, staging, apply, and persistence remain in the existing correlated hooks
- add per-session in-flight deduplication, queue/idle/pressure guards, confirmed-compaction cooldown, and shutdown cleanup
- record exhaustive content-free verification gap kinds plus `post-synthesis` / `post-state` failure stages
- release as 9.2.0

Fixes #41.
Addresses #42 with failure-stage observability while intentionally retaining both fail-closed gates; unverified summaries are never persisted or indexed.

## Safety invariants
- settled handler never calls `runSmartCompact`
- settled handler never consumes or overwrites `PendingSlot`
- tool-staged candidates are reused with zero extra EESV calls
- durable writes still require matching `session_compact` run/session correlation
- branch ancestry, host abort signal, four-call/60s auto caps, native fallback, and zero-gap verification remain unchanged

## Verification
- targeted: 115 tests, 344 assertions
- full suite: 849 tests, 4,364 assertions
- adversarial gate: 324 tests, 1,066 assertions / 26 suites
- typecheck, benchmark, build, release audit passed
- package audit: 148 files; frozen install and packaged CLIs passed
- compatibility: Pi 0.84.0 and current 0.84.1 passed
- `bun audit`: no vulnerabilities
- `npm pack --dry-run`: `pi-smart-compact-9.2.0.tgz`

Canary telemetry remains HOLD because there are no 9.2.0 applied canary runs; this opt-in path defaults off (`native-hook`).