### PR TITLE
fix: release audit under bun 1.4.0 file: path safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         # CI reproduces local builds deterministically (audit P0 #3).
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
 
       - name: Install dependencies
         # --frozen-lockfile catches accidental drift between bun.lock and
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
 
       - name: Install locked baseline
         run: bun install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Release audit resolves local peer dependencies through in-workspace symlinks, so `release:check` works under Bun 1.4.0's stricter `file:` path safety; toolchain pin moved 1.3.14 → 1.4.0 (#52).
+
 ## [9.5.0] - 2026-08-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pi-smart-compact",
 	"version": "9.5.0",
 	"description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
-	"packageManager": "bun@1.3.14",
+	"packageManager": "bun@1.4.0",
 	"engines": {
 		"node": ">=22.19.0"
 	},

--- a/scripts/release-audit.ts
+++ b/scripts/release-audit.ts
@@ -73,7 +73,12 @@ try {
 
   const peerPaths: Record<string, string> = {};
   for (const peer of Object.keys(sourceManifest.peerDependencies)) {
-    peerPaths[peer] = "file:" + join(root, "node_modules", peer);
+    // Bun >=1.4 refuses file: folder deps whose serialized path escapes the
+    // workspace, so expose each peer as an in-workspace symlink (issue #52).
+    const link = join(workspace, "vendor", peer);
+    mkdirSync(dirname(link), { recursive: true });
+    symlinkSync(join(root, "node_modules", peer), link, "dir");
+    peerPaths[peer] = "file:" + join("vendor", peer);
   }
   writeFileSync(join(workspace, "package.json"), JSON.stringify({
     name: "pi-smart-compact-frozen-smoke",


### PR DESCRIPTION
Fixes #52

## What

Bun 1.4.0's new path-safety check refuses `file:` folder dependencies whose serialized path escapes the install workspace, so `release:audit`'s frozen-install step failed with `refusing to install dependency ... with unsafe folder path` for all four peers. This is deliberate hardening in Bun 1.4 (breaking-changes #28792), not a regression — waiting upstream was not an option.

## Change

- `scripts/release-audit.ts`: peers are now exposed as `workspace/vendor/<peer>` symlinks and declared as `file:vendor/<peer>`, keeping the frozen install in-workspace (same pattern the node-smoke step already uses).
- Unpin the toolchain: `packageManager` and both CI `bun-version`s move `1.3.14` → `1.4.0`.
- CHANGELOG: `[Unreleased]` entry. No version bump — nothing shipped in the tarball changes (`scripts/`, CI, and `packageManager` are not packed).

## Verification

- `bun run release:audit` under **1.4.0**: passed (168 packed files; frozen install and CLIs verified).
- `bun run release:audit` under **1.3.14** (regression check): passed.
- `tsc -p tsconfig.scripts.json` clean; LSP clean.