### PR TITLE
Release 9.5.0 — showStatus footer toggle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         # CI reproduces local builds deterministically (audit P0 #3).
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
 
       - name: Install dependencies
         # --frozen-lockfile catches accidental drift between bun.lock and
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
 
       - name: Install locked baseline
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         # CI reproduces local builds deterministically (audit P0 #3).
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         # --frozen-lockfile catches accidental drift between bun.lock and
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.3.14"
 
       - name: Install locked baseline
         run: bun install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [9.5.0] - 2026-08-26
+
+### Added
+
+- `showStatus` supplies a permanent global default for the footer policy status line, with a matching "Footer status" control in `/smart-compact settings`. Disabling it clears the `smart-compact: ...` footer entry (e.g. "manual only") while the policy itself stays fully active; session branches keep restoring their own footer visibility. The default remains on, so existing setups see no change until they opt in.
+
 ## [9.4.0] - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ the run fails closed before staging or apply.
 | `segmentationThinkingLevel` | `minimal \| low \| medium \| high \| xhigh \| max \| null` | `minimal` | Reasoning level for exploration; provider default when null |
 | `agentToolAccess` | `"inherit" \| "enabled" \| "disabled"` | `"inherit"` | Respect Pi's active tools by default, or explicitly expose/hide `smart_compact`; manual command is unaffected |
 | `autoTrigger` | `boolean` | `true` | Allow smart compaction in Pi's native hook and the selected trigger strategy |
+| `showStatus` | `boolean` | `true` | Show the policy status line (e.g. "manual only") in Pi's footer; set `false` for a clean footer |
 | `autoTriggerStrategy` | `native-hook \| settled` | `native-hook` | `settled` additionally requests Pi's normal compact flow after an idle high-pressure agent run; verified with Pi 0.84.0+ |
 | `autoTriggerTimeoutMs` | `number` | `120000` | Requested auto cancellation deadline; the host hook clamps it to 60s and four LLM calls, shows live phase progress, then safely unwinds to native recovery |
 | `minContextPercent` | `number` | `60` | Auto/tool context gate; manual `/smart-compact` warns and bypasses it |

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "pi-smart-compact",
       "devDependencies": {
-        "@types/bun": "^1.4.0",
+        "@types/bun": "1.3.14",
         "@types/node": "^26.3.0",
         "typescript": "^7.0.2",
       },
@@ -146,7 +146,7 @@
 
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
-    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@26.3.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw=="],
 
@@ -206,7 +206,7 @@
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
-    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "pi-smart-compact",
       "devDependencies": {
-        "@types/bun": "^1.3.14",
-        "@types/node": "^26.1.2",
+        "@types/bun": "^1.4.0",
+        "@types/node": "^26.3.0",
         "typescript": "^7.0.2",
       },
       "peerDependencies": {
@@ -72,7 +72,7 @@
 
     "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.0", "@earendil-works/pi-telemetry": "^0.84.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-L1lw0lwR5LXCzGEeHD9XNEruU2bg0H8clOA8ySdGMHvxutp8GC+yZL6MZp4tqQRnLKP3gHmY7TrWzQ3YnFdJYQ=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-N9RDk8q0eglGiy+NqTZ3Ev2j+6oFNXSAJa8b0CYhvWB9HGiKZjsoCESXkUvMDLybrn0wXp75sdsoBzEtHxk9kA=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.3", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ=="],
 
     "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.0", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.0" } }, "sha512-fHXgw1FdLDh+uw42SvTkJRBfgc3nsrslghvbRFEAxdjfcOxJt7hPsTj4HHNK96wMy1f+zvQYL8Y2znvFoZ8JDA=="],
 
@@ -80,9 +80,9 @@
 
     "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.0", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-Fc28cCYGg5+aRnMzbAD7QAi6Xl//kbETyFroLHCs3Zf4oaXH9L2gzBqVLVAwrKIKeS0uffUrmihocGTECfKW6Q=="],
 
-    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.0", "", {}, "sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g=="],
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.3", "", {}, "sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-nbs0FeZJ5rWDD6VpKfXXmYbEHnHqb40V9glE2l9f8ftoWpsP8nw0WcXK8jOjfRsDPnT9dJHy3dItOHdn/AFGjA=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.3", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-fS6OEQKEEALnKa6Uw8LcgZZ+9CWck7f3MQSCETQp6leUgIFwMEDtKmOUnL9nsYm+RIPmy7OmplVxYRbV6hiaFg=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
@@ -107,12 +107,6 @@
     "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
 
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
-
-    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
-
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
-
-    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -152,9 +146,9 @@
 
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
-    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+    "@types/node": ["@types/node@26.3.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw=="],
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
@@ -212,7 +206,7 @@
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -286,7 +280,7 @@
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
-    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+    "openai": ["openai@6.40.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA=="],
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
@@ -332,15 +326,13 @@
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
-    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
     "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.13", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw=="],
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1103.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ=="],
 
     "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.13", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw=="],
+
+    "@earendil-works/pi-agent-core/@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.0", "", {}, "sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g=="],
 
     "@earendil-works/pi-agent-core/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
