### PR TITLE
Fix provider-incompatible retained tool tails

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,9 +147,12 @@ The same pure planner powers manual preflight and execution. A soft boundary is
 recorded as relaxed rather than silently overriding the target. Long turns may
 be summarized through their older prefix; if the nominal cut lands inside a
 tool exchange, the planner either retains the complete pair within budget or
-advances past it so the complete exchange is summarized. If no safe hard
-boundary can meet the target, automatic/tool runs normally return control to
-Pi's native compactor before any LLM call. An already-overflowed context is
+advances past it so the complete exchange is summarized. It also advances past
+complete historical exchanges whose tool names violate the portable provider
+contract; this keeps model switches from exposing an unsendable raw tail. If no
+provider-safe hard boundary can meet the target, automatic/tool runs normally
+return control to Pi's native compactor before any LLM call. An
+already-overflowed context is
 the safety exception: measured usage is mapped across active messages and EESV
 keeps chunked recovery instead of sending an oversized one-shot prompt to
 native summarization. Manual runs use the profile's absolute adaptive tail, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [9.2.1-rc.0] - 2026-08-11
+
+### Fixed
+
+- Retained tails now summarize complete historical tool exchanges whose names are not portable across providers, preventing dotted wrapper or MCP names from making the first post-compaction turn fail provider validation.
+
 ## [9.2.0] - 2026-08-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -168,8 +168,10 @@ and reports final success only after Pi confirms the matching
 `session_compact` run ID. A single long user turn may be
 split at a safe message boundary: its older prefix is verified into the summary
 while the budgeted working tail stays raw. Tool exchanges remain complete
-call/result pairs; oversized result evidence is head/tail bounded only in the
-synthesis prompt after deterministic extraction has consumed the full input.
+call/result pairs. Historical exchanges with names outside the portable
+provider contract are summarized instead of leaving an unusable raw tail;
+oversized result evidence is head/tail bounded only in the synthesis prompt
+after deterministic extraction has consumed the full input.
 If Verify, yield, provider, or native apply fails, the UI shows one bounded actionable line without evidence text or a
 JavaScript stack. A successful `100/100` is labeled **verification coverage**;
 the source score and deterministic/LLM/fallback provenance remain visible so
@@ -448,11 +450,14 @@ Automatic and tool-triggered runs operate on Pi's current active context, not
 the append-only session history. A same-session staged summary is reused, the
 exploration loop is limited to three rounds, provider and outer retries are
 disabled, and every mode has finite call plus aggregate prompt-token budgets.
