### PR TITLE
fix: resolve ~/.pi/agent via os.homedir() when HOME is unset (9.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [9.3.1] - 2026-08-15
+
+### Fixed
+
+- **Windows / GUI launches resolve `~/.pi/agent` correctly.** `home()` fell back to `"/tmp"` whenever `HOME` was unset — which is every Windows launch (Windows uses `USERPROFILE`, not `HOME`) and GUI launches that strip the environment. Settings, caches, run-locks, and backups were silently routed to `C:\tmp\.pi\agent`, so `settings.json` configuration (mode, models, thresholds, everything under `smartCompact`) was invisible to the extension. The fallback is now `os.homedir()`, matching how the pi host itself resolves its agent directory. The duplicated pattern in the session-log reader was unified onto the same helper (also fixing its path cache key).
+
 ## [9.3.0] - 2026-08-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-smart-compact",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
   "packageManager": "bun@1.3.14",
   "engines": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "9.3.0";
+export const VERSION = "9.3.1";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.1;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;

--- a/src/infra/paths.ts
+++ b/src/infra/paths.ts
@@ -17,113 +17,135 @@
  */
 
 import path from "node:path";
+import os from "node:os";
 import { EXTRACTION_CACHE_PREFIX } from "../constants.ts";
 
-function home(): string {
-  return process.env.HOME ?? "/tmp";
+/**
+ * `HOME` wins so tests can override the root; when it is unset (every
+ * Windows launch — Windows uses `USERPROFILE` — and GUI launches that strip
+ * the environment) fall back to `os.homedir()`, matching how the pi host
+ * resolves `~/.pi/agent`. The old `"/tmp"` fallback routed settings,
+ * caches, and run-locks to `C:\tmp` on Windows, making settings.json
+ * invisible to the extension.
+ */
+export function home(): string {
+ return process.env.HOME ?? os.homedir();
 }
 
 /** Root pi agent directory (`~/.pi/agent`). */
 export function piAgentDir(): string {
-  return path.join(home(), ".pi", "agent");
+ return path.join(home(), ".pi", "agent");
 }
 
 /** Shared cache root (`~/.pi/agent/.cache`). */
 export function cacheDir(): string {
-  return path.join(piAgentDir(), ".cache");
+ return path.join(piAgentDir(), ".cache");
 }
 
 /** Smart-compact specific cache root (`~/.pi/agent/.cache/smart-compact`). */
 export function smartCompactCacheDir(): string {
-  return path.join(cacheDir(), "smart-compact");
+ return path.join(cacheDir(), "smart-compact");
 }
 
 /** Project fingerprint directory. */
 export function projectFingerprintDir(): string {
-  return path.join(smartCompactCacheDir(), "projects");
+ return path.join(smartCompactCacheDir(), "projects");
 }
 
 /** Compaction state directory. */
 export function compactionStateDir(): string {
-  return path.join(smartCompactCacheDir(), "states");
+ return path.join(smartCompactCacheDir(), "states");
 }
 
 /** Pi-coding-agent session log directory. */
 export function sessionsDir(): string {
-  return path.join(piAgentDir(), "sessions");
+ return path.join(piAgentDir(), "sessions");
 }
 
 /** Pi-coding-agent settings file. */
 export function settingsFile(): string {
-  return path.join(piAgentDir(), "settings.json");
+ return path.join(piAgentDir(), "settings.json");
 }
 
 /** Default backup directory. */
 export function defaultBackupDir(): string {
-  return path.join(piAgentDir(), "compact-backups");
+ return path.join(piAgentDir(), "compact-backups");
 }
 
 /** Metrics JSONL log. */
 export function metricsLogFile(): string {
-  return path.join(cacheDir(), "compact-metrics.jsonl");
+ return path.join(cacheDir(), "compact-metrics.jsonl");
 }
 
 /** Cross-process Smart Compact semaphore/session lease directory. */
 export function runLocksDir(): string {
-  return path.join(smartCompactCacheDir(), "run-locks");
+ return path.join(smartCompactCacheDir(), "run-locks");
 }
 
 /** One-shot, branch-scoped native-compaction continuity handoffs. */
 export function nativeContinuityDir(): string {
-  return path.join(smartCompactCacheDir(), "native-continuity");
+ return path.join(smartCompactCacheDir(), "native-continuity");
 }
 
 /** Project-scoped persistent context graph (SQLite + FTS5). */
 export function contextGraphFile(): string {
-  return path.join(smartCompactCacheDir(), "context-graph.sqlite");
+ return path.join(smartCompactCacheDir(), "context-graph.sqlite");
 }
 
 /** Damage reports JSONL log. */
 export function damageReportsFile(): string {
-  return path.join(smartCompactCacheDir(), "damage-reports.jsonl");
+ return path.join(smartCompactCacheDir(), "damage-reports.jsonl");
 }
 
 /** Extraction cache file for a given session. */
 export function extractionCacheFile(sessionId: string): string {
-  return path.join(cacheDir(), EXTRACTION_CACHE_PREFIX + sessionId.replace(/[^a-zA-Z0-9-]/g, "_") + ".json");
+ return path.join(
+  cacheDir(),
+  EXTRACTION_CACHE_PREFIX + sessionId.replace(/[^a-zA-Z0-9-]/g, "_") + ".json",
+ );
 }
 
 /** Project fingerprint file for a given project id. */
 export function projectFingerprintFile(projectId: string): string {
-  return path.join(projectFingerprintDir(), projectId + ".json");
+ return path.join(projectFingerprintDir(), projectId + ".json");
 }
 
 /** Legacy project-wide compaction state file (v1). */
 export function compactionStateFile(projectId: string): string {
-  return path.join(compactionStateDir(), projectId.replace(/[^a-zA-Z0-9_-]/g, "_") + ".json");
+ return path.join(
+  compactionStateDir(),
+  projectId.replace(/[^a-zA-Z0-9_-]/g, "_") + ".json",
+ );
 }
 
 /** Pre-v8.1 session-only path, retained solely for one-time branch migration. */
-export function legacyScopedCompactionStateFile(projectId: string, sessionId: string): string {
-  const project = projectId.replace(/[^a-zA-Z0-9_-]/g, "_");
-  const session = sessionId.replace(/[^a-zA-Z0-9_-]/g, "_");
-  return path.join(compactionStateDir(), project, session + ".json");
+export function legacyScopedCompactionStateFile(
+ projectId: string,
+ sessionId: string,
+): string {
+ const project = projectId.replace(/[^a-zA-Z0-9_-]/g, "_");
+ const session = sessionId.replace(/[^a-zA-Z0-9_-]/g, "_");
+ return path.join(compactionStateDir(), project, session + ".json");
 }
 
 /** Immutable branch snapshot; descendants find it through their ancestry IDs. */
-export function scopedCompactionStateFile(projectId: string, sessionId: string, branchHeadId: string): string {
-  const project = projectId.replace(/[^a-zA-Z0-9_-]/g, "_");
-  const session = sessionId.replace(/[^a-zA-Z0-9_-]/g, "_");
-  const branch = branchHeadId.replace(/[^a-zA-Z0-9_-]/g, "_");
-  return path.join(compactionStateDir(), project, session, branch + ".json");
+export function scopedCompactionStateFile(
+ projectId: string,
+ sessionId: string,
+ branchHeadId: string,
+): string {
+ const project = projectId.replace(/[^a-zA-Z0-9_-]/g, "_");
+ const session = sessionId.replace(/[^a-zA-Z0-9_-]/g, "_");
+ const branch = branchHeadId.replace(/[^a-zA-Z0-9_-]/g, "_");
+ return path.join(compactionStateDir(), project, session, branch + ".json");
 }
 
 /** Remediation hints file — files to re-preserve after a damage event. */
 export function remediationHintsFile(projectId: string): string {
-  return path.join(smartCompactCacheDir(), "remediation-" + projectId + ".json");
+ return path.join(smartCompactCacheDir(), "remediation-" + projectId + ".json");
 }
 
 /** HTML metrics dashboard file. */
 export function metricsDashboardFile(): string {
-  return path.join(cacheDir(), "smart-compact-report.html");
+ return path.join(cacheDir(), "smart-compact-report.html");
 }

--- a/src/utils/session-log.ts
+++ b/src/utils/session-log.ts
@@ -23,7 +23,10 @@ import { extractText, TRUNCATE_RE } from "./extraction.ts";
 import type { LlmMessage, SessionMessageEntry } from "../types.ts";
 import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { asBranchMessage } from "../infra/ai-messages.ts";
-import { sessionsDir as sessionsDirPath } from "../infra/paths.ts";
+import {
+  sessionsDir as sessionsDirPath,
+  home as piHome,
+} from "../infra/paths.ts";
 // LRU helpers live in a sibling module so they can be unit-tested in
 // isolation and reused by other bounded caches.
 import { lruGet, lruSet } from "./lru.ts";
@@ -39,7 +42,10 @@ function getSessionsDir(): string {
  * recovery. Awaiting each chunk yields I/O back to the event loop instead of
  * blocking the agent while preserving exact UTF-8 line boundaries.
  */
-async function* streamJsonlLines(file: string, chunkSize = 64 * 1024): AsyncGenerator<string> {
+async function* streamJsonlLines(
+  file: string,
+  chunkSize = 64 * 1024,
+): AsyncGenerator<string> {
   const handle = await fs.promises.open(file, "r");
   try {
     const buffer = Buffer.allocUnsafe(chunkSize);
@@ -58,7 +64,9 @@ async function* streamJsonlLines(file: string, chunkSize = 64 * 1024): AsyncGene
     leftover += decoder.end();
     if (leftover.length > 0) yield leftover;
   } finally {
-    await handle.close().catch(error => log.debug("streamJsonlLines close failed", error));
+    await handle
+      .close()
+      .catch((error) => log.debug("streamJsonlLines close failed", error));
   }
 }
 
@@ -75,7 +83,11 @@ interface LogMessage {
   content?: unknown;
   toolCallId?: string;
   toolName?: string;
-  toolCall?: { id?: string; name?: string; arguments?: Record<string, unknown> };
+  toolCall?: {
+    id?: string;
+    name?: string;
+    arguments?: Record<string, unknown>;
+  };
   isError?: boolean;
   details?: Record<string, unknown>;
   display?: boolean;
@@ -124,10 +136,20 @@ function getMaxEntries(): number {
   return Number.isFinite(n) && n > 0 ? n : DEFAULT_CACHE_MAX_ENTRIES;
 }
 
-
-
-const logPathCache = new Map<string, { path: string | null; expiresAt: number; home: string }>();
-const messageMapCache = new Map<string, { logPath: string; mtimeMs: number; size: number; requestedIds: Set<string>; map: Map<string, LlmMessage> }>();
+const logPathCache = new Map<
+  string,
+  { path: string | null; expiresAt: number; home: string }
+>();
+const messageMapCache = new Map<
+  string,
+  {
+    logPath: string;
+    mtimeMs: number;
+    size: number;
+    requestedIds: Set<string>;
+    map: Map<string, LlmMessage>;
+  }
+>();
 
 /** @internal Test-only: drop both module caches between cases. */
 export function __resetSessionLogCachesForTests(): void {
@@ -136,18 +158,28 @@ export function __resetSessionLogCachesForTests(): void {
 }
 
 function sessionDirectoryForCwd(cwd: string): string {
-  const safeCwd = path.resolve(cwd).replace(/^[/\\]/, "").replace(/[:/\\]/g, "-");
+  const safeCwd = path
+    .resolve(cwd)
+    .replace(/^[/\\]/, "")
+    .replace(/[:/\\]/g, "-");
   return path.join(getSessionsDir(), "--" + safeCwd + "--");
 }
 
-function findLogInDirectory(directory: string, sessionId: string): string | null {
+function findLogInDirectory(
+  directory: string,
+  sessionId: string,
+): string | null {
   if (!fs.existsSync(directory)) return null;
   if (/^[a-zA-Z0-9_-]+$/.test(sessionId)) {
     const exact = path.join(directory, sessionId + ".jsonl");
     if (fs.existsSync(exact)) return exact;
   }
-  const match = fs.readdirSync(directory, { withFileTypes: true })
-    .find(entry => entry.isFile() && entry.name.endsWith("_" + sessionId + ".jsonl"));
+  const match = fs
+    .readdirSync(directory, { withFileTypes: true })
+    .find(
+      (entry) =>
+        entry.isFile() && entry.name.endsWith("_" + sessionId + ".jsonl"),
+    );
   return match ? path.join(directory, match.name) : null;
 }
 
@@ -159,18 +191,24 @@ function findLogInDirectory(directory: string, sessionId: string): string | null
  * We try the bare id first, then the glob suffix pattern.
  */
 function findSessionLogFile(sessionId: string, cwd?: string): string | null {
-  const home = process.env.HOME ?? "/tmp";
+  const home = piHome();
   const now = Date.now();
   const directDirectory = cwd ? sessionDirectoryForCwd(cwd) : null;
   const cacheKey = sessionId + "\0" + (directDirectory ?? "*");
   const remember = (foundPath: string | null) => {
-    lruSet(logPathCache, cacheKey, { path: foundPath, expiresAt: now + LOG_PATH_CACHE_TTL_MS, home }, getMaxEntries());
+    lruSet(
+      logPathCache,
+      cacheKey,
+      { path: foundPath, expiresAt: now + LOG_PATH_CACHE_TTL_MS, home },
+      getMaxEntries(),
+    );
     return foundPath;
   };
 
   try {
     const cached = lruGet(logPathCache, cacheKey);
-    if (cached && cached.home === home && cached.expiresAt > now) return cached.path;
+    if (cached && cached.home === home && cached.expiresAt > now)
+      return cached.path;
 
     const sessionsDir = getSessionsDir();
     if (!fs.existsSync(sessionsDir)) return remember(null);
@@ -202,7 +240,10 @@ function findSessionLogFile(sessionId: string, cwd?: string): string | null {
  * wrong values. The field is currently write-only internally, but using the
  * real timestamp keeps recovered messages consistent with their neighbors.
  */
-function normalizeLogMessage(msg: LogMessage | undefined, entryTimestamp?: string): LlmMessage | null {
+function normalizeLogMessage(
+  msg: LogMessage | undefined,
+  entryTimestamp?: string,
+): LlmMessage | null {
   if (!msg || !msg.role) return null;
 
   const role = msg.role;
@@ -225,7 +266,7 @@ function normalizeLogMessage(msg: LogMessage | undefined, entryTimestamp?: strin
  * Check if any message in the array has been truncated by pi-toolkit.
  */
 export function hasTruncatedMessages(msgs: LlmMessage[]): boolean {
-  return msgs.some(m => TRUNCATE_RE.test(extractText(m.content)));
+  return msgs.some((m) => TRUNCATE_RE.test(extractText(m.content)));
 }
 
 /**
@@ -248,11 +289,11 @@ async function readOriginalMessageMap(
     const stat = await fs.promises.stat(logPath);
     const cached = lruGet(messageMapCache, sessionId);
     if (
-      cached
-      && cached.logPath === logPath
-      && cached.mtimeMs === stat.mtimeMs
-      && cached.size === stat.size
-      && Array.from(wantedIds).every(id => cached.requestedIds.has(id))
+      cached &&
+      cached.logPath === logPath &&
+      cached.mtimeMs === stat.mtimeMs &&
+      cached.size === stat.size &&
+      Array.from(wantedIds).every((id) => cached.requestedIds.has(id))
     ) {
       return cached.map;
     }
@@ -267,21 +308,39 @@ async function readOriginalMessageMap(
       } catch {
         continue;
       }
-      if (entry.type !== "message" || !entry.id || !remaining.has(entry.id) || !entry.message) continue;
+      if (
+        entry.type !== "message" ||
+        !entry.id ||
+        !remaining.has(entry.id) ||
+        !entry.message
+      )
+        continue;
       remaining.delete(entry.id);
       const normalized = normalizeLogMessage(entry.message, entry.timestamp);
       if (normalized) map.set(entry.id, normalized);
       if (remaining.size === 0) break;
     }
 
-    log.debug("readOriginalMessageMap: " + map.size + "/" + wantedIds.size + " requested msgs from " + logPath);
-    lruSet(messageMapCache, sessionId, {
-      logPath,
-      mtimeMs: stat.mtimeMs,
-      size: stat.size,
-      requestedIds: new Set(wantedIds),
-      map,
-    }, getMaxEntries());
+    log.debug(
+      "readOriginalMessageMap: " +
+        map.size +
+        "/" +
+        wantedIds.size +
+        " requested msgs from " +
+        logPath,
+    );
+    lruSet(
+      messageMapCache,
+      sessionId,
+      {
+        logPath,
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+        requestedIds: new Set(wantedIds),
+        map,
+      },
+      getMaxEntries(),
+    );
     return map;
   } catch (error) {
     log.debug("readOriginalMessageMap failed", error);
@@ -307,7 +366,9 @@ export async function resolveCompactionMessages(
   toCompactEntries: SessionMessageEntry[],
   cwd?: string,
 ): Promise<ResolvedCompactionMessage[] | null> {
-  const wantedIds = new Set(toCompactEntries.flatMap(entry => entry.id ? [entry.id] : []));
+  const wantedIds = new Set(
+    toCompactEntries.flatMap((entry) => (entry.id ? [entry.id] : [])),
+  );
   const logMap = await readOriginalMessageMap(sessionId, wantedIds, cwd);
   if (!logMap) return null;
 
@@ -316,19 +377,28 @@ export async function resolveCompactionMessages(
 
   for (const entry of toCompactEntries) {
     if (!entry.id) continue;
-    const converted = convertToLlm([asBranchMessage(entry.message)]) as LlmMessage[];
+    const converted = convertToLlm([
+      asBranchMessage(entry.message),
+    ]) as LlmMessage[];
     if (!converted.length) continue;
     const logMsg = logMap.get(entry.id);
     if (logMsg && !hasTruncatedMessages([logMsg])) {
       result.push({ entryId: entry.id, message: logMsg });
       restoredCount++;
     } else {
-      for (const message of converted) result.push({ entryId: entry.id, message });
+      for (const message of converted)
+        result.push({ entryId: entry.id, message });
     }
   }
 
   if (restoredCount > 0) {
-    log.info("Session log recovery: " + restoredCount + "/" + result.length + " LLM messages restored from log");
+    log.info(
+      "Session log recovery: " +
+        restoredCount +
+        "/" +
+        result.length +
+        " LLM messages restored from log",
+    );
   }
   return result;
 }

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -1,0 +1,27 @@
+// pi-lens-ignore: ts(2307)
+import { describe, it, expect, afterEach } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import { piAgentDir, home } from "../src/infra/paths.ts";
+
+// paths.ts reads HOME at call time (module doc), so mutating env here is safe.
+const REAL_HOME = process.env.HOME;
+afterEach(() => {
+  if (REAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = REAL_HOME;
+});
+
+describe("home resolution fallback", () => {
+  it("falls back to os.homedir() when HOME is unset (Windows / GUI launches)", () => {
+    delete process.env.HOME;
+    expect(home()).toBe(os.homedir());
+    expect(piAgentDir()).toBe(path.join(os.homedir(), ".pi", "agent"));
+  });
+
+  it("prefers HOME when set (test overrides keep working)", () => {
+    process.env.HOME = "/tmp/sc-path-test-home";
+    expect(piAgentDir()).toBe(
+      path.join("/tmp/sc-path-test-home", ".pi", "agent"),
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

`home()` fell back to `"/tmp"` whenever `HOME` was unset — which is **every Windows launch** (Windows uses `USERPROFILE`, not `HOME`) and GUI launches that strip the environment. Settings, caches, run-locks, and backups were silently routed to `C:\tmp\.pi\agent`, so `settings.json` configuration was invisible to the extension.

## Fix

- `src/infra/paths.ts`: fallback is now `os.homedir()`, matching how the pi host itself resolves its agent directory (its config uses `join(homedir(), '.pi', 'agent')`). Helper exported with a doc comment.
- `src/utils/session-log.ts`: duplicated `HOME ?? "/tmp"` pattern unified onto the shared `home()` — also fixes the session-log path cache invalidation key.
- `test/paths.test.ts`: 2 asserts (HOME unset → `os.homedir()` fallback; HOME set → test overrides keep working).

## Verification

- `bun run release:check` ✅ (typecheck, 888/888 tests, gate, bench, build, release audit, `compat:pi latest`)
- Version bumped to **9.3.1** (patch), CHANGELOG dated entry added.

## Notes

- Formatting churn on the two touched modules is repo-canonical (edit-hook formatter, same style pass as 9.3.0).
- After merge: tagged `v9.3.1` on the merge commit; npm publish handled by the maintainer.