@@ -351,5 +343,7 @@
     "@earendil-works/pi-protocol/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "protobufjs/@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,85 +1,85 @@
 {
-  "name": "pi-smart-compact",
-  "version": "9.4.0",
-  "description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
-  "packageManager": "bun@1.3.14",
-  "engines": {
-    "node": ">=22.19.0"
-  },
-  "license": "MIT",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    }
-  },
-  "author": "Alper Tarhan <alpertarhan@gmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/alpertarhan/pi-smart-compact.git"
-  },
-  "homepage": "https://github.com/alpertarhan/pi-smart-compact#readme",
-  "bugs": {
-    "url": "https://github.com/alpertarhan/pi-smart-compact/issues"
-  },
-  "keywords": [
-    "pi-package",
-    "pi",
-    "pi-extension",
-    "pi-coding-agent",
-    "pi-smart-compact",
-    "smart-compaction",
-    "context-compression",
-    "eesv",
-    "conversation-summarization",
-    "llm-context"
-  ],
-  "files": [
-    "dist",
-    "docs",
-    "README.md",
-    "ARCHITECTURE.md",
-    "LICENSE",
-    "CHANGELOG.md",
-    "SECURITY.md",
-    "SUPPORT.md"
-  ],
-  "scripts": {
-    "sync-version": "bun run scripts/sync-version.ts",
-    "prebuild": "bun run sync-version",
-    "build": "rm -rf dist && mkdir dist && bun build ./src/index.ts --outdir ./dist --target bun --external '@earendil-works/*' --external 'typebox' && bun build ./scripts/provider-eval.ts ./scripts/provider-scenario-eval.ts ./scripts/telemetry-report.ts --outdir ./dist --target bun --external '@earendil-works/*' --external 'typebox' && bun x tsc --emitDeclarationOnly --outDir dist",
-    "test": "bun test",
-    "bench": "bun bench/hot-paths.bench.ts",
-    "gate": "bun run scripts/eval-gate.ts",
-    "provider-eval": "bun run dist/provider-eval.js",
-    "provider-eval:live": "bun run dist/provider-scenario-eval.js",
-    "telemetry-report": "bun run dist/telemetry-report.js",
-    "compat:pi": "bun run scripts/check-pi-compat.ts",
-    "release:audit": "bun run scripts/release-audit.ts",
-    "release:check": "bun run typecheck && bun test && bun run gate && bun run bench && bun run build && bun run release:audit && bun run compat:pi latest",
-    "typecheck": "bun x tsc --noEmit && bun x tsc -p tsconfig.scripts.json && bun x tsc -p tsconfig.test.json && bun x tsc -p bench/tsconfig.json",
-    "prepublishOnly": "bun run release:check"
-  },
-  "pi": {
-    "extensions": [
-      "./dist/index.js"
-    ],
-    "image": "https://raw.githubusercontent.com/alpertarhan/pi-smart-compact/main/docs/assets/pi-smart-compact.png"
-  },
-  "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*",
-    "typebox": "*"
-  },
-  "devDependencies": {
-    "@types/bun": "^1.3.14",
-    "@types/node": "^26.1.2",
-    "typescript": "^7.0.2"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "pi-smart-compact",
+	"version": "9.4.0",
+	"description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
+	"packageManager": "bun@1.4.0",
+	"engines": {
+		"node": ">=22.19.0"
+	},
+	"license": "MIT",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"author": "Alper Tarhan <alpertarhan@gmail.com>",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/alpertarhan/pi-smart-compact.git"
+	},
+	"homepage": "https://github.com/alpertarhan/pi-smart-compact#readme",
+	"bugs": {
+		"url": "https://github.com/alpertarhan/pi-smart-compact/issues"
+	},
+	"keywords": [
+		"pi-package",
+		"pi",
+		"pi-extension",
+		"pi-coding-agent",
+		"pi-smart-compact",
+		"smart-compaction",
+		"context-compression",
+		"eesv",
+		"conversation-summarization",
+		"llm-context"
+	],
+	"files": [
+		"dist",
+		"docs",
+		"README.md",
+		"ARCHITECTURE.md",
+		"LICENSE",
+		"CHANGELOG.md",
+		"SECURITY.md",
+		"SUPPORT.md"
+	],
+	"scripts": {
+		"sync-version": "bun run scripts/sync-version.ts",
+		"prebuild": "bun run sync-version",
+		"build": "rm -rf dist && mkdir dist && bun build ./src/index.ts --outdir ./dist --target bun --external '@earendil-works/*' --external 'typebox' && bun build ./scripts/provider-eval.ts ./scripts/provider-scenario-eval.ts ./scripts/telemetry-report.ts --outdir ./dist --target bun --external '@earendil-works/*' --external 'typebox' && bun x tsc --emitDeclarationOnly --outDir dist",
+		"test": "bun test",
+		"bench": "bun bench/hot-paths.bench.ts",
+		"gate": "bun run scripts/eval-gate.ts",
+		"provider-eval": "bun run dist/provider-eval.js",
+		"provider-eval:live": "bun run dist/provider-scenario-eval.js",
+		"telemetry-report": "bun run dist/telemetry-report.js",
+		"compat:pi": "bun run scripts/check-pi-compat.ts",
+		"release:audit": "bun run scripts/release-audit.ts",
+		"release:check": "bun run typecheck && bun test && bun run gate && bun run bench && bun run build && bun run release:audit && bun run compat:pi latest",
+		"typecheck": "bun x tsc --noEmit && bun x tsc -p tsconfig.scripts.json && bun x tsc -p tsconfig.test.json && bun x tsc -p bench/tsconfig.json",
+		"prepublishOnly": "bun run release:check"
+	},
+	"pi": {
+		"extensions": [
+			"./dist/index.js"
+		],
+		"image": "https://raw.githubusercontent.com/alpertarhan/pi-smart-compact/main/docs/assets/pi-smart-compact.png"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-ai": "*",
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*",
+		"typebox": "*"
+	},
+	"devDependencies": {
+		"@types/bun": "^1.4.0",
+		"@types/node": "^26.3.0",
+		"typescript": "^7.0.2"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pi-smart-compact",
-	"version": "9.4.0",
-	"description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
+	"version": "9.5.0",
+	"description": "Verification-oriented smart compaction extension for Pi Coding Agent \u2014 deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
 	"packageManager": "bun@1.4.0",
 	"engines": {
 		"node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "pi-smart-compact",
 	"version": "9.5.0",
-	"description": "Verification-oriented smart compaction extension for Pi Coding Agent \u2014 deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
-	"packageManager": "bun@1.4.0",
+	"description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
+	"packageManager": "bun@1.3.14",
 	"engines": {
 		"node": ">=22.19.0"
 	},
@@ -75,7 +75,7 @@
 		"typebox": "*"
 	},
 	"devDependencies": {
-		"@types/bun": "^1.4.0",
+		"@types/bun": "1.3.14",
 		"@types/node": "^26.3.0",
 		"typescript": "^7.0.2"
 	},

--- a/src/app/smart-compact-policy.ts
+++ b/src/app/smart-compact-policy.ts
@@ -18,11 +18,13 @@ export interface SmartCompactPolicySnapshot {
   /** Effective host state after allowlists and other tool controls are applied. */
   agentToolEnabled: boolean;
   autoTrigger: boolean;
+  showStatus: boolean;
 }
 
 interface DesiredSmartCompactPolicy {
   agentToolAccess: AgentToolAccess;
   autoTrigger: boolean;
+  showStatus: boolean;
 }
 
 interface PersistedSmartCompactPolicy extends DesiredSmartCompactPolicy {
@@ -44,7 +46,7 @@ export interface SmartCompactPolicy {
   ): SmartCompactPolicyUpdate;
 }
 
-function persistedPolicy(value: unknown): DesiredSmartCompactPolicy | null {
+function persistedPolicy(value: unknown): Partial<DesiredSmartCompactPolicy> | null {
   if (typeof value !== "object" || value === null) return null;
   const candidate = value as Record<string, unknown>;
   if (
@@ -54,10 +56,15 @@ function persistedPolicy(value: unknown): DesiredSmartCompactPolicy | null {
       candidate.agentToolAccess === "disabled") &&
     typeof candidate.autoTrigger === "boolean"
   ) {
-    return {
+    const desired: DesiredSmartCompactPolicy = {
       agentToolAccess: candidate.agentToolAccess,
       autoTrigger: candidate.autoTrigger,
+      showStatus: true,
     };
+    if (typeof candidate.showStatus === "boolean") {
+      desired.showStatus = candidate.showStatus;
+    }
+    return desired;
   }
   // Version 1 stored a boolean. Preserve an explicit user choice while moving
   // new/default sessions to host-owned `inherit` behavior.
@@ -79,6 +86,7 @@ function configDefaults(): DesiredSmartCompactPolicy {
   return {
     agentToolAccess: config.agentToolAccess,
     autoTrigger: config.autoTrigger,
+    showStatus: config.showStatus !== false,
   };
 }
 
@@ -117,7 +125,7 @@ export function createSmartCompactPolicy(pi: ExtensionAPI): SmartCompactPolicy {
       );
     }
     const effective = snapshot();
-    ctx.ui.setStatus(STATUS_KEY, statusText(effective));
+    ctx.ui.setStatus(STATUS_KEY, current.showStatus ? statusText(effective) : undefined);
     return effective;
   };
 
@@ -133,7 +141,7 @@ export function createSmartCompactPolicy(pi: ExtensionAPI): SmartCompactPolicy {
           entry.customType === SMART_COMPACT_POLICY_ENTRY
         ) {
           const restored = persistedPolicy(entry.data);
-          if (restored) current = restored;
+          if (restored) current = { ...current, ...restored };
         }
       }
       apply(ctx);
@@ -158,7 +166,7 @@ export function createSmartCompactPolicy(pi: ExtensionAPI): SmartCompactPolicy {
           log.debugError("Smart Compact policy rollback failed", rollbackError);
         }
         const rolledBack = snapshot();
-        ctx.ui.setStatus(STATUS_KEY, statusText(rolledBack));
+        ctx.ui.setStatus(STATUS_KEY, current.showStatus ? statusText(rolledBack) : undefined);
         return {
           ok: false,
           policy: rolledBack,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "9.4.0";
+export const VERSION = "9.5.0";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.1;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,6 +77,7 @@ export const DEFAULT_CONFIG = {
 	segmentationThinkingLevel: "minimal" as const,
 	agentToolAccess: "inherit" as const,
 	autoTrigger: true,
+	showStatus: true,
 	autoTriggerStrategy: "native-hook" as const,
 	autoTriggerTimeoutMs: 120000,
 	backupEnabled: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,8 @@ export interface CompactConfig {
  /** Whether Smart Compact inherits, enables, or disables its agent tool. */
  agentToolAccess: AgentToolAccess;
  autoTrigger: boolean;
+ /** Show the policy status line in Pi's footer. */
+ showStatus: boolean;
  /** Native hook participation, or an opt-in proactive request after an idle agent run. */
  autoTriggerStrategy: AutoTriggerStrategy;
  autoTriggerTimeoutMs: number;

--- a/src/ui/settings-overlay.ts
+++ b/src/ui/settings-overlay.ts
@@ -33,6 +33,7 @@ function parseAccessValue(
 
 function previousValue(id: string, policy: SmartCompactPolicySnapshot): string {
   if (id === "agentToolAccess") return accessValue(policy);
+  if (id === "showStatus") return policy.showStatus ? ENABLED : DISABLED;
   return policy.autoTrigger ? ENABLED : DISABLED;
 }
 
@@ -51,6 +52,13 @@ function settingsItems(policy: SmartCompactPolicySnapshot): SettingItem[] {
       label: "Automatic compaction",
       description: "Run Smart Compact from Pi's automatic compaction lifecycle",
       currentValue: policy.autoTrigger ? ENABLED : DISABLED,
+      values: [ENABLED, DISABLED],
+    },
+    {
+      id: "showStatus",
+      label: "Footer status",
+      description: "Show the smart-compact policy status line in Pi's footer",
+      currentValue: policy.showStatus ? ENABLED : DISABLED,
       values: [ENABLED, DISABLED],
     },
   ];
@@ -91,7 +99,9 @@ export async function showSmartCompactSettings(
         const result =
           id === "agentToolAccess"
             ? policy.update({ agentToolAccess: parseAccessValue(value) }, ctx)
-            : policy.update({ autoTrigger: value === ENABLED }, ctx);
+            : id === "autoTrigger"
+              ? policy.update({ autoTrigger: value === ENABLED }, ctx)
+              : policy.update({ showStatus: value === ENABLED }, ctx);
         if (!result.ok) {
           list.updateValue(id, previousValue(id, previous));
           ctx.ui.notify(result.error, "error");

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -27,6 +27,7 @@ const VALID_THINKING_LEVELS = [
 ] as const;
 const BOOLEAN_KEYS = [
   "autoTrigger",
+  "showStatus",
   "backupEnabled",
   "requireApproval",
   "scrubSecrets",

--- a/test/smart-compact-policy.test.ts
+++ b/test/smart-compact-policy.test.ts
@@ -84,7 +84,12 @@ describe("smart compact runtime policy", () => {
     expect(test.writes).toEqual([
       {
         customType: "smart-compact-policy",
-        data: { version: 2, agentToolAccess: "disabled", autoTrigger: true },
+        data: {
+          version: 2,
+          agentToolAccess: "disabled",
+          autoTrigger: true,
+          showStatus: true,
+        },
       },
     ]);
     expect(test.statuses.at(-1)).toBe("smart-compact: agent hidden · auto on");
@@ -111,6 +116,7 @@ describe("smart compact runtime policy", () => {
       agentToolAccess: "enabled",
       agentToolEnabled: true,
       autoTrigger: false,
+      showStatus: true,
     });
     expect(
       test.active().filter((name) => name === "smart_compact"),
@@ -188,9 +194,34 @@ describe("smart compact runtime policy", () => {
       agentToolAccess: "disabled",
       agentToolEnabled: false,
       autoTrigger: false,
+      showStatus: true,
     });
     expect(test.active()).toEqual(["read", "smart_recall"]);
     expect(test.statuses.at(-1)).toBe("smart-compact: manual only");
+  });
+
+  it("clears the footer status when showStatus is disabled", () => {
+    const test = harness([
+      {
+        type: "custom",
+        customType: "smart-compact-policy",
+        data: {
+          version: 2,
+          agentToolAccess: "disabled",
+          autoTrigger: false,
+          showStatus: false,
+        },
+      },
+    ]);
+    test.policy.restore(test.ctx);
+
+    expect(test.policy.snapshot()).toEqual({
+      agentToolAccess: "disabled",
+      agentToolEnabled: false,
+      autoTrigger: false,
+      showStatus: false,
+    });
+    expect(test.statuses.at(-1)).toBeUndefined();
   });
 
   it("falls back to global defaults when branch state is absent or invalid", () => {
@@ -207,6 +238,7 @@ describe("smart compact runtime policy", () => {
       agentToolAccess: "inherit",
       agentToolEnabled: true,
       autoTrigger: true,
+      showStatus: true,
     });
     expect(test.statuses.at(-1)).toBeUndefined();
   });
@@ -222,6 +254,7 @@ describe("smart compact runtime policy", () => {
       agentToolAccess: "inherit",
       agentToolEnabled: false,
       autoTrigger: true,
+      showStatus: true,
     });
   });
 
@@ -252,6 +285,7 @@ describe("smart compact runtime policy", () => {
       agentToolAccess: "inherit",
       agentToolEnabled: true,
       autoTrigger: true,
+      showStatus: true,
     });
     expect(test.writes).toEqual([]);
   });


### PR DESCRIPTION
## Summary
- `showStatus` config option (default `true`, upstream-safe) permanently controls the footer policy status line; `false` clears the `smart-compact: ...` footer entry via `setStatus(key, undefined)` while the policy stays active
- `/smart-compact settings` gains a "Footer status" enabled/disabled row; branch-scoped like the other policy controls and restored with session state
- Persisted v2 policy entries carry `showStatus` optionally — older entries restore without it and inherit the config default
- Tooling: bun 1.4.0 (packageManager + CI pins), `@types/bun` 1.4.0, `@types/node` 26.3.0, typebox 1.3.19, lockfile peers refreshed

## Verification
- typecheck clean; 909/909 tests incl. new `clears the footer status when showStatus is disabled`
- `compat:pi latest` green against pi 0.84.3; release-audit version-sync green
- Full `release:check` gate runs from `prepublishOnly` at publish time