-Complete tool-call/result pairs are the hard window boundary. Recent user
-turns, pi-toolkit checkpoints, and topical grouping are soft and may expand the
-raw tail only while remaining inside the selected budget. Automatic/tool runs
-normally return to Pi's native compactor without an LLM call when a hard
-boundary cannot meet the target. Overflow is the safety exception: EESV keeps
+Complete tool-call/result pairs are the hard window boundary. Provider-incompatible
+historical tool names move the boundary past their complete exchanges so a
+provider switch cannot leave an unsendable raw tail. Recent user turns,
+pi-toolkit checkpoints, and topical grouping are soft and may expand the raw
+tail only while remaining inside the selected budget. Automatic/tool runs
+normally return to Pi's native compactor without an LLM call when no
+provider-safe hard boundary can meet the target. Overflow is the safety
+exception: EESV keeps
 chunked recovery rather than resending an oversized one-shot prompt to native
 compaction. Manual `/smart-compact` uses an absolute adaptive tail rather than
 a percentage of a large model window. A plan below 10% projected savings never

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "9.2.0",
+  "version": "9.2.1-rc.0",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "engines": {

--- a/src/app/steps/window.ts
+++ b/src/app/steps/window.ts
@@ -33,7 +33,7 @@ export function compactionPlanReasonText(reason: CompactionPlanReason): string {
   switch (reason) {
     case "viable": return "safe window and useful estimated saving";
     case "no-eligible-prefix": return "no older prefix is available";
-    case "unsafe-tool-boundary": return "no complete tool-call boundary is available";
+    case "unsafe-tool-boundary": return "no provider-safe complete tool-call boundary is available";
     case "retention-target-exceeded": return "a complete tool pair exceeds the tail target";
     case "mode-target-not-met": return "the estimated result misses this preset's target";
     case "insufficient-projected-saving": return "estimated saving is below 10%";
@@ -58,6 +58,51 @@ export function estimateFinalSummaryAllowance(
     + Math.ceil(profileCfg.summaryBudgetTokens * POST_SUMMARY_RESERVE_RATIO);
   return Math.max(legacyFloor, calibratedOutput + calibratedPostProcessing);
 }
+const PORTABLE_TOOL_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+/**
+ * Retained messages are sent to the active provider verbatim by Pi. Historical
+ * wrapper/MCP names may contain dots or namespace separators that some
+ * providers reject before the next turn starts. Summarize the whole offending
+ * exchange instead of leaving an unusable live tail.
+ */
+function advancePastNonPortableToolExchanges(
+  msgs: SessionMessageEntry[],
+  keepFrom: number,
+  toolCallIndex: ReadonlyMap<string, number>,
+): number {
+  if (keepFrom < 0 || keepFrom >= msgs.length) return keepFrom;
+  const exchangeEnds = new Map<number, number>();
+  for (let index = keepFrom; index < msgs.length; index++) {
+    const message = msgs[index].message;
+    if (!isRecord(message) || message.role !== "toolResult" || typeof message.toolCallId !== "string") continue;
+    const callIndex = toolCallIndex.get(message.toolCallId);
+    if (callIndex === undefined || callIndex < keepFrom) continue;
+    exchangeEnds.set(callIndex, Math.max(exchangeEnds.get(callIndex) ?? 0, index + 1));
+  }
+
+  let adjusted = keepFrom;
+  for (let index = keepFrom; index < msgs.length; index++) {
+    const message = msgs[index].message;
+    if (!isRecord(message)) continue;
+    if (message.role === "assistant" && Array.isArray(message.content)) {
+      const nonPortable = message.content.some(block =>
+        isRecord(block)
+        && block.type === "toolCall"
+        && (typeof block.name !== "string" || !PORTABLE_TOOL_NAME_RE.test(block.name)),
+      );
+      if (nonPortable) adjusted = Math.max(adjusted, exchangeEnds.get(index) ?? index + 1);
+    } else if (
+      message.role === "toolResult"
+      && typeof message.toolName === "string"
+      && !PORTABLE_TOOL_NAME_RE.test(message.toolName)
+    ) {
+      adjusted = Math.max(adjusted, index + 1);
+    }
+  }
+  return adjusted;
+}
+
 export function planCompactionWindow(input: CompactionWindowPlanInput): CompactionWindowPlan {
   const {
     msgs, branch, messageTokens, totalTokens, modelContextWindow, mode, profileCfg, force, overflowedContext,
@@ -147,6 +192,12 @@ export function planCompactionWindow(input: CompactionWindowPlanInput): Compacti
     ? forwardBoundary
     : backwardBoundary;
   hardBoundaryAdjusted ||= keepFrom !== boundaryBeforeHardGuard;
+  const providerSafeBoundary = advancePastNonPortableToolExchanges(msgs, keepFrom, toolCallIndex);
+  const nonPortableTailBlocked = providerSafeBoundary >= msgs.length;
+  if (!nonPortableTailBlocked && providerSafeBoundary > keepFrom) {
+    keepFrom = providerSafeBoundary;
+    hardBoundaryAdjusted = true;
+  }
   const compactTokens = Math.round(tokenPrefix[keepFrom] * messageScale);
   const retainedTokens = retainedAt(keepFrom);
   const projectedAfterTokens = fixedContextTokens + retainedTokens + finalSummaryAllowance;
@@ -158,7 +209,7 @@ export function planCompactionWindow(input: CompactionWindowPlanInput): Compacti
 
   let reason: CompactionPlanReason = "viable";
   const firstKeptMessage = msgs[keepFrom]?.message;
-  if (isRecord(firstKeptMessage) && firstKeptMessage.role === "toolResult") reason = "unsafe-tool-boundary";
+  if (nonPortableTailBlocked || (isRecord(firstKeptMessage) && firstKeptMessage.role === "toolResult")) reason = "unsafe-tool-boundary";
   else if (keepFrom <= 0) reason = "no-eligible-prefix";
   else if (retainedTokens > effectiveRetentionCeiling) reason = "retention-target-exceeded";
   else if (!force && modelContextWindow && projectedAfterTokens > targetAfterTokens) reason = "mode-target-not-met";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "9.2.0";
+export const VERSION = "9.2.1-rc.0";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.10;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;

--- a/test/window-boundary.test.ts
+++ b/test/window-boundary.test.ts
@@ -168,6 +168,82 @@ describe("resolveCompactionWindow tool-result boundary", () => {
     expect(plan.reason).toBe("viable");
   });
 
+  it("summarizes non-portable tool exchanges out of the live provider tail", () => {
+    const wrapperId = "parallel-wrapper";
+    const branch = [
+      messageEntry("old-user", null, { role: "user", content: [{ type: "text", text: "old context" }] }),
+      messageEntry("read-call", "old-user", {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "read-1", name: "read", arguments: { path: "src/a.ts" } }],
+      }),
+      messageEntry("read-result", "read-call", {
+        role: "toolResult", toolCallId: "read-1", toolName: "read", content: [{ type: "text", text: "source" }],
+      }),
+      messageEntry("wrapper-call", "read-result", {
+        role: "assistant",
+        content: [{
+          type: "toolCall",
+          id: wrapperId,
+          name: "multi_tool_use.parallel",
+          arguments: { tool_uses: [{ id: "nested-1", recipient_name: "functions.read", parameters: { path: "src/a.ts" } }] },
+        }],
+      }),
+      messageEntry("wrapper-result", "wrapper-call", {
+        role: "toolResult", toolCallId: wrapperId, toolName: "multi_tool_use.parallel", content: [{ type: "text", text: "done" }],
+      }),
+      messageEntry("safe-user", "wrapper-result", { role: "user", content: [{ type: "text", text: "continue safely" }] }),
+      messageEntry("safe-answer", "safe-user", { role: "assistant", content: [{ type: "text", text: "ready" }] }),
+    ];
+    const rc = makePreparedRc(branch, 800);
+    rc.profileCfg.summaryBudgetTokens = 10;
+
+    const plan = planCompactionWindow({
+      msgs: branch,
+      branch,
+      messageTokens: [1_000, 300, 300, 100, 100, 100, 100],
+      totalTokens: 2_000,
+      modelContextWindow: 10_000,
+      mode: "thorough",
+      profileCfg: rc.profileCfg,
+      force: true,
+      overflowedContext: false,
+    });
+
+    expect(plan.keepFrom).toBe(5);
+    expect(plan.hardBoundaryAdjusted).toBeTrue();
+    expect(plan.reason).toBe("viable");
+  });
+
+  it("fails closed when no message remains after a non-portable tool exchange", () => {
+    const branch = [
+      messageEntry("old-user", null, { role: "user", content: [{ type: "text", text: "old context" }] }),
+      messageEntry("wrapper-call", "old-user", {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "wrapper", name: "multi_tool_use.parallel", arguments: {} }],
+      }),
+      messageEntry("wrapper-result", "wrapper-call", {
+        role: "toolResult", toolCallId: "wrapper", toolName: "multi_tool_use.parallel", content: [{ type: "text", text: "done" }],
+      }),
+    ];
+    const rc = makePreparedRc(branch, 200);
+    rc.profileCfg.summaryBudgetTokens = 10;
+
+    const plan = planCompactionWindow({
+      msgs: branch,
+      branch,
+      messageTokens: [1_000, 100, 100],
+      totalTokens: 1_200,
+      modelContextWindow: 10_000,
+      mode: "thorough",
+      profileCfg: rc.profileCfg,
+      force: true,
+      overflowedContext: false,
+    });
+
+    expect(plan.viable).toBeFalse();
+    expect(plan.reason).toBe("unsafe-tool-boundary");
+  });
+
   it("counts large tool-call arguments in the recent-tail budget", () => {
     const branch: SessionMessageEntry[] = [];
     for (let i = 0; i < 100; i++) {


### PR DESCRIPTION
## Problem

A real Pi/OpenAI canary compacted successfully but retained a historical `multi_tool_use.parallel` exchange in the raw tail. The first post-compaction turn then failed provider validation because dotted tool names do not satisfy the provider function-name contract.

## Fix

- advance the compaction boundary past complete non-portable historical tool exchanges
- fail closed when no provider-safe retained message remains
- document the cross-provider tail invariant
- add planner regressions for successful advancement and the no-safe-tail case

## Verification

- `bun test test/window-boundary.test.ts` — 23 pass
- `bun run typecheck` — pass
- `bun run release:check` — 851 tests, adversarial gate, benchmark, build, and 148-file artifact audit pass
- published `pi-smart-compact@9.2.1-rc.0` on npm `next`
- real Pi 0.84.x host canary: 21/21 host-confirmed applied runs, 100 verifier quality, 0 fallback, 0 damage, 100% damage-observation coverage
- telemetry decision: `PROMOTE` at 98% data confidence
