### PR TITLE
Release 9.6.0 — unified settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ coverage/
 .DS_Store
 
 # Scratch / progress files used by sub-agents and chains
+.pi/
 progress.md
 context.md
 chain-runs/
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,22 @@
 
 ## [Unreleased]
 
+## [9.6.0] - 2026-08-31
+
+### Added
+
+- `/smart-compact settings` is now the unified settings surface for every Smart Compact option. Branch-scoped controls remain separate from global defaults; categorized submenus add model selection plus validated numeric, path, pin, and profile-budget editors.
+- Global settings updates preserve unrelated host configuration and use locked atomic writes. Runtime-owned tool, trigger, footer, and project-memory visibility settings apply immediately; other changes apply to the next operation.
+
+### Changed
+
+- Branch policy entries now persist sparse overrides with per-field reset-to-global behavior while retaining compatibility with earlier policy records.
+- Project-memory tools leave the active tool list when the context graph is disabled and restore only tools hidden by that setting when re-enabled, keeping manual `/tools` choices intact.
+
 ### Fixed
 
+- Settings loading safely handles invalid roots, isolates cached nested values, merges partial profile overrides with built-ins, and shares numeric limits with the TUI to prevent validation drift.
+- Settings locks are owner-token-safe, never steal from a live slow writer, and clean partial initialization artifacts without deleting a successor's lock.
 - Release audit resolves local peer dependencies through in-workspace symlinks, so `release:check` works under Bun 1.4.0's stricter `file:` path safety; toolchain pin moved 1.3.14 → 1.4.0 (#52).
 
 ## [9.5.0] - 2026-08-26

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then run `/smart-compact` for an explainable preflight before anything changes.
 /smart-compact dashboard                            # interactive dashboard
 /smart-compact restore                              # browse and restore backups
 /smart-compact loops                                # manage persisted open loops
-/smart-compact settings                             # agent visibility + automatic mode
+/smart-compact settings                             # unified branch + global settings TUI
 ```
 
 Command controls are consumed only from the left edge. Once note text starts,
@@ -134,7 +134,8 @@ content, and paths. Each project may have at most 500 active manual memories.
 It rejects empty inputs, scrubs configured secrets/PII, deduplicates exact facts,
 and must not be used for guesses, transient progress, secrets, or code that is
 cheap to re-read. Set `contextGraphEnabled` to `false` to disable indexing and
-both tools.
+remove both tools from the active tool set, so they no longer reach the system
+prompt.
 
 ## Usage surfaces
 
@@ -144,7 +145,7 @@ both tools.
 | `session_before_compact` | Auto path. Returns/stages a verification-scored summary under pressure; durable state waits for matching `session_compact`. |
 | `smart_compact` tool | Agent path. Produces a pending summary for Pi's next natural compact; does not compact mid-turn. Can be hidden from the agent. |
 | `/smart-compact loops` | Project-level open-loop manager: resolve/reopen, priority, pin/unpin. |
-| `/smart-compact settings` | TUI policy editor for agent access and automatic compaction. Manual `/smart-compact` always remains available. |
+| `/smart-compact settings` | Unified TUI for branch overrides and every `smartCompact` global setting. Manual `/smart-compact` always remains available. |
 
 ### Manual preflight
 
@@ -405,17 +406,30 @@ Add `smartCompact` to `~/.pi/agent/settings.json`:
 }
 ```
 
-`/smart-compact settings` can hide `smart_compact` from the agent and disable
-automatic compaction independently. Changes apply immediately and are stored in
-the current session branch; navigating the session tree restores that branch's
-last policy. They do not edit `settings.json`. Set `agentToolAccess` to
-`"disabled"` and `autoTrigger` to `false` below for a permanent Smart Compact
-manual-only default. `"inherit"` (the default) respects Pi's `/tools`, host
-allowlists, and other extensions instead of forcing the tool back on. This
-disables Smart Compact's hook participation, not Pi's built-in native compactor.
-Registering the tool internally does not expose it: Pi's active-tool list
-controls the schema
-and prompt guidance visible on the next agent turn.
+`/smart-compact settings` separates **Current branch** overrides from **Global**
+defaults. The three branch controls (agent access, automatic compaction, and
+footer status) are stored in session history; session-tree navigation restores
+that branch's sparse overrides. Choosing `global` removes an override. Global
+categories persist every other setting under `smartCompact` in
+`~/.pi/agent/settings.json` while preserving unrelated Pi and extension keys.
+
+Agent access, automatic compaction, footer status, and project-memory tool
+exposure apply immediately from the TUI without an extension reload. Active
+tool schemas and prompt guidance update on the next agent turn. Mode, model,
+budget, safety, path, profile, and monitoring changes apply to the next
+compaction or indexing operation; a run already in progress keeps its starting
+configuration. `"inherit"` respects Pi's `/tools`, host allowlists, and other
+extensions instead of forcing `smart_compact` back on. Manual
+`/smart-compact` remains available even when agent access is disabled.
+
+Edits made externally to `settings.json` are detected by normal operations via
+the config mtime cache. Because external writes do not emit a Pi UI event,
+active tool/footer state is refreshed on `/reload` or the next session restore;
+no filesystem watcher is installed.
+
+Settings writes fail closed behind `~/.pi/agent/settings.json.lock`. If Pi is
+terminated during a write and leaves that directory behind, verify no Pi
+process is writing settings, then remove the stale lock directory manually.
 
 `native-hook` preserves the existing passive behavior. The opt-in proactive
 strategy is:
@@ -578,12 +592,13 @@ cancelled runs.
 
 Default artifacts live under `~/.pi/agent/`. Smart Compact normalizes the
 private directories it creates to `0700` and its files to `0600`; a custom
-`backupDir` receives the same protection. `settings.json` remains host-owned
-and read-only to the extension.
+`backupDir` receives the same protection. `settings.json` remains host-owned;
+Smart Compact only updates its own `smartCompact` section through the settings
+TUI, using a shared lock and atomic replacement while preserving other keys.
 
 | Path | Purpose |
 | --- | --- |
-| `settings.json` | Configuration (read only) |
+| `settings.json` | Host configuration; the settings TUI can update `smartCompact` defaults |
 | `compact-backups/` | Full selected pre-prune conversation backups, scrubbed before write and retention-pruned |
 | `.cache/compact-extraction-<session>.json` | Incremental extraction cache |
 | `.cache/compact-metrics.jsonl` | Tail-retained metrics log; 5 MiB cap |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-smart-compact",
-	"version": "9.5.0",
+	"version": "9.6.0",
 	"description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
 	"packageManager": "bun@1.4.0",
 	"engines": {

--- a/src/app/global-settings-runtime.ts
+++ b/src/app/global-settings-runtime.ts
@@ -1,0 +1,21 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ContextToolAvailability } from "./register-context-tools.ts";
+import type { SmartCompactPolicy } from "./smart-compact-policy.ts";
+import type { GlobalConfigPath } from "../utils/config.ts";
+
+const POLICY_PATHS = new Set<GlobalConfigPath>([
+  "agentToolAccess",
+  "autoTrigger",
+  "showStatus",
+]);
+
+/** Apply the small subset of global settings that own live host state. */
+export function applyGlobalSettingRuntime(
+  path: GlobalConfigPath,
+  ctx: ExtensionContext,
+  policy: SmartCompactPolicy,
+  contextTools: ContextToolAvailability,
+): void {
+  if (POLICY_PATHS.has(path)) policy.restore(ctx);
+  if (path === "contextGraphEnabled") contextTools.apply();
+}

--- a/src/app/register-context-tools.ts
+++ b/src/app/register-context-tools.ts
@@ -59,7 +59,15 @@ export function resolveGraphScope(
   };
 }
 
-export function registerContextTools(pi: ExtensionAPI): void {
+export interface ContextToolAvailability {
+  apply(): void;
+}
+
+export function registerContextTools(
+  pi: ExtensionAPI,
+): ContextToolAvailability {
+  const availability = createContextToolAvailability(pi);
+
   pi.registerTool({
     name: "smart_recall",
     label: "Smart Recall",
@@ -312,4 +320,56 @@ export function registerContextTools(pi: ExtensionAPI): void {
       }
     },
   });
+
+  availability.apply();
+  pi.on("session_start", availability.apply);
+  return availability;
+}
+
+const CONTEXT_TOOL_NAMES = ["smart_recall", "smart_save_memory"] as const;
+
+function createContextToolAvailability(
+  pi: ExtensionAPI,
+): ContextToolAvailability {
+  const hiddenByConfig = new Set<string>();
+  let disabledByConfig = false;
+
+  return {
+    apply(): void {
+      try {
+        const enabled = loadConfig().contextGraphEnabled;
+        const active = pi.getActiveTools();
+
+        if (!enabled) {
+          const visibleContextTools = CONTEXT_TOOL_NAMES.filter((name) =>
+            active.includes(name),
+          );
+          for (const name of visibleContextTools) hiddenByConfig.add(name);
+          disabledByConfig = true;
+          if (visibleContextTools.length > 0) {
+            pi.setActiveTools(
+              active.filter(
+                (name) =>
+                  !(CONTEXT_TOOL_NAMES as readonly string[]).includes(name),
+              ),
+            );
+          }
+          return;
+        }
+
+        if (disabledByConfig) {
+          const restored = [...hiddenByConfig].filter(
+            (name) => !active.includes(name),
+          );
+          if (restored.length > 0) {
+            pi.setActiveTools([...new Set([...active, ...restored])]);
+          }
+          hiddenByConfig.clear();
+          disabledByConfig = false;
+        }
+      } catch (error) {
+        log.debugError("Context tool availability update failed", error);
+      }
+    },
+  };
 }

--- a/src/app/register-smart-compact-command.ts
+++ b/src/app/register-smart-compact-command.ts
@@ -31,7 +31,10 @@ import {
   writeMetricsDashboard,
 } from "../ui/metrics-report.ts";
 import { showMetricsDashboardUI } from "../ui/metrics-dashboard-overlay.ts";
-import { showSmartCompactSettings } from "../ui/settings-overlay.ts";
+import {
+  GlobalSettingsCoordinator,
+  showSmartCompactSettings,
+} from "../ui/settings-overlay.ts";
 import {
   showBackupViewer,
   showCompactUI,
@@ -46,12 +49,17 @@ import { runSmartCompact } from "./run-smart-compact.ts";
 import type { SessionRunLock } from "./session-run-lock.ts";
 import { parseSmartCompactCommand } from "./smart-compact-input.ts";
 import type { SmartCompactPolicy } from "./smart-compact-policy.ts";
+import type { GlobalConfigPath } from "../utils/config.ts";
 
 interface SmartCompactCommandDependencies {
   pendingRef: PendingSlot;
   runLock: SessionRunLock;
   onNativeApplyError: (runId: string) => boolean;
   policy: SmartCompactPolicy;
+  onGlobalSettingApplied?: (
+    path: GlobalConfigPath,
+    ctx: ExtensionCommandContext,
+  ) => void | Promise<void>;
 }
 
 async function showMetrics(
@@ -293,6 +301,7 @@ export function registerSmartCompactCommand(
   pi: ExtensionAPI,
   dependencies: SmartCompactCommandDependencies,
 ): void {
+  const settingsCoordinator = new GlobalSettingsCoordinator();
   pi.registerCommand("smart-compact", {
     description:
       "EESV smart compaction v" +
@@ -360,7 +369,12 @@ export function registerSmartCompactCommand(
             );
             return;
           }
-          await showSmartCompactSettings(ctx, dependencies.policy);
+        await showSmartCompactSettings(
+          ctx,
+          dependencies.policy,
+          settingsCoordinator,
+          (path) => dependencies.onGlobalSettingApplied?.(path, ctx),
+        );
           return;
         }
         const config = loadConfig();

--- a/src/app/smart-compact-policy.ts
+++ b/src/app/smart-compact-policy.ts
@@ -8,7 +8,7 @@ import * as log from "../utils/logger.ts";
 
 const SMART_COMPACT_TOOL_NAME = "smart_compact";
 const SMART_COMPACT_POLICY_ENTRY = "smart-compact-policy";
-const POLICY_VERSION = 2;
+const POLICY_VERSION = 3;
 const STATUS_KEY = "smart-compact-policy";
 
 type AgentToolAccess = CompactConfig["agentToolAccess"];
@@ -21,15 +21,18 @@ export interface SmartCompactPolicySnapshot {
   showStatus: boolean;
 }
 
-interface DesiredSmartCompactPolicy {
+export interface DesiredSmartCompactPolicy {
   agentToolAccess: AgentToolAccess;
   autoTrigger: boolean;
   showStatus: boolean;
 }
 
-interface PersistedSmartCompactPolicy extends DesiredSmartCompactPolicy {
+interface PersistedSmartCompactPolicy {
   version: typeof POLICY_VERSION;
+  overrides: Partial<DesiredSmartCompactPolicy>;
 }
+
+export type SmartCompactPolicyField = keyof DesiredSmartCompactPolicy;
 
 type SmartCompactPolicyUpdate =
   | { ok: true; policy: SmartCompactPolicySnapshot }
@@ -37,11 +40,16 @@ type SmartCompactPolicyUpdate =
 
 export interface SmartCompactPolicy {
   snapshot(): SmartCompactPolicySnapshot;
+  branchOverrides(): Readonly<Partial<DesiredSmartCompactPolicy>>;
   isAgentToolEnabled(): boolean;
   isAutoTriggerEnabled(): boolean;
   restore(ctx: ExtensionContext): void;
   update(
     patch: Partial<DesiredSmartCompactPolicy>,
+    ctx: ExtensionContext,
+  ): SmartCompactPolicyUpdate;
+  reset(
+    field: SmartCompactPolicyField,
     ctx: ExtensionContext,
   ): SmartCompactPolicyUpdate;
 }
@@ -51,6 +59,34 @@ function persistedPolicy(value: unknown): Partial<DesiredSmartCompactPolicy> | n
   const candidate = value as Record<string, unknown>;
   if (
     candidate.version === POLICY_VERSION &&
+    typeof candidate.overrides === "object" &&
+    candidate.overrides !== null &&
+    !Array.isArray(candidate.overrides)
+  ) {
+    const values = candidate.overrides as Record<string, unknown>;
+    const overrides: Partial<DesiredSmartCompactPolicy> = {};
+    if (values.agentToolAccess !== undefined) {
+      if (
+        values.agentToolAccess !== "inherit" &&
+        values.agentToolAccess !== "enabled" &&
+        values.agentToolAccess !== "disabled"
+      ) {
+        return null;
+      }
+      overrides.agentToolAccess = values.agentToolAccess;
+    }
+    if (values.autoTrigger !== undefined) {
+      if (typeof values.autoTrigger !== "boolean") return null;
+      overrides.autoTrigger = values.autoTrigger;
+    }
+    if (values.showStatus !== undefined) {
+      if (typeof values.showStatus !== "boolean") return null;
+      overrides.showStatus = values.showStatus;
+    }
+    return overrides;
+  }
+  if (
+    candidate.version === 2 &&
     (candidate.agentToolAccess === "inherit" ||
       candidate.agentToolAccess === "enabled" ||
       candidate.agentToolAccess === "disabled") &&
@@ -104,17 +140,23 @@ function statusText(policy: SmartCompactPolicySnapshot): string | undefined {
 }
 
 export function createSmartCompactPolicy(pi: ExtensionAPI): SmartCompactPolicy {
-  let current = configDefaults();
+  let overrides: Partial<DesiredSmartCompactPolicy> = {};
+
+  const desired = (): DesiredSmartCompactPolicy => ({
+    ...configDefaults(),
+    ...overrides,
+  });
 
   const effectiveToolState = (): boolean =>
     pi.getActiveTools().includes(SMART_COMPACT_TOOL_NAME);
 
   const snapshot = (): SmartCompactPolicySnapshot => ({
-    ...current,
+    ...desired(),
     agentToolEnabled: effectiveToolState(),
   });
 
   const apply = (ctx: ExtensionContext): SmartCompactPolicySnapshot => {
+    const current = desired();
     const active = pi.getActiveTools();
     const hasTool = active.includes(SMART_COMPACT_TOOL_NAME);
     if (current.agentToolAccess === "enabled" && !hasTool) {
@@ -129,51 +171,80 @@ export function createSmartCompactPolicy(pi: ExtensionAPI): SmartCompactPolicy {
     return effective;
   };
 
+  const restoreToolMembership = (enabled: boolean): void => {
+    const active = pi.getActiveTools();
+    const hasTool = active.includes(SMART_COMPACT_TOOL_NAME);
+    if (enabled && !hasTool) {
+      pi.setActiveTools([...new Set([...active, SMART_COMPACT_TOOL_NAME])]);
+    } else if (!enabled && hasTool) {
+      pi.setActiveTools(
+        active.filter((name) => name !== SMART_COMPACT_TOOL_NAME),
+      );
+    }
+  };
+
+  const persist = (
+    next: Partial<DesiredSmartCompactPolicy>,
+    ctx: ExtensionContext,
+  ): SmartCompactPolicyUpdate => {
+    const previous = overrides;
+    const previousToolEnabled = effectiveToolState();
+    overrides = next;
+    try {
+      const effective = apply(ctx);
+      pi.appendEntry<PersistedSmartCompactPolicy>(
+        SMART_COMPACT_POLICY_ENTRY,
+        { version: POLICY_VERSION, overrides: { ...overrides } },
+      );
+      return { ok: true, policy: effective };
+    } catch (error) {
+      log.debugError("Smart Compact policy update failed", error);
+      overrides = previous;
+      try {
+        restoreToolMembership(previousToolEnabled);
+      } catch (rollbackError) {
+        log.debugError("Smart Compact policy rollback failed", rollbackError);
+      }
+      const rolledBack = snapshot();
+      const previousDesired = desired();
+      ctx.ui.setStatus(
+        STATUS_KEY,
+        previousDesired.showStatus ? statusText(rolledBack) : undefined,
+      );
+      return {
+        ok: false,
+        policy: rolledBack,
+        error:
+          "Smart Compact settings could not be saved; the previous policy was restored.",
+      };
+    }
+  };
+
   return {
     snapshot,
+    branchOverrides: () => ({ ...overrides }),
     isAgentToolEnabled: effectiveToolState,
-    isAutoTriggerEnabled: () => current.autoTrigger,
+    isAutoTriggerEnabled: () => desired().autoTrigger,
     restore(ctx) {
-      current = configDefaults();
+      overrides = {};
       for (const entry of ctx.sessionManager.getBranch()) {
         if (
           entry.type === "custom" &&
           entry.customType === SMART_COMPACT_POLICY_ENTRY
         ) {
           const restored = persistedPolicy(entry.data);
-          if (restored) current = { ...current, ...restored };
+          if (restored) overrides = restored;
         }
       }
       apply(ctx);
     },
     update(patch, ctx) {
-      const previous = current;
-      const previousActiveTools = pi.getActiveTools();
-      current = { ...current, ...patch };
-      try {
-        const effective = apply(ctx);
-        pi.appendEntry<PersistedSmartCompactPolicy>(
-          SMART_COMPACT_POLICY_ENTRY,
-          { version: POLICY_VERSION, ...current },
-        );
-        return { ok: true, policy: effective };
-      } catch (error) {
-        log.debugError("Smart Compact policy update failed", error);
-        current = previous;
-        try {
-          pi.setActiveTools(previousActiveTools);
-        } catch (rollbackError) {
-          log.debugError("Smart Compact policy rollback failed", rollbackError);
-        }
-        const rolledBack = snapshot();
-        ctx.ui.setStatus(STATUS_KEY, current.showStatus ? statusText(rolledBack) : undefined);
-        return {
-          ok: false,
-          policy: rolledBack,
-          error:
-            "Smart Compact settings could not be saved; the previous policy was restored.",
-        };
-      }
+      return persist({ ...overrides, ...patch }, ctx);
+    },
+    reset(field, ctx) {
+      const next = { ...overrides };
+      delete next[field];
+      return persist(next, ctx);
     },
   };
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "9.5.0";
+export const VERSION = "9.6.0";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.1;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;
@@ -65,6 +65,34 @@ export const PROFILES: Record<CompressionProfile, ProfileConfig> = {
 		batchMaxTokens: 18000,
 	},
 };
+
+export const PROFILE_NUMERIC_BOUNDS = {
+	summaryBudgetTokens: [256, 100_000],
+	keepRecentTokens: [1_000, 500_000],
+	minChunkTokens: [100, 100_000],
+	maxChunkTokens: [500, 200_000],
+	singlePassMaxTokens: [1_000, 500_000],
+	batchMaxTokens: [1_000, 500_000],
+} as const;
+
+export const CONFIG_NUMERIC_LIMITS = {
+	minContextPercent: { min: 0, max: 100, integer: false },
+	autoTriggerTimeoutMs: { min: 1_000, max: 300_000, integer: true },
+	maxLlmCalls: { min: 0, max: 100, integer: true },
+	maxLlmInputTokens: { min: 0, max: 1_000_000, integer: true },
+	codexMaxCallMs: {
+		min: 5_000,
+		max: 300_000,
+		integer: true,
+		zeroOrRange: true,
+	},
+	maxLatencyMs: {
+		min: 5_000,
+		max: 600_000,
+		integer: true,
+		zeroOrRange: true,
+	},
+} as const;
 
 export const DEFAULT_CONFIG = {
 	mode: "auto" as const,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { loadConfig } from "./utils/config.ts";
 import { getProviderCaps, safeContextPercent } from "./utils/tokens.ts";
 import { appendMetricsSnapshot } from "./utils/cache.ts";
 import { runSmartCompact } from "./app/run-smart-compact.ts";
+import { applyGlobalSettingRuntime } from "./app/global-settings-runtime.ts";
 import {
   clearCompactProgress,
   notifyAppliedCompaction,
@@ -188,13 +189,25 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
     }
   };
 
-  registerContextTools(pi);
+  const contextToolAvailability = registerContextTools(pi);
 
   registerSmartCompactCommand(pi, {
     pendingRef,
     runLock: isRunning,
     onNativeApplyError,
     policy,
+    onGlobalSettingApplied(path, ctx) {
+      try {
+        applyGlobalSettingRuntime(
+          path,
+          ctx,
+          policy,
+          contextToolAvailability,
+        );
+      } catch (error) {
+        log.debugError("Smart Compact runtime settings refresh failed", error);
+      }
+    },
   });
 
   pi.on("session_start", (_event, ctx) => {

--- a/src/infra/fs.ts
+++ b/src/infra/fs.ts
@@ -25,7 +25,8 @@
  *    `atomicWriteFile` for new async-friendly callers (background metrics).
  *
  * Lock acquisition is fail-closed: callers never continue an append/trim
- * without ownership. Locks older than 5s are reclaimed with an atomic rename.
+ * without ownership. Locks are never stolen on elapsed time because a live,
+ * slow owner must not overlap a successor.
  */
 
 import fs from "node:fs";
@@ -34,7 +35,6 @@ import path from "node:path";
 import crypto from "node:crypto";
 import * as log from "../utils/logger.ts";
 
-const LOCK_STALE_MS = 5_000;
 const LOCK_RETRY_MS = 25;
 const LOCK_MAX_RETRIES = 80; // ≈2s
 
@@ -64,8 +64,8 @@ export function atomicWriteFileSync(target: string, data: string | Uint8Array): 
   const tmp = tempPath(target);
   try {
     fs.writeFileSync(tmp, data, { mode: 0o600 });
+    fs.chmodSync(tmp, 0o600);
     fs.renameSync(tmp, target);
-    fs.chmodSync(target, 0o600);
   } catch (e) {
     // Clean up the temp file if rename failed — we never want orphans.
     try { fs.unlinkSync(tmp); } catch { /* best effort */ }
@@ -78,8 +78,8 @@ export async function atomicWriteFile(target: string, data: string | Uint8Array)
   const tmp = tempPath(target);
   try {
     await fsp.writeFile(tmp, data, { mode: 0o600 });
+    await fsp.chmod(tmp, 0o600);
     await fsp.rename(tmp, target);
-    await fsp.chmod(target, 0o600);
   } catch (e) {
     try { await fsp.unlink(tmp); } catch { /* best effort */ }
     throw e;
@@ -91,32 +91,40 @@ export async function atomicWriteFile(target: string, data: string | Uint8Array)
  * `mkdir` is atomic on every reasonable filesystem, which is exactly what we
  * need for a multi-process advisory lock without depending on `flock`.
  *
- * If it stays held for longer than LOCK_STALE_MS we assume the owning process
- * crashed and reclaim it. Acquisition errors/timeouts throw, so callers never
- * proceed unlocked. Callers should always release through the returned function.
+ * Acquisition errors/timeouts throw, so callers never proceed unlocked. The
+ * owner token makes release idempotent and prevents an old release callback
+ * from deleting a later owner's lock. Crash leftovers require explicit cleanup;
+ * guessing liveness from lock age would violate mutual exclusion.
  */
 function tryAcquireLock(target: string): (() => void) | null {
   const lockDir = target + ".lock";
-  for (let reclaimAttempt = 0; reclaimAttempt < 2; reclaimAttempt++) {
-    try {
-      fs.mkdirSync(lockDir, { mode: 0o700 });
-      return () => { try { fs.rmdirSync(lockDir); } catch { /* ignore */ } };
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException)?.code !== "EEXIST") {
-        throw new Error("Failed to acquire lock for " + target, { cause: error });
-      }
-      try {
-        const stat = fs.statSync(lockDir);
-        if (Date.now() - stat.mtimeMs <= LOCK_STALE_MS) return null;
-        const stolen = lockDir + ".stale." + process.pid + "." + crypto.randomBytes(4).toString("hex");
-        fs.renameSync(lockDir, stolen);
-        const stolenStat = fs.statSync(stolen);
-        if (Date.now() - stolenStat.mtimeMs > LOCK_STALE_MS) fs.rmdirSync(stolen);
-        else try { fs.renameSync(stolen, lockDir); } catch { /* released */ }
-      } catch { /* lock changed; retry acquisition once */ }
-    }
+  const ownerFile = path.join(lockDir, "owner");
+  const token = process.pid + ":" + crypto.randomBytes(8).toString("hex");
+  try {
+    fs.mkdirSync(lockDir, { mode: 0o700 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "EEXIST") return null;
+    throw new Error("Failed to acquire lock for " + target, { cause: error });
   }
-  return null;
+  try {
+    fs.writeFileSync(ownerFile, token, { mode: 0o600, flag: "wx" });
+  } catch (error) {
+    try {
+      fs.rmSync(lockDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup of an acquisition interrupted before owner write.
+    }
+    throw new Error("Failed to acquire lock for " + target, { cause: error });
+  }
+  return () => {
+    try {
+      if (fs.readFileSync(ownerFile, "utf8") === token) {
+        fs.rmSync(lockDir, { recursive: true });
+      }
+    } catch {
+      // Already released or ownership changed.
+    }
+  };
 }
 
 /** Immediate lock attempt for synchronous best-effort paths; never parks JS. */

--- a/src/ui/settings-complex.ts
+++ b/src/ui/settings-complex.ts
@@ -1,0 +1,589 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import path from "node:path";
+import {
+  Container,
+  type Focusable,
+  Input,
+  Key,
+  matchesKey,
+  type SelectItem,
+  SelectList,
+  type SettingItem,
+  SettingsList,
+  Text,
+} from "@earendil-works/pi-tui";
+import { getSettingsListTheme } from "@earendil-works/pi-coding-agent";
+import {
+  CONFIG_NUMERIC_LIMITS,
+  PROFILE_NUMERIC_BOUNDS,
+  PROFILES,
+} from "../constants.ts";
+import type { CompactConfig, CompressionProfile } from "../types.ts";
+import {
+  type GlobalConfigPath,
+  type GlobalConfigValue,
+  loadConfig,
+  readGlobalConfigValue,
+  writeGlobalConfigValue,
+} from "../utils/config.ts";
+
+export type GlobalConfigWriter = (
+  path: GlobalConfigPath,
+  value: GlobalConfigValue,
+) => Promise<CompactConfig>;
+
+interface InputSetting {
+  id: GlobalConfigPath;
+  label: string;
+  description: string;
+  placeholder: string;
+  parse(input: string): GlobalConfigValue;
+  format(value: GlobalConfigValue): string;
+}
+
+const MODEL_SETTINGS = [
+  {
+    id: "summaryModel",
+    label: "Summary model",
+    description: "Model used for synthesis and verification fallback.",
+  },
+  {
+    id: "segmentationModel",
+    label: "Segmentation model",
+    description: "Optional model used for transcript exploration.",
+  },
+  {
+    id: "verificationModel",
+    label: "Verification model",
+    description: "Optional model used for repair after verification.",
+  },
+] as const satisfies ReadonlyArray<{
+  id: GlobalConfigPath;
+  label: string;
+  description: string;
+}>;
+
+const PROFILE_NAMES = Object.keys(PROFILES) as CompressionProfile[];
+
+function numberParser(options: {
+  min: number;
+  max: number;
+  integer?: boolean;
+  zeroOrRange?: boolean;
+}): (input: string) => number | undefined {
+  return (input) => {
+    const trimmed = input.trim();
+    if (!trimmed) return undefined;
+    const value = Number(trimmed);
+    const inRange = value >= options.min && value <= options.max;
+    if (
+      !Number.isFinite(value) ||
+      (options.integer !== false && !Number.isSafeInteger(value)) ||
+      (!inRange && !(options.zeroOrRange && value === 0))
+    ) {
+      const allowed = options.zeroOrRange
+        ? `0 or ${options.min}–${options.max}`
+        : `${options.min}–${options.max}`;
+      throw new Error(`Enter ${options.integer === false ? "a number" : "an integer"} in ${allowed}.`);
+    }
+    return value;
+  };
+}
+
+function scalarFormat(value: GlobalConfigValue): string {
+  return value === undefined ? "default" : String(value);
+}
+
+const LIMIT_SETTINGS: readonly InputSetting[] = [
+  {
+    id: "minContextPercent",
+    label: "Minimum context percent",
+    description: "Auto compaction starts at or above this context usage.",
+    placeholder: "0–100; blank uses default",
+    parse: numberParser(CONFIG_NUMERIC_LIMITS.minContextPercent),
+    format: scalarFormat,
+  },
+  {
+    id: "autoTriggerTimeoutMs",
+    label: "Auto-trigger timeout",
+    description: "Maximum host auto-compaction time in milliseconds.",
+    placeholder: "1000–300000; blank uses default",
+    parse: numberParser(CONFIG_NUMERIC_LIMITS.autoTriggerTimeoutMs),
+    format: scalarFormat,
+  },
+  {
+    id: "maxLlmCalls",
+    label: "Maximum LLM calls",
+    description: "Zero uses the selected mode's call cap.",
+    placeholder: "0–100; blank uses default",
+    parse: numberParser(CONFIG_NUMERIC_LIMITS.maxLlmCalls),
+    format: scalarFormat,
+  },
+  {
+    id: "maxLlmInputTokens",
+    label: "Maximum LLM input tokens",
+    description: "Zero uses the selected mode's token cap.",
+    placeholder: "0–1000000; blank uses default",
+    parse: numberParser(CONFIG_NUMERIC_LIMITS.maxLlmInputTokens),
+    format: scalarFormat,
+  },
+  {
+    id: "codexMaxCallMs",
+    label: "Codex call watchdog",
+    description: "Zero derives the per-call watchdog automatically.",
+    placeholder: "0 or 5000–300000; blank uses default",
+    parse: numberParser(CONFIG_NUMERIC_LIMITS.codexMaxCallMs),
+    format: scalarFormat,
+  },
+  {
+    id: "maxLatencyMs",
+    label: "Pipeline latency limit",
+    description: "Zero disables the overall pipeline deadline.",
+    placeholder: "0 or 5000–600000; blank uses default",
+    parse: numberParser(CONFIG_NUMERIC_LIMITS.maxLatencyMs),
+    format: scalarFormat,
+  },
+];
+
+const PATH_SETTINGS: readonly InputSetting[] = [
+  {
+    id: "backupDir",
+    label: "Backup directory",
+    description: "Directory for recovery Markdown files.",
+    placeholder: "Absolute path; blank uses default",
+    parse(input) {
+      const value = input.trim();
+      if (!value) return undefined;
+      if (value.includes("\0") || /[\r\n]/.test(value)) {
+        throw new Error("Backup directory must be a single valid path.");
+      }
+      if (!path.isAbsolute(value)) {
+        throw new Error("Backup directory must be an absolute path.");
+      }
+      return value;
+    },
+    format: scalarFormat,
+  },
+  {
+    id: "pinPaths",
+    label: "Pinned paths",
+    description: "Comma-separated file paths that summaries must preserve.",
+    placeholder: "src/api.ts, docs/design.md; blank clears",
+    parse(input) {
+      const trimmed = input.trim();
+      if (!trimmed) return undefined;
+      const paths = trimmed
+        .split(/[,\n]/)
+        .map((value) => value.trim())
+        .filter(Boolean);
+      if (paths.some((value) => value.includes("\0"))) {
+        throw new Error("Pinned paths cannot contain NUL characters.");
+      }
+      return [...new Set(paths)];
+    },
+    format(value: GlobalConfigValue) {
+      return value === undefined
+        ? "default"
+        : Array.isArray(value)
+          ? value.join(", ") || "none"
+          : String(value);
+    },
+  },
+];
+
+const PROFILE_FIELDS = [
+  ["summaryBudgetTokens", "Summary budget"],
+  ["keepRecentTokens", "Recent raw tail"],
+  ["minChunkTokens", "Minimum chunk"],
+  ["maxChunkTokens", "Maximum chunk"],
+  ["singlePassMaxTokens", "Single-pass limit"],
+  ["batchMaxTokens", "Batch limit"],
+] as const;
+
+function profileSettings(profile: CompressionProfile): InputSetting[] {
+  return PROFILE_FIELDS.map(([key, label]) => {
+    const [min, max] = PROFILE_NUMERIC_BOUNDS[key];
+    return {
+      id: `profiles.${profile}.${key}` as GlobalConfigPath,
+      label,
+      description: `${profile} profile token budget; related chunk bounds must remain consistent.`,
+      placeholder: `${min}–${max}; blank uses built-in`,
+      parse: numberParser({ min, max }),
+      format: scalarFormat,
+    };
+  });
+}
+
+function effectiveValue(
+  config: CompactConfig,
+  id: GlobalConfigPath,
+): GlobalConfigValue {
+  const parts = id.split(".");
+  if (parts[0] !== "profiles") {
+    return config[id as keyof CompactConfig] as GlobalConfigValue;
+  }
+  const [, profile, key] = parts as [
+    "profiles",
+    CompressionProfile,
+    keyof CompactConfig["profiles"][CompressionProfile],
+  ];
+  return config.profiles[profile][key];
+}
+
+class InputSettingEditor extends Container implements Focusable {
+  private readonly input = new Input();
+  private readonly status = new Text("", 0, 0);
+  private saving = false;
+  private pending: Promise<void> = Promise.resolve();
+
+  get focused(): boolean {
+    return this.input.focused;
+  }
+
+  set focused(value: boolean) {
+    this.input.focused = value;
+  }
+
+  constructor(
+    setting: InputSetting,
+    initial: string,
+    private readonly requestRender: () => void,
+    private readonly save: (value: GlobalConfigValue) => Promise<void>,
+    private readonly done: () => void,
+  ) {
+    super();
+    this.addChild(new Text(setting.label, 0, 0));
+    this.addChild(new Text(setting.description, 0, 0));
+    this.addChild(new Text(`Hint: ${setting.placeholder}`, 0, 0));
+    this.addChild(new Text("", 0, 0));
+    this.input.setValue(initial);
+    this.input.handleInput("\x1b[F");
+    this.input.onSubmit = (value) => {
+      if (this.saving) return;
+      let parsed: GlobalConfigValue;
+      try {
+        parsed = setting.parse(value);
+      } catch (error) {
+        this.status.setText(error instanceof Error ? error.message : String(error));
+        this.requestRender();
+        return;
+      }
+      this.saving = true;
+      this.status.setText("Saving…");
+      this.requestRender();
+      this.pending = this.save(parsed)
+        .then(() => this.done())
+        .catch((error) => {
+          this.saving = false;
+          this.status.setText(
+            error instanceof Error ? error.message : String(error),
+          );
+          this.requestRender();
+        });
+    };
+    this.input.onEscape = () => {
+      if (!this.saving) this.done();
+    };
+    this.addChild(this.input);
+    this.addChild(new Text("", 0, 0));
+    this.addChild(this.status);
+    this.addChild(new Text("Enter save · Esc cancel", 0, 0));
+  }
+
+  handleInput(data: string): void {
+    this.input.handleInput(data);
+    this.requestRender();
+  }
+
+  settled(): Promise<void> {
+    return this.pending;
+  }
+}
+
+interface ModelChoice extends SelectItem {
+  settingValue: string;
+}
+
+class ModelSettingEditor extends Container implements Focusable {
+  private readonly search = new Input();
+  private readonly list: SelectList;
+  private readonly status = new Text("", 0, 0);
+  private saving = false;
+  private pending: Promise<void> = Promise.resolve();
+
+  get focused(): boolean {
+    return this.search.focused;
+  }
+
+  set focused(value: boolean) {
+    this.search.focused = value;
+  }
+
+  constructor(
+    models: ModelChoice[],
+    selectedValue: string,
+    private readonly requestRender: () => void,
+    save: (value: string) => Promise<void>,
+    done: () => void,
+  ) {
+    super();
+    this.addChild(new Text("Search provider/model", 0, 0));
+    this.addChild(this.search);
+    this.addChild(new Text("", 0, 0));
+    this.list = new SelectList(models, 10, {
+      selectedPrefix: (text) => text,
+      selectedText: (text) => text,
+      description: (text) => text,
+      scrollInfo: (text) => text,
+      noMatch: (text) => text,
+    });
+    const selectedIndex = models.findIndex(
+      (item) => item.settingValue === selectedValue,
+    );
+    this.list.setSelectedIndex(Math.max(0, selectedIndex));
+    this.list.onSelect = (item) => {
+      if (this.saving) return;
+      this.saving = true;
+      this.status.setText("Saving…");
+      this.requestRender();
+      const selected = models.find((candidate) => candidate.value === item.value);
+      if (!selected) return;
+      this.pending = save(selected.settingValue)
+        .then(done)
+        .catch((error) => {
+          this.saving = false;
+          this.status.setText(
+            error instanceof Error ? error.message : String(error),
+          );
+          this.requestRender();
+        });
+    };
+    this.list.onCancel = () => {
+      if (!this.saving) done();
+    };
+    this.addChild(this.list);
+    this.addChild(this.status);
+    this.addChild(new Text("Type to filter · Enter select · Esc cancel", 0, 0));
+  }
+
+  handleInput(data: string): void {
+    if (
+      matchesKey(data, Key.up) ||
+      matchesKey(data, Key.down) ||
+      matchesKey(data, Key.enter) ||
+      matchesKey(data, Key.escape)
+    ) {
+      this.list.handleInput(data);
+    } else {
+      this.search.handleInput(data);
+      this.list.setFilter(this.search.getValue());
+    }
+    this.requestRender();
+  }
+
+  settled(): Promise<void> {
+    return this.pending;
+  }
+}
+
+function inputSettingsList(
+  settings: readonly InputSetting[],
+  requestRender: () => void,
+  done: () => void,
+  writeConfig: GlobalConfigWriter,
+): SettingsList {
+  const config = loadConfig();
+  const items: SettingItem[] = settings.map((setting) => {
+    const override = readGlobalConfigValue(setting.id);
+    const item: SettingItem = {
+      id: setting.id,
+      label: setting.label,
+      description: `${setting.description} Effective global value: ${setting.format(effectiveValue(config, setting.id))}.`,
+      currentValue: setting.format(override),
+    };
+    item.submenu = (_current, close) => {
+      const persisted = readGlobalConfigValue(setting.id);
+      return new InputSettingEditor(
+        setting,
+        persisted === undefined
+          ? ""
+          : Array.isArray(persisted)
+            ? persisted.join(", ")
+            : String(persisted),
+        requestRender,
+        async (value) => {
+          const effective = await writeConfig(setting.id, value);
+          item.currentValue = setting.format(value);
+          item.description = `${setting.description} Effective global value: ${setting.format(effectiveValue(effective, setting.id))}.`;
+        },
+        close,
+      );
+    };
+    return item;
+  });
+  return new SettingsList(
+    items,
+    9,
+    getSettingsListTheme(),
+    () => {},
+    done,
+  );
+}
+
+export function modelSettingsItems(
+  ctx: ExtensionCommandContext,
+  requestRender: () => void,
+  writeConfig: GlobalConfigWriter = writeGlobalConfigValue,
+): SettingItem[] {
+  const config = loadConfig();
+  return MODEL_SETTINGS.map((setting) => {
+    const override = readGlobalConfigValue(setting.id);
+    const current = typeof override === "string" ? override : "default";
+    const item: SettingItem = {
+      id: setting.id,
+      label: setting.label,
+      description: `${setting.description} Effective global value: ${String(config[setting.id])}.`,
+      currentValue: current,
+    };
+    item.submenu = (_value, close) => {
+      const persisted = readGlobalConfigValue(setting.id);
+      const selectedValue =
+        typeof persisted === "string" ? persisted : "default";
+      const effective = loadConfig();
+      item.currentValue = selectedValue;
+      item.description = `${setting.description} Effective global value: ${String(effective[setting.id])}.`;
+      const available: ModelChoice[] = ctx.modelRegistry
+        .getAvailable()
+        .map((model) => ({
+          value: `${model.provider}/${model.id} — ${model.name}`,
+          settingValue: `${model.provider}/${model.id}`,
+          label: `${model.provider}/${model.id}`,
+          description: model.name,
+        }))
+        .sort((left, right) => left.value.localeCompare(right.value));
+      const choices: ModelChoice[] = [
+        {
+          value: "default — use active session model",
+          settingValue: "default",
+          label: "default",
+          description: "Remove the global model override",
+        },
+        ...available,
+      ];
+      if (
+        selectedValue !== "default" &&
+        !choices.some((candidate) => candidate.settingValue === selectedValue)
+      ) {
+        choices.splice(1, 0, {
+          value: selectedValue,
+          settingValue: selectedValue,
+          label: selectedValue,
+          description: "Configured model is currently unavailable",
+        });
+      }
+      return new ModelSettingEditor(
+        choices,
+        selectedValue,
+        requestRender,
+        async (selected) => {
+          const effective = await writeConfig(
+            setting.id,
+            selected === "default" ? undefined : selected,
+          );
+          item.currentValue = selected;
+          item.description = `${setting.description} Effective global value: ${String(effective[setting.id])}.`;
+        },
+        close,
+      );
+    };
+    return item;
+  });
+}
+
+export function complexSettingsCategories(
+  ctx: ExtensionCommandContext,
+  requestRender: () => void,
+  writeConfig: GlobalConfigWriter = writeGlobalConfigValue,
+): SettingItem[] {
+  return [
+    {
+      id: "models",
+      label: "Global models",
+      description: "Stage-specific model routing",
+      currentValue: "3 settings",
+      submenu: (_value, done) =>
+        new SettingsList(
+          modelSettingsItems(ctx, requestRender, writeConfig),
+          7,
+          getSettingsListTheme(),
+          () => {},
+          done,
+        ),
+    },
+    {
+      id: "limits",
+      label: "Global limits & performance",
+      description: "Context threshold, call budgets, and timeouts",
+      currentValue: "6 settings",
+      submenu: (_value, done) =>
+        inputSettingsList(
+          LIMIT_SETTINGS,
+          requestRender,
+          done,
+          writeConfig,
+        ),
+    },
+    {
+      id: "paths",
+      label: "Global paths",
+      description: "Backup directory and pinned summary paths",
+      currentValue: "2 settings",
+      submenu: (_value, done) =>
+        inputSettingsList(
+          PATH_SETTINGS,
+          requestRender,
+          done,
+          writeConfig,
+        ),
+    },
+    {
+      id: "profiles",
+      label: "Global profile budgets",
+      description: "Advanced token-budget tuning for each profile",
+      currentValue: "3 profiles",
+      submenu: (_value, done) => {
+        const profiles: SettingItem[] = PROFILE_NAMES.map((profile) => ({
+          id: profile,
+          label: profile,
+          description: `Six token-budget settings for the ${profile} profile.`,
+          currentValue: "6 settings",
+          submenu: (_current, close) =>
+            inputSettingsList(
+              profileSettings(profile),
+              requestRender,
+              close,
+              writeConfig,
+            ),
+        }));
+        return new SettingsList(
+          profiles,
+          7,
+          getSettingsListTheme(),
+          () => {},
+          done,
+        );
+      },
+    },
+  ];
+}
+
+export function complexConfigPaths(): GlobalConfigPath[] {
+  return [
+    ...MODEL_SETTINGS.map((setting) => setting.id),
+    ...LIMIT_SETTINGS.map((setting) => setting.id),
+    ...PATH_SETTINGS.map((setting) => setting.id),
+    ...PROFILE_NAMES.flatMap((profile) =>
+      profileSettings(profile).map((setting) => setting.id),
+    ),
+  ];
+}

--- a/src/ui/settings-overlay.ts
+++ b/src/ui/settings-overlay.ts
@@ -3,80 +3,683 @@ import {
   type ExtensionCommandContext,
 } from "@earendil-works/pi-coding-agent";
 import {
+  type Component,
   Container,
-  type SettingItem,
+  type Focusable,
   SettingsList,
+  type SettingItem,
   Text,
 } from "@earendil-works/pi-tui";
+import {
+  loadConfig,
+  readGlobalConfigValue,
+  type GlobalConfigPath,
+  type GlobalConfigValue,
+  writeGlobalConfigValue,
+} from "../utils/config.ts";
+import type { CompactConfig } from "../types.ts";
+import {
+  complexSettingsCategories,
+  type GlobalConfigWriter,
+} from "./settings-complex.ts";
 import type {
   SmartCompactPolicy,
+  SmartCompactPolicyField,
   SmartCompactPolicySnapshot,
 } from "../app/smart-compact-policy.ts";
 
-const INHERIT = "host default";
-const ENABLED = "enabled";
-const DISABLED = "disabled";
-
-function accessValue(policy: SmartCompactPolicySnapshot): string {
-  return policy.agentToolAccess === "inherit"
-    ? INHERIT
-    : policy.agentToolAccess;
+function enabled(value: boolean): "enabled" | "disabled" {
+  return value ? "enabled" : "disabled";
 }
 
-function parseAccessValue(
-  value: string,
-): SmartCompactPolicySnapshot["agentToolAccess"] {
-  return value === INHERIT
-    ? "inherit"
-    : (value as SmartCompactPolicySnapshot["agentToolAccess"]);
+interface GlobalChoiceSetting {
+  id: GlobalConfigPath;
+  label: string;
+  description: string;
+  values: readonly GlobalConfigValue[];
 }
 
-function previousValue(id: string, policy: SmartCompactPolicySnapshot): string {
-  if (id === "agentToolAccess") return accessValue(policy);
-  if (id === "showStatus") return policy.showStatus ? ENABLED : DISABLED;
-  return policy.autoTrigger ? ENABLED : DISABLED;
+type GlobalChoiceGroup =
+  | "behavior"
+  | "reasoning"
+  | "safety"
+  | "advanced";
+
+type GlobalSettingWriter = typeof updateGlobalChoiceSetting;
+export type GlobalSettingApplied = (
+  path: GlobalConfigPath,
+  config: CompactConfig,
+) => void | Promise<void>;
+
+interface GlobalSettingState {
+  display: string;
+  config?: CompactConfig;
 }
 
-function settingsItems(policy: SmartCompactPolicySnapshot): SettingItem[] {
-  return [
+export class GlobalSettingsCoordinator {
+  private queue: Promise<void> = Promise.resolve();
+  private readonly confirmed = new Map<string, string>();
+  private confirmedConfig: CompactConfig | undefined;
+  private readonly pending = new Map<
+    string,
+    { revision: number; display: string }
+  >();
+  private readonly listeners = new Map<
+    string,
+    Set<(state: GlobalSettingState) => void>
+  >();
+
+  constructor(
+    private readonly writer: GlobalSettingWriter = updateGlobalChoiceSetting,
+  ) {}
+
+  display(id: GlobalConfigPath): string {
+    return (
+      this.pending.get(id)?.display ??
+      choiceDisplay(readGlobalConfigValue(id))
+    );
+  }
+
+  subscribe(
+    ids: readonly GlobalConfigPath[],
+    listener: (id: GlobalConfigPath, state: GlobalSettingState) => void,
+  ): () => void {
+    const registrations: Array<[
+      GlobalConfigPath,
+      (state: GlobalSettingState) => void,
+    ]> = [];
+    for (const id of ids) {
+      const callbacks = this.listeners.get(id) ?? new Set();
+      const callback = (state: GlobalSettingState) => listener(id, state);
+      callbacks.add(callback);
+      this.listeners.set(id, callbacks);
+      registrations.push([id, callback]);
+    }
+    return () => {
+      for (const [id, callback] of registrations) {
+        const callbacks = this.listeners.get(id);
+        callbacks?.delete(callback);
+        if (callbacks?.size === 0) this.listeners.delete(id);
+      }
+    };
+  }
+
+  submit(
+    group: GlobalChoiceGroup,
+    id: GlobalConfigPath,
+    display: string,
+    onError: (message: string) => void,
+    onApplied: GlobalSettingApplied = () => {},
+  ): void {
+    if (this.pending.size === 0) this.confirmedConfig = loadConfig();
+    if (!this.pending.has(id)) {
+      this.confirmed.set(id, choiceDisplay(readGlobalConfigValue(id)));
+    }
+    const revision = (this.pending.get(id)?.revision ?? 0) + 1;
+    this.pending.set(id, { revision, display });
+    this.queue = this.queue.then(async () => {
+      try {
+        const config = await this.writer(group, id, display);
+        await onApplied(id, config);
+        this.confirmed.set(id, display);
+        this.confirmedConfig = config;
+        if (this.pending.get(id)?.revision === revision) {
+          this.pending.delete(id);
+          this.emit(id, { display, config });
+        }
+      } catch (error) {
+        onError(error instanceof Error ? error.message : String(error));
+        if (this.pending.get(id)?.revision === revision) {
+          this.pending.delete(id);
+          this.emit(id, {
+            display: this.confirmed.get(id) ?? "default",
+            config: this.confirmedConfig,
+          });
+        }
+      }
+    });
+  }
+
+  settled(): Promise<void> {
+    return this.queue;
+  }
+
+  private emit(id: string, state: GlobalSettingState): void {
+    for (const listener of this.listeners.get(id) ?? []) listener(state);
+  }
+}
+
+const BOOLEAN_VALUES = [true, false] as const;
+const THINKING_VALUES = [
+  null,
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+
+const GLOBAL_CHOICE_SETTINGS: Record<
+  GlobalChoiceGroup,
+  readonly GlobalChoiceSetting[]
+> = {
+  behavior: [
+    {
+      id: "mode",
+      label: "Compaction mode",
+      description: "Default compaction strategy.",
+      values: ["auto", "fast", "balanced", "thorough"],
+    },
+    {
+      id: "profile",
+      label: "Compression profile",
+      description: "Legacy detail-budget profile.",
+      values: ["light", "balanced", "aggressive"],
+    },
     {
       id: "agentToolAccess",
-      label: "Agent access",
-      description:
-        "Inherit Pi's tool selection, or explicitly enable/disable smart_compact",
-      currentValue: accessValue(policy),
-      values: [INHERIT, ENABLED, DISABLED],
+      label: "Agent tool access",
+      description: "Global default for agent-visible smart_compact access.",
+      values: ["inherit", "enabled", "disabled"],
     },
     {
       id: "autoTrigger",
       label: "Automatic compaction",
-      description: "Run Smart Compact from Pi's automatic compaction lifecycle",
-      currentValue: policy.autoTrigger ? ENABLED : DISABLED,
-      values: [ENABLED, DISABLED],
+      description: "Global default for pressure-triggered compaction.",
+      values: BOOLEAN_VALUES,
     },
     {
       id: "showStatus",
       label: "Footer status",
-      description: "Show the smart-compact policy status line in Pi's footer",
-      currentValue: policy.showStatus ? ENABLED : DISABLED,
-      values: [ENABLED, DISABLED],
+      description: "Global default for the Smart Compact footer indicator.",
+      values: BOOLEAN_VALUES,
+    },
+    {
+      id: "autoTriggerStrategy",
+      label: "Trigger strategy",
+      description: "Host-native hook or settled-turn triggering.",
+      values: ["native-hook", "settled"],
+    },
+  ],
+  reasoning: [
+    {
+      id: "summaryThinkingLevel",
+      label: "Summary thinking",
+      description: "Thinking level for synthesis and repair.",
+      values: THINKING_VALUES,
+    },
+    {
+      id: "segmentationThinkingLevel",
+      label: "Segmentation thinking",
+      description: "Thinking level for transcript segmentation.",
+      values: THINKING_VALUES,
+    },
+  ],
+  safety: [
+    {
+      id: "backupEnabled",
+      label: "Backups",
+      description: "Write a recovery backup before applying a compacted summary.",
+      values: BOOLEAN_VALUES,
+    },
+    {
+      id: "requireApproval",
+      label: "Require approval",
+      description: "Ask before applying manual compaction output.",
+      values: BOOLEAN_VALUES,
+    },
+    {
+      id: "scrubSecrets",
+      label: "Scrub secrets",
+      description: "Redact likely credentials before model calls and memory writes.",
+      values: BOOLEAN_VALUES,
+    },
+    {
+      id: "scrubPii",
+      label: "Scrub PII",
+      description: "Redact email, phone, and payment-card shaped data.",
+      values: BOOLEAN_VALUES,
+    },
+    {
+      id: "contextGraphEnabled",
+      label: "Project memory",
+      description: "Index project context and expose recall/save tools.",
+      values: BOOLEAN_VALUES,
+    },
+  ],
+  advanced: [
+    {
+      id: "focusWeighting",
+      label: "Focus weighting",
+      description: "Steer synthesis toward the current task focus.",
+      values: BOOLEAN_VALUES,
+    },
+    {
+      id: "zeroCallEnabled",
+      label: "Zero-call fast path",
+      description: "Allow deterministic compaction without an LLM call.",
+      values: BOOLEAN_VALUES,
+    },
+    {
+      id: "telemetryChannel",
+      label: "Telemetry channel",
+      description: "Tag local metrics as stable or canary.",
+      values: ["stable", "canary"],
+    },
+    {
+      id: "adaptiveDamageFeedback",
+      label: "Adaptive damage feedback",
+      description: "Increase preservation budgets using prior damage signals.",
+      values: BOOLEAN_VALUES,
+    },
+    {
+      id: "onlineDamageMonitor",
+      label: "Online damage monitor",
+      description: "Monitor confirmed compactions for preservation damage.",
+      values: BOOLEAN_VALUES,
+    },
+  ],
+};
+
+const GLOBAL_CHOICE_CATEGORIES: ReadonlyArray<{
+  group: GlobalChoiceGroup;
+  label: string;
+  description: string;
+}> = [
+  {
+    group: "behavior",
+    label: "Global behavior",
+    description: "Mode, profile, automation, and agent defaults",
+  },
+  {
+    group: "reasoning",
+    label: "Global reasoning",
+    description: "Thinking-level defaults",
+  },
+  {
+    group: "safety",
+    label: "Global safety & storage",
+    description: "Backups, approval, scrubbing, and project memory",
+  },
+  {
+    group: "advanced",
+    label: "Global advanced",
+    description: "Focus, fast path, telemetry, and damage monitoring",
+  },
+];
+
+function choiceDisplay(value: GlobalConfigValue): string {
+  if (value === undefined) return "default";
+  if (value === null) return "provider default";
+  if (typeof value === "boolean") return enabled(value);
+  return String(value);
+}
+
+function choiceValue(
+  setting: GlobalChoiceSetting,
+  display: string,
+): GlobalConfigValue {
+  if (display === "default") return undefined;
+  const value = setting.values.find(
+    (candidate) => choiceDisplay(candidate) === display,
+  );
+  if (value === undefined) {
+    throw new Error(`Invalid value for ${setting.id}: ${display}`);
+  }
+  return value;
+}
+
+function effectiveChoiceDescription(
+  setting: GlobalChoiceSetting,
+  config: CompactConfig,
+): string {
+  const effective = config[
+    setting.id as keyof CompactConfig
+  ] as GlobalConfigValue;
+  return `${setting.description} Effective global value: ${choiceDisplay(effective)}.`;
+}
+
+export function globalChoiceSettingsItems(
+  group: GlobalChoiceGroup,
+  config: CompactConfig,
+  coordinator?: GlobalSettingsCoordinator,
+): SettingItem[] {
+  return GLOBAL_CHOICE_SETTINGS[group].map((setting) => ({
+    id: setting.id,
+    label: setting.label,
+    description: effectiveChoiceDescription(setting, config),
+    currentValue:
+      coordinator?.display(setting.id) ??
+      choiceDisplay(readGlobalConfigValue(setting.id)),
+    values: ["default", ...setting.values.map(choiceDisplay)],
+  }));
+}
+
+export async function updateGlobalChoiceSetting(
+  group: GlobalChoiceGroup,
+  id: string,
+  display: string,
+): Promise<CompactConfig> {
+  const setting = GLOBAL_CHOICE_SETTINGS[group].find(
+    (candidate) => candidate.id === id,
+  );
+  if (!setting) throw new Error(`Unknown global choice setting: ${id}`);
+  return writeGlobalConfigValue(setting.id, choiceValue(setting, display));
+}
+
+function effectiveDescription(
+  field: SmartCompactPolicyField,
+  policy: SmartCompactPolicySnapshot,
+): string {
+  return field === "agentToolAccess"
+    ? `Effective tool state: ${enabled(policy.agentToolEnabled)}`
+    : `Effective value: ${enabled(policy[field])}`;
+}
+
+export function sessionSettingsItems(
+  policy: SmartCompactPolicy,
+): SettingItem[] {
+  const current = policy.snapshot();
+  const overrides = policy.branchOverrides();
+  return [
+    {
+      id: "agentToolAccess",
+      label: "Agent access",
+      description: effectiveDescription("agentToolAccess", current),
+      currentValue: overrides.agentToolAccess ?? "global",
+      values: ["global", "inherit", "enabled", "disabled"],
+    },
+    {
+      id: "autoTrigger",
+      label: "Automatic compaction",
+      description: effectiveDescription("autoTrigger", current),
+      currentValue:
+        overrides.autoTrigger === undefined
+          ? "global"
+          : enabled(overrides.autoTrigger),
+      values: ["global", "enabled", "disabled"],
+    },
+    {
+      id: "showStatus",
+      label: "Footer status",
+      description: effectiveDescription("showStatus", current),
+      currentValue:
+        overrides.showStatus === undefined
+          ? "global"
+          : enabled(overrides.showStatus),
+      values: ["global", "enabled", "disabled"],
     },
   ];
 }
 
-/** Session/branch-scoped policy editor. Manual `/smart-compact` always remains available. */
+function policyField(id: string): SmartCompactPolicyField {
+  switch (id) {
+    case "agentToolAccess":
+    case "autoTrigger":
+    case "showStatus":
+      return id;
+    default:
+      throw new Error(`Unknown session setting: ${id}`);
+  }
+}
+
+export function updateSessionSetting(
+  policy: SmartCompactPolicy,
+  ctx: ExtensionCommandContext,
+  id: string,
+  value: string,
+) {
+  const field = policyField(id);
+  if (value === "global") return policy.reset(field, ctx);
+  switch (field) {
+    case "agentToolAccess":
+      if (value !== "inherit" && value !== "enabled" && value !== "disabled") {
+        throw new Error(`Invalid agent access value: ${value}`);
+      }
+      return policy.update({ agentToolAccess: value }, ctx);
+    case "autoTrigger":
+      return policy.update({ autoTrigger: value === "enabled" }, ctx);
+    case "showStatus":
+      return policy.update({ showStatus: value === "enabled" }, ctx);
+  }
+}
+
+function displayValue(
+  field: SmartCompactPolicyField,
+  policy: SmartCompactPolicy,
+): string {
+  const override = policy.branchOverrides()[field];
+  if (override === undefined) return "global";
+  if (typeof override === "boolean") return enabled(override);
+  return override;
+}
+
+function sessionSettingsList(
+  policy: SmartCompactPolicy,
+  ctx: ExtensionCommandContext,
+  done: () => void,
+): SettingsList {
+  const items = sessionSettingsItems(policy);
+  let list: SettingsList;
+  list = new SettingsList(
+    items,
+    7,
+    getSettingsListTheme(),
+    (id, value) => {
+      try {
+        const result = updateSessionSetting(policy, ctx, id, value);
+        const field = policyField(id);
+        const item = items.find((candidate) => candidate.id === id);
+        if (item) item.description = effectiveDescription(field, result.policy);
+        if (!result.ok) {
+          ctx.ui.notify(result.error, "error");
+          list.updateValue(id, displayValue(field, policy));
+        }
+      } catch (error) {
+        ctx.ui.notify(
+          error instanceof Error ? error.message : String(error),
+          "error",
+        );
+        list.updateValue(
+          id,
+          displayValue(policyField(id), policy),
+        );
+      }
+    },
+    done,
+  );
+  return list;
+}
+
+function globalChoiceSettingsList(
+  group: GlobalChoiceGroup,
+  ctx: ExtensionCommandContext,
+  done: () => void,
+  requestRender: () => void,
+  coordinator: GlobalSettingsCoordinator,
+  onApplied: GlobalSettingApplied,
+): SettingsList {
+  const settings = GLOBAL_CHOICE_SETTINGS[group];
+  const items = globalChoiceSettingsItems(group, loadConfig(), coordinator);
+  let list: SettingsList;
+
+  list = new SettingsList(
+    items,
+    9,
+    getSettingsListTheme(),
+    (id, display) => {
+      coordinator.submit(group, id as GlobalConfigPath, display, (message) =>
+        ctx.ui.notify(message, "error"),
+        onApplied,
+      );
+    },
+    () => {
+      unsubscribe();
+      done();
+    },
+  );
+  const unsubscribe = coordinator.subscribe(
+    settings.map((setting) => setting.id),
+    (id, state) => {
+      list.updateValue(id, state.display);
+      if (state.config) {
+        for (const setting of settings) {
+          const item = items.find((candidate) => candidate.id === setting.id);
+          if (item) {
+            item.description = effectiveChoiceDescription(setting, state.config);
+          }
+        }
+      }
+      requestRender();
+    },
+  );
+  return list;
+}
+
+export function settingsCategoryItems(
+  policy: SmartCompactPolicy,
+  ctx: ExtensionCommandContext,
+  requestRender: () => void = () => {},
+  coordinator: GlobalSettingsCoordinator = new GlobalSettingsCoordinator(),
+  onApplied: GlobalSettingApplied = () => {},
+  writeConfig: GlobalConfigWriter = writeGlobalConfigValue,
+): SettingItem[] {
+  return [
+    {
+      id: "session",
+      label: "Current branch",
+      description: "Agent access, automatic compaction, and footer status",
+      currentValue: "3 settings",
+      submenu: (_current, done) => sessionSettingsList(policy, ctx, done),
+    },
+    ...GLOBAL_CHOICE_CATEGORIES.map(({ group, label, description }) => ({
+      id: group,
+      label,
+      description,
+      currentValue: `${GLOBAL_CHOICE_SETTINGS[group].length} settings`,
+      submenu: (_current: string, done: () => void) =>
+        globalChoiceSettingsList(
+          group,
+          ctx,
+          done,
+          requestRender,
+          coordinator,
+          onApplied,
+        ),
+    })),
+    ...complexSettingsCategories(ctx, requestRender, writeConfig),
+  ];
+}
+
+export function createSettingsRoot(
+  policy: SmartCompactPolicy,
+  ctx: ExtensionCommandContext,
+  onCancel: () => void,
+  requestRender: () => void = () => {},
+  coordinator: GlobalSettingsCoordinator = new GlobalSettingsCoordinator(),
+  onApplied: GlobalSettingApplied = () => {},
+  writeConfig: GlobalConfigWriter = writeGlobalConfigValue,
+): SettingsList {
+  return new SettingsList(
+    settingsCategoryItems(
+      policy,
+      ctx,
+      requestRender,
+      coordinator,
+      onApplied,
+      writeConfig,
+    ),
+    8,
+    getSettingsListTheme(),
+    () => {},
+    onCancel,
+  );
+}
+
+interface NestedSettingsComponent extends Component {
+  submenuComponent?: Component;
+  focused?: boolean;
+}
+
+function deepestFocusable(component: Component): Focusable | undefined {
+  let current: NestedSettingsComponent | undefined =
+    component as NestedSettingsComponent;
+  let focusable: Focusable | undefined;
+  while (current) {
+    if (typeof current.focused === "boolean") {
+      focusable = current as Focusable;
+    }
+    current = current.submenuComponent as NestedSettingsComponent | undefined;
+  }
+  return focusable;
+}
+
+export function createSettingsController(
+  root: SettingsList,
+  display: Component,
+  requestRender: () => void,
+): Component & Focusable {
+  let focused = false;
+  let target: Focusable | undefined;
+  const syncFocus = () => {
+    const next = focused ? deepestFocusable(root) : undefined;
+    if (target !== next) {
+      if (target) target.focused = false;
+      target = next;
+    }
+    if (target) target.focused = focused;
+  };
+  return {
+    get focused() {
+      return focused;
+    },
+    set focused(value: boolean) {
+      focused = value;
+      syncFocus();
+    },
+    render(width: number) {
+      syncFocus();
+      return display.render(width);
+    },
+    handleInput(data: string) {
+      root.handleInput(data);
+      syncFocus();
+      requestRender();
+    },
+    invalidate: () => display.invalidate(),
+  };
+}
+
+/** Open the unified Smart Compact settings panel. */
 export async function showSmartCompactSettings(
   ctx: ExtensionCommandContext,
   policy: SmartCompactPolicy,
+  coordinator: GlobalSettingsCoordinator = new GlobalSettingsCoordinator(),
+  onApplied: GlobalSettingApplied = () => {},
 ): Promise<void> {
+  const writeConfig: GlobalConfigWriter = async (path, value) => {
+    const config = await writeGlobalConfigValue(path, value);
+    await onApplied(path, config);
+    return config;
+  };
   await ctx.ui.custom<void>((tui, theme, _keybindings, done) => {
+    const root = createSettingsRoot(
+      policy,
+      ctx,
+      done,
+      () => tui.requestRender(),
+      coordinator,
+      onApplied,
+      writeConfig,
+    );
     const container = new Container();
     container.addChild(
       new Text(theme.fg("accent", theme.bold("Smart Compact Settings")), 0, 0),
     );
     container.addChild(
       new Text(
-        theme.fg("dim", "Changes apply now and follow this session branch."),
+        theme.fg("dim", "Global defaults and branch-specific overrides."),
         0,
         0,
       ),
@@ -89,39 +692,15 @@ export async function showSmartCompactSettings(
       ),
     );
     container.addChild(new Text("", 0, 0));
-
-    const list = new SettingsList(
-      settingsItems(policy.snapshot()),
-      6,
-      getSettingsListTheme(),
-      (id, value) => {
-        const previous = policy.snapshot();
-        const result =
-          id === "agentToolAccess"
-            ? policy.update({ agentToolAccess: parseAccessValue(value) }, ctx)
-            : id === "autoTrigger"
-              ? policy.update({ autoTrigger: value === ENABLED }, ctx)
-              : policy.update({ showStatus: value === ENABLED }, ctx);
-        if (!result.ok) {
-          list.updateValue(id, previousValue(id, previous));
-          ctx.ui.notify(result.error, "error");
-        }
-      },
-      () => done(undefined),
-    );
-    container.addChild(list);
+    container.addChild(root);
     container.addChild(new Text("", 0, 0));
     container.addChild(
-      new Text(theme.fg("dim", "↑↓ navigate · enter change · esc close"), 0, 0),
+      new Text(
+        theme.fg("dim", "↑↓ navigate · enter open/change · esc back/close"),
+        0,
+        0,
+      ),
     );
-
-    return {
-      render: (width: number) => container.render(width),
-      invalidate: () => container.invalidate(),
-      handleInput(data: string) {
-        list.handleInput?.(data);
-        tui.requestRender();
-      },
-    };
+    return createSettingsController(root, container, () => tui.requestRender());
   });
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,10 +1,13 @@
 import fs from "node:fs";
 import {
+  CONFIG_NUMERIC_LIMITS,
   CONFIG_KEY,
   CONFIG_KEY_ALT,
   DEFAULT_CONFIG,
+  PROFILE_NUMERIC_BOUNDS,
   PROFILES,
 } from "../constants.ts";
+import { acquireLock, atomicWriteFile } from "../infra/fs.ts";
 import { defaultBackupDir, settingsFile } from "../infra/paths.ts";
 import type {
   CompactConfig,
@@ -55,17 +58,157 @@ const PROFILE_NUMERIC_KEYS = [
   "singlePassMaxTokens",
   "batchMaxTokens",
 ] as const;
-const PROFILE_NUMERIC_BOUNDS: Record<
-  (typeof PROFILE_NUMERIC_KEYS)[number],
-  readonly [number, number]
-> = {
-  summaryBudgetTokens: [256, 100_000],
-  keepRecentTokens: [1_000, 500_000],
-  minChunkTokens: [100, 100_000],
-  maxChunkTokens: [500, 200_000],
-  singlePassMaxTokens: [1_000, 500_000],
-  batchMaxTokens: [1_000, 500_000],
-};
+type TopLevelConfigKey = Exclude<keyof CompactConfig, "profiles">;
+type ProfileNumericKey = (typeof PROFILE_NUMERIC_KEYS)[number];
+export type GlobalConfigPath =
+  | TopLevelConfigKey
+  | `profiles.${CompressionProfile}.${ProfileNumericKey}`;
+export type GlobalConfigValue =
+  | CompactConfig[TopLevelConfigKey]
+  | ProfileConfig[ProfileNumericKey]
+  | undefined;
+
+export function readGlobalConfigValue(
+  configPath: GlobalConfigPath,
+): GlobalConfigValue {
+  assertGlobalConfigPath(configPath);
+  try {
+    const section = configuredSection(readSettingsRoot(settingsFile()));
+    validateSmartCompactConfig(section);
+    return cloneGlobalConfigValue(configPathValue(section, configPath));
+  } catch {
+    return undefined;
+  }
+}
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneProfiles(
+  profiles: Record<CompressionProfile, ProfileConfig>,
+): Record<CompressionProfile, ProfileConfig> {
+  return Object.fromEntries(
+    VALID_PROFILES.map((name) => [name, { ...profiles[name] }]),
+  ) as Record<CompressionProfile, ProfileConfig>;
+}
+
+function cloneConfig(config: CompactConfig): CompactConfig {
+  return {
+    ...config,
+    profiles: cloneProfiles(config.profiles),
+    pinPaths: [...config.pinPaths],
+  };
+}
+
+function defaultConfig(): CompactConfig {
+  return cloneConfig({
+    ...DEFAULT_CONFIG,
+    backupDir: defaultBackupDir(),
+  } as CompactConfig);
+}
+
+function cloneGlobalConfigValue(value: GlobalConfigValue): GlobalConfigValue {
+  return Array.isArray(value) ? [...value] : value;
+}
+
+function readSettingsRoot(file: string): Record<string, unknown> {
+  if (!fs.existsSync(file)) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    throw new Error("settings.json must contain valid JSON");
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("settings.json root must be an object");
+  }
+  return parsed;
+}
+
+function configuredSection(root: Record<string, unknown>): Record<string, unknown> {
+  const selected = Object.hasOwn(root, CONFIG_KEY)
+    ? root[CONFIG_KEY]
+    : (root[CONFIG_KEY_ALT] ?? {});
+  if (!isRecord(selected)) {
+    throw new Error("smartCompact must be an object");
+  }
+  return structuredClone(selected);
+}
+
+function deleteEmptyProfileContainers(
+  section: Record<string, unknown>,
+  profile: CompressionProfile,
+): void {
+  if (!isRecord(section.profiles)) return;
+  if (isRecord(section.profiles[profile])) {
+    const values = section.profiles[profile] as Record<string, unknown>;
+    if (Object.keys(values).length === 0) delete section.profiles[profile];
+  }
+  if (Object.keys(section.profiles).length === 0) delete section.profiles;
+}
+
+function setConfigPath(
+  section: Record<string, unknown>,
+  configPath: GlobalConfigPath,
+  value: GlobalConfigValue,
+): void {
+  const parts = configPath.split(".");
+  if (parts[0] !== "profiles") {
+    if (value === undefined) delete section[configPath];
+    else section[configPath] = value;
+    return;
+  }
+
+  const [, profile, key] = parts as [
+    "profiles",
+    CompressionProfile,
+    ProfileNumericKey,
+  ];
+  if (!isRecord(section.profiles)) section.profiles = {};
+  const profiles = section.profiles as Record<string, unknown>;
+  if (!isRecord(profiles[profile])) profiles[profile] = {};
+  const values = profiles[profile] as Record<string, unknown>;
+  if (value === undefined) delete values[key];
+  else values[key] = value;
+  deleteEmptyProfileContainers(section, profile);
+}
+
+function assertGlobalConfigPath(configPath: string): asserts configPath is GlobalConfigPath {
+  if (configPath !== "profiles" && Object.hasOwn(DEFAULT_CONFIG, configPath)) {
+    return;
+  }
+  const parts = configPath.split(".");
+  if (
+    parts.length === 3 &&
+    parts[0] === "profiles" &&
+    (VALID_PROFILES as readonly string[]).includes(parts[1]) &&
+    (PROFILE_NUMERIC_KEYS as readonly string[]).includes(parts[2])
+  ) {
+    return;
+  }
+  throw new Error(`Unknown smartCompact setting path: ${configPath}`);
+}
+
+function configPathValue(
+  section: Record<string, unknown>,
+  configPath: GlobalConfigPath,
+): GlobalConfigValue {
+  const parts = configPath.split(".");
+  if (parts[0] !== "profiles") {
+    return section[configPath] as GlobalConfigValue;
+  }
+  const [, profile, key] = parts;
+  if (!isRecord(section.profiles)) return undefined;
+  const values = section.profiles[profile];
+  return isRecord(values) ? (values[key] as GlobalConfigValue) : undefined;
+}
+
+function sameJsonValue(
+  left: GlobalConfigValue,
+  right: GlobalConfigValue,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
 
 function discard(
   sc: Record<string, unknown>,
@@ -192,9 +335,7 @@ function validateBasicFields(sc: Record<string, unknown>): void {
 function validateProfiles(sc: Record<string, unknown>): void {
   if (!("profiles" in sc)) return;
   if (
-    typeof sc.profiles !== "object" ||
-    sc.profiles === null ||
-    Array.isArray(sc.profiles)
+    !isRecord(sc.profiles)
   ) {
     discard(
       sc,
@@ -216,7 +357,7 @@ function validateProfiles(sc: Record<string, unknown>): void {
       );
       continue;
     }
-    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    if (!isRecord(value)) {
       discard(
         profiles,
         profileName,
@@ -226,7 +367,7 @@ function validateProfiles(sc: Record<string, unknown>): void {
       );
       continue;
     }
-    const profileCfg = value as Record<string, unknown>;
+    const profileCfg = value;
     for (const [key, raw] of Object.entries(profileCfg)) {
       if (!PROFILE_NUMERIC_KEYS.includes(key as never)) {
         discard(
@@ -288,11 +429,23 @@ interface NumericRule {
   message: (value: unknown) => string;
 }
 
+function validNumericLimit(
+  key: keyof typeof CONFIG_NUMERIC_LIMITS,
+  value: number,
+): boolean {
+  const limit = CONFIG_NUMERIC_LIMITS[key];
+  return (
+    Number.isFinite(value) &&
+    (!limit.integer || Number.isSafeInteger(value)) &&
+    ((value >= limit.min && value <= limit.max) ||
+      ("zeroOrRange" in limit && limit.zeroOrRange && value === 0))
+  );
+}
+
 const NUMERIC_RULES: readonly NumericRule[] = [
   {
     key: "autoTriggerTimeoutMs",
-    valid: (value) =>
-      Number.isFinite(value) && value >= 1_000 && value <= 300_000,
+    valid: (value) => validNumericLimit("autoTriggerTimeoutMs", value),
     message: (value) =>
       "smart-compact config: autoTriggerTimeoutMs must be 1000–300000, got " +
       value +
@@ -302,36 +455,31 @@ const NUMERIC_RULES: readonly NumericRule[] = [
   },
   {
     key: "maxLlmCalls",
-    valid: (value) => Number.isInteger(value) && value >= 0 && value <= 100,
+    valid: (value) => validNumericLimit("maxLlmCalls", value),
     message: () =>
       "smart-compact config: maxLlmCalls must be 0–100; 0 uses the selected mode cap.",
   },
   {
     key: "maxLlmInputTokens",
-    valid: (value) =>
-      Number.isInteger(value) && value >= 0 && value <= 1_000_000,
+    valid: (value) => validNumericLimit("maxLlmInputTokens", value),
     message: () =>
       "smart-compact config: maxLlmInputTokens must be 0–1000000; 0 uses the mode cap.",
   },
   {
     key: "codexMaxCallMs",
-    valid: (value) =>
-      Number.isInteger(value) &&
-      (value === 0 || (value >= 5_000 && value <= 300_000)),
+    valid: (value) => validNumericLimit("codexMaxCallMs", value),
     message: () =>
       "smart-compact config: codexMaxCallMs must be 0 or 5000–300000; 0 derives a cap from maxTokens.",
   },
   {
     key: "maxLatencyMs",
-    valid: (value) =>
-      Number.isFinite(value) &&
-      (value === 0 || (value >= 5_000 && value <= 600_000)),
+    valid: (value) => validNumericLimit("maxLatencyMs", value),
     message: () =>
       "smart-compact config: maxLatencyMs must be 0 or 5000–600000; 0 means unlimited.",
   },
   {
     key: "minContextPercent",
-    valid: (value) => Number.isFinite(value) && value >= 0 && value <= 100,
+    valid: (value) => validNumericLimit("minContextPercent", value),
     message: (value) =>
       "smart-compact config: minContextPercent must be 0–100, got " +
       value +
@@ -383,6 +531,41 @@ export function validateSmartCompactConfig(sc: Record<string, unknown>): void {
   validateLimits(sc);
 }
 
+/**
+ * Persist one extension-owned global setting without replacing other Pi or
+ * extension settings. Passing undefined removes the override so the built-in
+ * default becomes effective again.
+ */
+export async function writeGlobalConfigValue(
+  configPath: GlobalConfigPath,
+  value: GlobalConfigValue,
+): Promise<CompactConfig> {
+  assertGlobalConfigPath(configPath);
+  const file = settingsFile();
+  const release = await acquireLock(file);
+  try {
+    const root = readSettingsRoot(file);
+    const section = configuredSection(root);
+    setConfigPath(section, configPath, cloneGlobalConfigValue(value));
+    if (value === undefined && configPath === "agentToolAccess") {
+      delete section.agentToolEnabled;
+    }
+    const validated = structuredClone(section);
+    validateSmartCompactConfig(validated);
+
+    if (!sameJsonValue(configPathValue(validated, configPath), value)) {
+      throw new Error(`Invalid smartCompact setting: ${configPath}`);
+    }
+
+    root[CONFIG_KEY] = section;
+    await atomicWriteFile(file, JSON.stringify(root, null, 2) + "\n");
+    resetConfigCache();
+    return loadConfig();
+  } finally {
+    release();
+  }
+}
+
 let cachedConfig: CompactConfig | null = null;
 let cachedMtime = 0;
 let cachedPath: string | null = null;
@@ -399,11 +582,21 @@ export function loadConfig(): CompactConfig {
     const file = settingsFile();
     const stat = fs.statSync(file);
     if (cachedConfig && cachedPath === file && stat.mtimeMs === cachedMtime)
-      return cachedConfig;
-    const raw = JSON.parse(fs.readFileSync(file, "utf-8"));
-    const sc = raw[CONFIG_KEY] ?? raw[CONFIG_KEY_ALT] ?? {};
-    validateSmartCompactConfig(sc as Record<string, unknown>);
-    const merged = { ...DEFAULT_CONFIG, ...sc } as CompactConfig;
+      return cloneConfig(cachedConfig);
+    const parsed: unknown = JSON.parse(fs.readFileSync(file, "utf-8"));
+    const raw = isRecord(parsed) ? parsed : {};
+    if (raw !== parsed) {
+      log.warn("smart-compact config: settings.json root must be an object.");
+    }
+    const configured = Object.hasOwn(raw, CONFIG_KEY)
+      ? raw[CONFIG_KEY]
+      : (raw[CONFIG_KEY_ALT] ?? {});
+    const sc = isRecord(configured) ? configured : {};
+    if (sc !== configured) {
+      log.warn("smart-compact config: smartCompact must be an object.");
+    }
+    validateSmartCompactConfig(sc);
+    const merged = { ...defaultConfig(), ...sc } as CompactConfig;
     if (!("mode" in sc) && "profile" in sc) {
       merged.mode =
         sc.profile === "light"
@@ -411,26 +604,29 @@ export function loadConfig(): CompactConfig {
           : (sc.profile as CompactConfig["mode"]);
     }
     if (sc.profiles) {
-      merged.profiles = { ...PROFILES, ...sc.profiles } as Record<
+      const overrides = sc.profiles as Record<
         CompressionProfile,
-        ProfileConfig
+        Partial<ProfileConfig>
       >;
+      merged.profiles = Object.fromEntries(
+        VALID_PROFILES.map((name) => [
+          name,
+          { ...PROFILES[name], ...overrides[name] },
+        ]),
+      ) as Record<CompressionProfile, ProfileConfig>;
     }
     if (!merged.backupDir) merged.backupDir = defaultBackupDir();
     cachedConfig = merged;
     cachedMtime = stat.mtimeMs;
     cachedPath = file;
-    return cachedConfig;
+    return cloneConfig(cachedConfig);
   } catch (error) {
     log.debug(
       "loadConfig: settings.json not found or unreadable, using defaults",
       error,
     );
-    cachedConfig = {
-      ...DEFAULT_CONFIG,
-      backupDir: defaultBackupDir(),
-    } as CompactConfig;
+    cachedConfig = defaultConfig();
     cachedPath = null;
-    return cachedConfig;
+    return cloneConfig(cachedConfig);
   }
 }

--- a/test/config-loading.test.ts
+++ b/test/config-loading.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { PROFILES } from "../src/constants.ts";
+import {
+  loadConfig,
+  resetConfigCache,
+  writeGlobalConfigValue,
+} from "../src/utils/config.ts";
+
+const originalHome = process.env.HOME;
+let home = "";
+let settings = "";
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "smart-compact-config-"));
+  process.env.HOME = home;
+  const agentDir = path.join(home, ".pi", "agent");
+  fs.mkdirSync(agentDir, { recursive: true });
+  settings = path.join(agentDir, "settings.json");
+  resetConfigCache();
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  resetConfigCache();
+});
+
+function writeSettings(value: unknown): void {
+  fs.writeFileSync(settings, JSON.stringify(value));
+  resetConfigCache();
+}
+
+describe("loadConfig", () => {
+  it("falls back safely when the settings root is not an object", () => {
+    writeSettings(["unexpected"]);
+    const config = loadConfig();
+    expect(config.mode).toBe("auto");
+    expect(config.profiles.balanced).toEqual(PROFILES.balanced);
+  });
+
+  it("falls back safely when smartCompact is not an object", () => {
+    writeSettings({ smartCompact: ["unexpected"] });
+    const config = loadConfig();
+    expect(config.mode).toBe("auto");
+    expect(config.autoTrigger).toBe(true);
+  });
+
+  it("does not fall through to the legacy key when the canonical key is null", () => {
+    writeSettings({
+      smartCompact: null,
+      semanticCompact: { autoTrigger: false },
+    });
+    expect(loadConfig().autoTrigger).toBe(true);
+  });
+
+  it("deep-merges partial profile overrides with built-in values", () => {
+    writeSettings({
+      smartCompact: {
+        profiles: { balanced: { summaryBudgetTokens: 7_000 } },
+      },
+    });
+    const config = loadConfig();
+    expect(config.profiles.balanced).toEqual({
+      ...PROFILES.balanced,
+      summaryBudgetTokens: 7_000,
+    });
+    expect(config.profiles.light).toEqual(PROFILES.light);
+  });
+
+  it("discards an override whose merged chunk bounds are inconsistent", () => {
+    writeSettings({
+      smartCompact: {
+        profiles: { balanced: { maxChunkTokens: 30_000 } },
+      },
+    });
+    const config = loadConfig();
+    expect(config.profiles.balanced).toEqual(PROFILES.balanced);
+  });
+
+  it("isolates cached and default nested values from caller mutation", () => {
+    writeSettings({});
+    const first = loadConfig();
+    first.profiles.balanced.summaryBudgetTokens = 999;
+    first.pinPaths.push("mutated");
+
+    const cached = loadConfig();
+    expect(cached.profiles.balanced.summaryBudgetTokens).toBe(
+      PROFILES.balanced.summaryBudgetTokens,
+    );
+    expect(cached.pinPaths).toEqual([]);
+
+    resetConfigCache();
+    const reloaded = loadConfig();
+    expect(reloaded.profiles.balanced).toEqual(PROFILES.balanced);
+    expect(reloaded.pinPaths).toEqual([]);
+  });
+});
+
+describe("writeGlobalConfigValue", () => {
+  it("preserves unrelated root and smartCompact keys", async () => {
+    writeSettings({
+      theme: "dark",
+      anotherExtension: { enabled: true },
+      smartCompact: {
+        autoTrigger: "invalid-but-unrelated",
+        futureOption: "preserve-me",
+        profiles: {
+          balanced: { futureBudget: 123 },
+          futureProfile: { futureBudget: 456 },
+        },
+      },
+    });
+
+    const effective = await writeGlobalConfigValue("mode", "thorough");
+    expect(effective.mode).toBe("thorough");
+    expect(JSON.parse(fs.readFileSync(settings, "utf8"))).toEqual({
+      theme: "dark",
+      anotherExtension: { enabled: true },
+      smartCompact: {
+        autoTrigger: "invalid-but-unrelated",
+        futureOption: "preserve-me",
+        profiles: {
+          balanced: { futureBudget: 123 },
+          futureProfile: { futureBudget: 456 },
+        },
+        mode: "thorough",
+      },
+    });
+  });
+
+  it("writes and removes a nested profile override", async () => {
+    await writeGlobalConfigValue(
+      "profiles.balanced.summaryBudgetTokens",
+      7_000,
+    );
+    expect(loadConfig().profiles.balanced.summaryBudgetTokens).toBe(7_000);
+
+    await writeGlobalConfigValue(
+      "profiles.balanced.summaryBudgetTokens",
+      undefined,
+    );
+    const root = JSON.parse(fs.readFileSync(settings, "utf8"));
+    expect(root.smartCompact.profiles).toBeUndefined();
+    expect(loadConfig().profiles.balanced.summaryBudgetTokens).toBe(
+      PROFILES.balanced.summaryBudgetTokens,
+    );
+  });
+
+  it("rejects invalid values without changing the file", async () => {
+    writeSettings({ smartCompact: { mode: "balanced" } });
+    const before = fs.readFileSync(settings, "utf8");
+    await expect(writeGlobalConfigValue("mode", "invalid")).rejects.toThrow(
+      "Invalid smartCompact setting: mode",
+    );
+    expect(fs.readFileSync(settings, "utf8")).toBe(before);
+  });
+
+  it("rejects unknown runtime paths before property lookup", async () => {
+    writeSettings({ smartCompact: {} });
+    await expect(
+      writeGlobalConfigValue(
+        "profiles.__proto__.summaryBudgetTokens" as any,
+        7_000,
+      ),
+    ).rejects.toThrow("Unknown smartCompact setting path");
+    expect(({} as Record<string, unknown>).summaryBudgetTokens).toBeUndefined();
+  });
+
+  it("removes the deprecated alias when resetting agent tool access", async () => {
+    writeSettings({ smartCompact: { agentToolEnabled: false } });
+    await writeGlobalConfigValue("agentToolAccess", undefined);
+    const root = JSON.parse(fs.readFileSync(settings, "utf8"));
+    expect(root.smartCompact.agentToolAccess).toBeUndefined();
+    expect(root.smartCompact.agentToolEnabled).toBeUndefined();
+    expect(loadConfig().agentToolAccess).toBe("inherit");
+  });
+
+  it("rejects malformed JSON without replacing it", async () => {
+    fs.writeFileSync(settings, "{ definitely-not-json");
+    resetConfigCache();
+    const before = fs.readFileSync(settings, "utf8");
+    await expect(writeGlobalConfigValue("mode", "fast")).rejects.toThrow();
+    expect(fs.readFileSync(settings, "utf8")).toBe(before);
+  });
+
+  it("leaves the original intact when the settings lock cannot be acquired", async () => {
+    writeSettings({ smartCompact: { mode: "balanced" } });
+    const before = fs.readFileSync(settings, "utf8");
+    fs.mkdirSync(settings + ".lock");
+    try {
+      await expect(writeGlobalConfigValue("mode", "fast")).rejects.toThrow(
+        "Timed out acquiring lock",
+      );
+      expect(fs.readFileSync(settings, "utf8")).toBe(before);
+    } finally {
+      fs.rmSync(settings + ".lock", { recursive: true, force: true });
+    }
+  });
+
+  it("invalidates the load cache after a successful write", async () => {
+    writeSettings({ smartCompact: { autoTrigger: true } });
+    expect(loadConfig().autoTrigger).toBe(true);
+    await writeGlobalConfigValue("autoTrigger", false);
+    expect(loadConfig().autoTrigger).toBe(false);
+  });
+
+  it("serializes competing process updates without losing either field", async () => {
+    writeSettings({ theme: "dark", smartCompact: {} });
+    const moduleUrl = pathToFileURL(
+      path.resolve(import.meta.dir, "../src/utils/config.ts"),
+    ).href;
+    const worker = (setting: string, value: unknown) =>
+      Bun.spawn(
+        [
+          process.execPath,
+          "-e",
+          `const { writeGlobalConfigValue } = await import(${JSON.stringify(moduleUrl)}); await writeGlobalConfigValue(${JSON.stringify(setting)}, ${JSON.stringify(value)});`,
+        ],
+        {
+          env: { ...process.env, HOME: home },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+    const first = worker("mode", "fast");
+    const second = worker("autoTrigger", false);
+    const [firstExit, secondExit] = await Promise.all([
+      first.exited,
+      second.exited,
+    ]);
+    expect(firstExit).toBe(0);
+    expect(secondExit).toBe(0);
+    expect(JSON.parse(fs.readFileSync(settings, "utf8"))).toEqual({
+      theme: "dark",
+      smartCompact: { mode: "fast", autoTrigger: false },
+    });
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -146,6 +146,16 @@ describe("validateSmartCompactConfig", () => {
     expect(sc2.autoTriggerTimeoutMs).toBe(300000);
   });
 
+  it("rejects fractional millisecond limits", () => {
+    const sc: Record<string, unknown> = {
+      autoTriggerTimeoutMs: 45_000.5,
+      maxLatencyMs: 60_000.5,
+    };
+    validateSmartCompactConfig(sc);
+    expect(sc.autoTriggerTimeoutMs).toBeUndefined();
+    expect(sc.maxLatencyMs).toBeUndefined();
+  });
+
   it("uses a less aggressive default auto-trigger timeout", () => {
     expect(DEFAULT_CONFIG.autoTriggerTimeoutMs).toBe(120000);
   });

--- a/test/context-tools.test.ts
+++ b/test/context-tools.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import smartCompactExtension from "../src/index.ts";
 import { contextGraphFile } from "../src/infra/paths.ts";
+import { resetConfigCache } from "../src/utils/config.ts";
 
 const originalHome = process.env.HOME;
 let home = "";
@@ -18,21 +19,52 @@ afterEach(() => {
   fs.rmSync(home, { recursive: true, force: true });
 });
 
-function registeredTools(): Map<string, any> {
+function writeContextGraphSetting(enabled: boolean): void {
+  fs.mkdirSync(path.join(home, ".pi", "agent"), { recursive: true });
+  fs.writeFileSync(
+    path.join(home, ".pi", "agent", "settings.json"),
+    JSON.stringify({ smartCompact: { contextGraphEnabled: enabled } }),
+  );
+  resetConfigCache();
+}
+
+function registeredTools(options?: {
+  contextGraphEnabled?: boolean;
+  activeTools?: string[];
+}) {
+  if (options?.contextGraphEnabled !== undefined) {
+    writeContextGraphSetting(options.contextGraphEnabled);
+  }
   const tools = new Map<string, any>();
+  const active = new Set<string>(
+    options?.activeTools ?? ["read", "smart_recall", "smart_save_memory"],
+  );
+  const handlers = new Map<string, Array<(...args: any[]) => unknown>>();
   smartCompactExtension({
     registerCommand: () => {},
     registerTool: (definition: any) => tools.set(definition.name, definition),
-    on: () => {},
+    on: (event: string, handler: (...args: any[]) => unknown) => {
+      const registered = handlers.get(event) ?? [];
+      registered.push(handler);
+      handlers.set(event, registered);
+    },
+    getActiveTools: () => [...active],
+    setActiveTools: (names: string[]) => {
+      active.clear();
+      for (const name of names) active.add(name);
+    },
   } as any);
-  return tools;
+  return { tools, active, handlers };
 }
 
 function context(approved = true, cwd = process.cwd()) {
   return {
     cwd,
     hasUI: true,
-    ui: { confirm: async (_title: string, _message: string) => approved },
+    ui: {
+      confirm: async (_title: string, _message: string) => approved,
+      setStatus: () => {},
+    },
     sessionManager: {
       getSessionId: () => "session-a",
       getBranch: () => [{ id: "branch-root" }, { id: "branch-head" }],
@@ -42,7 +74,7 @@ function context(approved = true, cwd = process.cwd()) {
 
 describe("context memory tools", () => {
   it("registers bounded recall and explicit save contracts", () => {
-    const tools = registeredTools();
+    const { tools } = registeredTools();
     const recall = tools.get("smart_recall");
     const save = tools.get("smart_save_memory");
 
@@ -56,8 +88,35 @@ describe("context memory tools", () => {
     );
   });
 
+  it("hides both context tools when contextGraphEnabled=false and keeps them otherwise", () => {
+    const disabled = registeredTools({ contextGraphEnabled: false });
+    expect([...disabled.active]).toEqual(["read"]);
+
+    const enabled = registeredTools({ contextGraphEnabled: true });
+    expect([...enabled.active]).toEqual([
+      "read",
+      "smart_recall",
+      "smart_save_memory",
+    ]);
+  });
+
+  it("restores only tools hidden by config after a same-process re-enable", () => {
+    const extension = registeredTools({
+      contextGraphEnabled: false,
+      activeTools: ["read", "smart_save_memory"],
+    });
+    expect([...extension.active]).toEqual(["read"]);
+
+    writeContextGraphSetting(true);
+    for (const handler of extension.handlers.get("session_start") ?? []) {
+      handler({}, context());
+    }
+
+    expect([...extension.active]).toEqual(["read", "smart_save_memory"]);
+  });
+
   it("saves scrubbed memory and recalls it from the current project", async () => {
-    const tools = registeredTools();
+    const { tools } = registeredTools();
     const ctx = context();
     const token = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";
     const saved = await tools.get("smart_save_memory").execute(
@@ -119,7 +178,7 @@ describe("context memory tools", () => {
   });
 
   it("fails closed for project memory save and recall from HOME or root", async () => {
-    const tools = registeredTools();
+    const { tools } = registeredTools();
     for (const cwd of [home, path.parse(home).root]) {
       const ctx = context(true, cwd);
       const saved = await tools.get("smart_save_memory").execute(
@@ -149,7 +208,7 @@ describe("context memory tools", () => {
   });
 
   it("shows the full scrubbed content before an unapproved long memory write", async () => {
-    const tools = registeredTools();
+    const { tools } = registeredTools();
     const content = "a".repeat(850) + " visible-confirmation-tail";
     let confirmation = "";
     const ctx = context();
@@ -191,7 +250,7 @@ describe("context memory tools", () => {
     process.env.HOME = isolatedHome;
     fs.mkdirSync(contextGraphFile(), { recursive: true });
     try {
-      const save = registeredTools().get("smart_save_memory");
+      const save = registeredTools().tools.get("smart_save_memory");
       let failure: unknown;
       try {
         await save.execute(
@@ -215,7 +274,7 @@ describe("context memory tools", () => {
   });
 
   it("refuses memory writes in a non-interactive host", async () => {
-    const save = registeredTools().get("smart_save_memory");
+    const save = registeredTools().tools.get("smart_save_memory");
     const ctx = { ...context(), hasUI: false };
     const result = await save.execute(
       "save-3",

--- a/test/global-settings-runtime.test.ts
+++ b/test/global-settings-runtime.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { applyGlobalSettingRuntime } from "../src/app/global-settings-runtime.ts";
+
+describe("global settings runtime refresh", () => {
+  it("hot-applies policy-owned tool, trigger, and status settings", () => {
+    const restored: string[] = [];
+    const contextApplies: string[] = [];
+    const policy = {
+      restore: () => restored.push("policy"),
+    } as any;
+    const contextTools = {
+      apply: () => contextApplies.push("context"),
+    };
+
+    for (const path of [
+      "agentToolAccess",
+      "autoTrigger",
+      "showStatus",
+    ] as const) {
+      applyGlobalSettingRuntime(
+        path,
+        {} as ExtensionContext,
+        policy,
+        contextTools,
+      );
+    }
+
+    expect(restored).toEqual(["policy", "policy", "policy"]);
+    expect(contextApplies).toEqual([]);
+  });
+
+  it("hot-applies context tool exposure only for contextGraphEnabled", () => {
+    const restored: string[] = [];
+    const contextApplies: string[] = [];
+    const policy = {
+      restore: () => restored.push("policy"),
+    } as any;
+    const contextTools = {
+      apply: () => contextApplies.push("context"),
+    };
+
+    applyGlobalSettingRuntime(
+      "contextGraphEnabled",
+      {} as ExtensionContext,
+      policy,
+      contextTools,
+    );
+    applyGlobalSettingRuntime(
+      "summaryModel",
+      {} as ExtensionContext,
+      policy,
+      contextTools,
+    );
+
+    expect(contextApplies).toEqual(["context"]);
+    expect(restored).toEqual([]);
+  });
+});

--- a/test/infra-fs.test.ts
+++ b/test/infra-fs.test.ts
@@ -100,6 +100,51 @@ describe("appendLineLocked", () => {
     expect(fs.readFileSync(target, "utf8")).toContain("\"ok\":1");
   });
 
+  it("never steals a live lock based only on elapsed time", () => {
+    const target = path.join(tmp, "aged-lock.jsonl");
+    const release = acquireLockSync(target);
+    const lockDir = target + ".lock";
+    const old = new Date(Date.now() - 60_000);
+    fs.utimesSync(lockDir, old, old);
+    try {
+      expect(() => acquireLockSync(target)).toThrow("Lock busy");
+    } finally {
+      release();
+    }
+  });
+
+  it("does not let an old release callback remove a successor's lock", () => {
+    const target = path.join(tmp, "owned-lock.jsonl");
+    const releaseFirst = acquireLockSync(target);
+    releaseFirst();
+    const releaseSecond = acquireLockSync(target);
+    try {
+      releaseFirst();
+      expect(() => acquireLockSync(target)).toThrow("Lock busy");
+    } finally {
+      releaseSecond();
+    }
+  });
+
+  it("cleans a partial owner file when lock initialization fails", () => {
+    const target = path.join(tmp, "partial-owner.jsonl");
+    const originalWrite = fs.writeFileSync;
+    const mutableFs = fs as { writeFileSync: typeof fs.writeFileSync };
+    mutableFs.writeFileSync = ((file: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      if (String(file).endsWith(path.join(".lock", "owner"))) {
+        originalWrite(file, "partial");
+        throw Object.assign(new Error("disk full"), { code: "ENOSPC" });
+      }
+      return Reflect.apply(originalWrite, fs, [file, ...args]);
+    }) as typeof fs.writeFileSync;
+    try {
+      expect(() => acquireLockSync(target)).toThrow("Failed to acquire lock");
+      expect(fs.existsSync(target + ".lock")).toBe(false);
+    } finally {
+      mutableFs.writeFileSync = originalWrite;
+    }
+  });
+
   it("fails closed instead of appending through a non-directory parent", () => {
     expect(() => appendLineLocked(path.join("/dev/null", "log.jsonl"), "unsafe")).toThrow();
   });

--- a/test/settings-complex.test.ts
+++ b/test/settings-complex.test.ts
@@ -1,0 +1,259 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ExtensionCommandContext,
+  initTheme,
+} from "@earendil-works/pi-coding-agent";
+import { CURSOR_MARKER } from "@earendil-works/pi-tui";
+import {
+  complexConfigPaths,
+  complexSettingsCategories,
+  modelSettingsItems,
+} from "../src/ui/settings-complex.ts";
+import {
+  createSettingsController,
+  createSettingsRoot,
+} from "../src/ui/settings-overlay.ts";
+import {
+  readGlobalConfigValue,
+  resetConfigCache,
+  writeGlobalConfigValue,
+} from "../src/utils/config.ts";
+
+const originalHome = process.env.HOME;
+let home = "";
+let renders = 0;
+
+beforeAll(() => initTheme("dark", false));
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "settings-complex-"));
+  process.env.HOME = home;
+  fs.mkdirSync(path.join(home, ".pi", "agent"), { recursive: true });
+  renders = 0;
+  resetConfigCache();
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  resetConfigCache();
+});
+
+function context(models: Array<{ provider: string; id: string; name: string }> = []) {
+  return {
+    modelRegistry: {
+      getAvailable: () =>
+        models.map((model) => ({
+          ...model,
+          api: "test",
+          baseUrl: "",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 100_000,
+          maxTokens: 10_000,
+        })),
+    },
+    ui: { notify: () => {} },
+  } as unknown as ExtensionCommandContext;
+}
+
+async function settleActive(component: unknown): Promise<void> {
+  let active = component as {
+    submenuComponent?: unknown;
+    settled?: () => Promise<void>;
+  };
+  while (active?.submenuComponent) {
+    active = active.submenuComponent as typeof active;
+  }
+  await active?.settled?.();
+}
+
+describe("complex settings coverage", () => {
+  it("covers every remaining top-level and nested profile setting", () => {
+    expect(complexConfigPaths()).toEqual([
+      "summaryModel",
+      "segmentationModel",
+      "verificationModel",
+      "minContextPercent",
+      "autoTriggerTimeoutMs",
+      "maxLlmCalls",
+      "maxLlmInputTokens",
+      "codexMaxCallMs",
+      "maxLatencyMs",
+      "backupDir",
+      "pinPaths",
+      "profiles.light.summaryBudgetTokens",
+      "profiles.light.keepRecentTokens",
+      "profiles.light.minChunkTokens",
+      "profiles.light.maxChunkTokens",
+      "profiles.light.singlePassMaxTokens",
+      "profiles.light.batchMaxTokens",
+      "profiles.balanced.summaryBudgetTokens",
+      "profiles.balanced.keepRecentTokens",
+      "profiles.balanced.minChunkTokens",
+      "profiles.balanced.maxChunkTokens",
+      "profiles.balanced.singlePassMaxTokens",
+      "profiles.balanced.batchMaxTokens",
+      "profiles.aggressive.summaryBudgetTokens",
+      "profiles.aggressive.keepRecentTokens",
+      "profiles.aggressive.minChunkTokens",
+      "profiles.aggressive.maxChunkTokens",
+      "profiles.aggressive.singlePassMaxTokens",
+      "profiles.aggressive.batchMaxTokens",
+    ]);
+    expect(
+      complexSettingsCategories(context(), () => {}).map((item) => item.id),
+    ).toEqual(["models", "limits", "paths", "profiles"]);
+  });
+});
+
+describe("model settings", () => {
+  it("filters available models and persists provider/model IDs", async () => {
+    const ctx = context([
+      { provider: "zeta", id: "writer", name: "Writer" },
+      { provider: "alpha", id: "reasoner", name: "Reasoner" },
+    ]);
+    const item = modelSettingsItems(ctx, () => renders++)[0];
+    const selector = item.submenu?.("default", () => {});
+    selector?.handleInput?.("alpha/reasoner");
+    expect(selector?.render(100).join("\n")).toContain("Reasoner");
+    expect(selector?.render(100).join("\n")).not.toContain("Writer");
+    expect(selector?.render(35).join("\n")).toContain("alpha/reasoner");
+    selector?.handleInput?.("\r");
+    await settleActive(selector);
+
+    expect(readGlobalConfigValue("summaryModel")).toBe("alpha/reasoner");
+    expect(item.currentValue).toBe("alpha/reasoner");
+    expect(renders).toBeGreaterThan(0);
+  });
+
+  it("refreshes the configured model each time the editor opens", async () => {
+    const ctx = context([
+      { provider: "alpha", id: "reasoner", name: "Reasoner" },
+    ]);
+    const item = modelSettingsItems(ctx, () => {})[0];
+    await writeGlobalConfigValue("summaryModel", "alpha/reasoner");
+    const selector = item.submenu?.("default", () => {});
+
+    expect(item.currentValue).toBe("alpha/reasoner");
+    expect(selector?.render(35).join("\n")).toContain("alpha/reasoner");
+  });
+
+  it("propagates host focus to the active nested search input", () => {
+    const ctx = context([
+      { provider: "alpha", id: "reasoner", name: "Reasoner" },
+    ]);
+    const policy = {
+      snapshot: () => ({
+        agentToolAccess: "inherit",
+        agentToolEnabled: true,
+        autoTrigger: true,
+        showStatus: true,
+      }),
+      branchOverrides: () => ({}),
+    } as any;
+    const root = createSettingsRoot(policy, ctx, () => {});
+    const controller = createSettingsController(root, root, () => {});
+    controller.focused = true;
+    for (let index = 0; index < 5; index++) controller.handleInput?.("\x1b[B");
+    controller.handleInput?.("\r");
+    controller.handleInput?.("\r");
+
+    expect(controller.render(80).join("\n")).toContain(CURSOR_MARKER);
+  });
+
+  it("keeps an unavailable configured model visible and resettable", async () => {
+    await writeGlobalConfigValue("summaryModel", "offline/missing");
+    const item = modelSettingsItems(context(), () => {})[0];
+    const selector = item.submenu?.("offline/missing", () => {});
+    expect(selector?.render(100).join("\n")).toContain(
+      "Configured model is currently unavailable",
+    );
+    selector?.handleInput?.("\x1b[A");
+    selector?.handleInput?.("\r");
+    await settleActive(selector);
+    expect(readGlobalConfigValue("summaryModel")).toBeUndefined();
+  });
+});
+
+describe("validated input settings", () => {
+  it("rejects invalid numeric input without writing and accepts decimals where valid", async () => {
+    const limits = complexSettingsCategories(context(), () => renders++).find(
+      (item) => item.id === "limits",
+    )!;
+    const list = limits.submenu?.("6 settings", () => {});
+    list?.handleInput?.("\r");
+    list?.handleInput?.("101");
+    list?.handleInput?.("\r");
+    expect(list?.render(100).join("\n")).toContain("0–100");
+    expect(readGlobalConfigValue("minContextPercent")).toBeUndefined();
+
+    list?.handleInput?.("\x15");
+    list?.handleInput?.("75.5");
+    list?.handleInput?.("\r");
+    await settleActive(list);
+    expect(readGlobalConfigValue("minContextPercent")).toBe(75.5);
+  });
+
+  it("requires an absolute backup directory and deduplicates pinned paths", async () => {
+    const paths = complexSettingsCategories(context(), () => {}).find(
+      (item) => item.id === "paths",
+    )!;
+    const list = paths.submenu?.("2 settings", () => {});
+    list?.handleInput?.("\r");
+    list?.handleInput?.("relative/backups");
+    list?.handleInput?.("\r");
+    expect(list?.render(100).join("\n")).toContain("absolute path");
+    expect(readGlobalConfigValue("backupDir")).toBeUndefined();
+    list?.handleInput?.("\x1b");
+
+    list?.handleInput?.("\x1b[B");
+    list?.handleInput?.("\r");
+    list?.handleInput?.("src/a.ts, src/a.ts, docs/b.md");
+    list?.handleInput?.("\r");
+    await settleActive(list);
+    expect(readGlobalConfigValue("pinPaths")).toEqual([
+      "src/a.ts",
+      "docs/b.md",
+    ]);
+  });
+
+  it("surfaces cross-field profile invariants and persists a valid budget", async () => {
+    const profiles = complexSettingsCategories(context(), () => {}).find(
+      (item) => item.id === "profiles",
+    )!;
+    const profileList = profiles.submenu?.("3 profiles", () => {});
+    profileList?.handleInput?.("\r");
+    for (let index = 0; index < 3; index++) profileList?.handleInput?.("\x1b[B");
+    profileList?.handleInput?.("\r");
+    profileList?.handleInput?.("40000");
+    profileList?.handleInput?.("\r");
+    await settleActive(profileList);
+    expect(profileList?.render(100).join("\n")).toContain(
+      "Invalid smartCompact setting",
+    );
+    expect(
+      readGlobalConfigValue("profiles.light.maxChunkTokens"),
+    ).toBeUndefined();
+
+    profileList?.handleInput?.("\x15");
+    profileList?.handleInput?.("20000");
+    profileList?.handleInput?.("\r");
+    await settleActive(profileList);
+    expect(readGlobalConfigValue("profiles.light.maxChunkTokens")).toBe(
+      20_000,
+    );
+  });
+});

--- a/test/settings-overlay.test.ts
+++ b/test/settings-overlay.test.ts
@@ -1,0 +1,441 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ExtensionCommandContext,
+  initTheme,
+} from "@earendil-works/pi-coding-agent";
+import type {
+  DesiredSmartCompactPolicy,
+  SmartCompactPolicy,
+} from "../src/app/smart-compact-policy.ts";
+import {
+  createSettingsRoot,
+  GlobalSettingsCoordinator,
+  globalChoiceSettingsItems,
+  sessionSettingsItems,
+  settingsCategoryItems,
+  updateSessionSetting,
+  updateGlobalChoiceSetting,
+} from "../src/ui/settings-overlay.ts";
+import {
+  type GlobalConfigValue,
+  loadConfig,
+  readGlobalConfigValue,
+  resetConfigCache,
+  writeGlobalConfigValue,
+} from "../src/utils/config.ts";
+
+function policyHarness() {
+  let overrides: Partial<DesiredSmartCompactPolicy> = {};
+  const updates: unknown[] = [];
+  const resets: string[] = [];
+  const policy: SmartCompactPolicy = {
+    snapshot: () => ({
+      agentToolAccess: overrides.agentToolAccess ?? "inherit",
+      agentToolEnabled: true,
+      autoTrigger: overrides.autoTrigger ?? true,
+      showStatus: overrides.showStatus ?? true,
+    }),
+    branchOverrides: () => ({ ...overrides }),
+    isAgentToolEnabled: () => true,
+    isAutoTriggerEnabled: () => overrides.autoTrigger ?? true,
+    restore: () => {},
+    update: (patch) => {
+      updates.push(patch);
+      overrides = { ...overrides, ...patch };
+      return { ok: true, policy: policy.snapshot() };
+    },
+    reset: (field) => {
+      resets.push(field);
+      delete overrides[field];
+      return { ok: true, policy: policy.snapshot() };
+    },
+  };
+  return { policy, updates, resets };
+}
+
+const ctx = {
+  ui: { notify: () => {} },
+} as unknown as ExtensionCommandContext;
+
+beforeAll(() => initTheme("dark", false));
+
+const originalHome = process.env.HOME;
+let home = "";
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "settings-overlay-"));
+  process.env.HOME = home;
+  fs.mkdirSync(path.join(home, ".pi", "agent"), { recursive: true });
+  resetConfigCache();
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  resetConfigCache();
+});
+
+describe("Smart Compact settings navigation", () => {
+  it("keeps all existing branch controls in the Current branch category", () => {
+    const { policy } = policyHarness();
+    expect(sessionSettingsItems(policy).map((item) => item.id)).toEqual([
+      "agentToolAccess",
+      "autoTrigger",
+      "showStatus",
+    ]);
+
+    const categories = settingsCategoryItems(policy, ctx);
+    expect(categories.map((item) => item.id)).toEqual([
+      "session",
+      "behavior",
+      "reasoning",
+      "safety",
+      "advanced",
+      "models",
+      "limits",
+      "paths",
+      "profiles",
+    ]);
+    expect(categories[0].submenu).toBeFunction();
+  });
+
+  it("opens the branch submenu and Escape returns to parent then closes", () => {
+    const { policy } = policyHarness();
+    let closed = false;
+    const root = createSettingsRoot(policy, ctx, () => {
+      closed = true;
+    });
+
+    root.handleInput("\r");
+    expect(root.render(100).join("\n")).toContain("Agent access");
+    root.handleInput("\x1b");
+    expect(root.render(100).join("\n")).toContain("Current branch");
+    expect(closed).toBe(false);
+    root.handleInput("\x1b");
+    expect(closed).toBe(true);
+  });
+
+  it("refreshes the effective description after a successful update", () => {
+    const { policy } = policyHarness();
+    const category = settingsCategoryItems(policy, ctx)[0];
+    const submenu = category.submenu?.("3 settings", () => {});
+
+    submenu?.handleInput?.("\x1b[B");
+    submenu?.handleInput?.("\r");
+    submenu?.handleInput?.("\r");
+    expect(submenu?.render(100).join("\n")).toContain(
+      "Effective value: disabled",
+    );
+  });
+
+  it("restores the displayed value and notifies when persistence fails", () => {
+    const test = policyHarness();
+    const notifications: string[] = [];
+    test.policy.update = () => ({
+      ok: false,
+      policy: test.policy.snapshot(),
+      error: "read-only session",
+    });
+    const failingCtx = {
+      ui: { notify: (message: string) => notifications.push(message) },
+    } as unknown as ExtensionCommandContext;
+    const category = settingsCategoryItems(test.policy, failingCtx)[0];
+    const submenu = category.submenu?.("3 settings", () => {});
+
+    submenu?.handleInput?.("\r");
+    expect(submenu?.render(100).join("\n")).toContain("global");
+    expect(notifications).toEqual(["read-only session"]);
+  });
+
+  it("routes explicit values and global reset exhaustively", () => {
+    const { policy, updates, resets } = policyHarness();
+    updateSessionSetting(policy, ctx, "agentToolAccess", "disabled");
+    updateSessionSetting(policy, ctx, "autoTrigger", "disabled");
+    updateSessionSetting(policy, ctx, "showStatus", "enabled");
+    updateSessionSetting(policy, ctx, "autoTrigger", "global");
+
+    expect(updates).toEqual([
+      { agentToolAccess: "disabled" },
+      { autoTrigger: false },
+      { showStatus: true },
+    ]);
+    expect(resets).toEqual(["autoTrigger"]);
+    expect(() =>
+      updateSessionSetting(policy, ctx, "unknown", "enabled"),
+    ).toThrow("Unknown session setting");
+  });
+});
+
+describe("global boolean and enum settings", () => {
+  const groups = ["behavior", "reasoning", "safety", "advanced"] as const;
+
+  it("exposes every boolean and enum CompactConfig field", () => {
+    const ids = groups.flatMap((group) =>
+      globalChoiceSettingsItems(group, loadConfig()).map((item) => item.id),
+    );
+    expect(ids).toEqual([
+      "mode",
+      "profile",
+      "agentToolAccess",
+      "autoTrigger",
+      "showStatus",
+      "autoTriggerStrategy",
+      "summaryThinkingLevel",
+      "segmentationThinkingLevel",
+      "backupEnabled",
+      "requireApproval",
+      "scrubSecrets",
+      "scrubPii",
+      "contextGraphEnabled",
+      "focusWeighting",
+      "zeroCallEnabled",
+      "telemetryChannel",
+      "adaptiveDamageFeedback",
+      "onlineDamageMonitor",
+    ]);
+  });
+
+  it("persists one typed value for every simple global setting", async () => {
+    const expected = new Map<string, GlobalConfigValue>();
+    for (const group of groups) {
+      const items = globalChoiceSettingsItems(group, loadConfig());
+      for (const item of items) {
+        const display = item.values?.[1];
+        expect(display).toBeDefined();
+        await updateGlobalChoiceSetting(group, item.id, display!);
+        const value =
+          display === "enabled"
+            ? true
+            : display === "disabled"
+              ? false
+              : display === "provider default"
+                ? null
+                : display;
+        expected.set(item.id, value);
+      }
+    }
+
+    for (const [id, value] of expected) {
+      expect(readGlobalConfigValue(id as any)).toEqual(value);
+    }
+  });
+
+  it("resets to the built-in default and rejects cross-category routing", async () => {
+    await updateGlobalChoiceSetting("behavior", "mode", "thorough");
+    await updateGlobalChoiceSetting("behavior", "mode", "default");
+    expect(readGlobalConfigValue("mode")).toBeUndefined();
+    await expect(
+      updateGlobalChoiceSetting("safety", "mode", "fast"),
+    ).rejects.toThrow("Unknown global choice setting: mode");
+  });
+
+  it("displays the migrated legacy agent-tool setting", () => {
+    fs.writeFileSync(
+      path.join(home, ".pi", "agent", "settings.json"),
+      JSON.stringify({ smartCompact: { agentToolEnabled: false } }),
+    );
+    resetConfigCache();
+    const item = globalChoiceSettingsItems("behavior", loadConfig()).find(
+      (candidate) => candidate.id === "agentToolAccess",
+    );
+    expect(item?.currentValue).toBe("disabled");
+  });
+
+  it("refreshes dependent effective descriptions after a profile change", async () => {
+    const coordinator = new GlobalSettingsCoordinator();
+    const behavior = settingsCategoryItems(
+      policyHarness().policy,
+      ctx,
+      () => {},
+      coordinator,
+    ).find((item) => item.id === "behavior")!;
+    const list = behavior.submenu?.("6 settings", () => {});
+
+    list?.handleInput?.("\x1b[B");
+    list?.handleInput?.("\r");
+    await coordinator.settled();
+    list?.handleInput?.("\x1b[A");
+
+    expect(list?.render(100).join("\n")).toContain(
+      "Effective global value: thorough",
+    );
+  });
+
+  it("restores dependent descriptions after queued success then failure", async () => {
+    let calls = 0;
+    const coordinator = new GlobalSettingsCoordinator(
+      async (group, id, display) => {
+        calls++;
+        if (calls === 2) throw new Error("second write failed");
+        return updateGlobalChoiceSetting(group, id, display);
+      },
+    );
+    const behavior = settingsCategoryItems(
+      policyHarness().policy,
+      ctx,
+      () => {},
+      coordinator,
+    ).find((item) => item.id === "behavior")!;
+    const list = behavior.submenu?.("6 settings", () => {});
+
+    list?.handleInput?.("\x1b[B");
+    list?.handleInput?.("\r");
+    list?.handleInput?.("\r");
+    await coordinator.settled();
+    list?.handleInput?.("\x1b[A");
+
+    const rendered = list?.render(100).join("\n");
+    expect(rendered).toContain("Effective global value: thorough");
+    expect(readGlobalConfigValue("profile")).toBe("light");
+  });
+
+  it("keeps the newest cross-setting config after a queued failure", async () => {
+    let calls = 0;
+    const coordinator = new GlobalSettingsCoordinator(
+      async (group, id, display) => {
+        calls++;
+        if (calls === 3) throw new Error("third write failed");
+        return updateGlobalChoiceSetting(group, id, display);
+      },
+    );
+    const behavior = settingsCategoryItems(
+      policyHarness().policy,
+      ctx,
+      () => {},
+      coordinator,
+    ).find((item) => item.id === "behavior")!;
+    const list = behavior.submenu?.("6 settings", () => {});
+
+    list?.handleInput?.("\x1b[B");
+    list?.handleInput?.("\r");
+    list?.handleInput?.("\x1b[A");
+    list?.handleInput?.("\r");
+    list?.handleInput?.("\x1b[B");
+    list?.handleInput?.("\r");
+    await coordinator.settled();
+    list?.handleInput?.("\x1b[A");
+
+    expect(list?.render(100).join("\n")).toContain(
+      "Effective global value: auto",
+    );
+    expect(readGlobalConfigValue("mode")).toBe("auto");
+    expect(readGlobalConfigValue("profile")).toBe("light");
+  });
+
+  it("shares optimistic state and save ordering across submenu reopen", async () => {
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    let secondStarted!: () => void;
+    const first = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const second = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const secondStart = new Promise<void>((resolve) => {
+      secondStarted = resolve;
+    });
+    const calls: string[] = [];
+    const coordinator = new GlobalSettingsCoordinator(
+      async (group, id, display) => {
+        calls.push(display);
+        if (calls.length === 1) await first;
+        else {
+          secondStarted();
+          await second;
+        }
+        return updateGlobalChoiceSetting(group, id, display);
+      },
+    );
+    const categories = settingsCategoryItems(
+      policyHarness().policy,
+      ctx,
+      () => {},
+      coordinator,
+    );
+    const behavior = categories.find((item) => item.id === "behavior")!;
+    const firstList = behavior.submenu?.("6 settings", () => {});
+    firstList?.handleInput?.("\r");
+    firstList?.handleInput?.("\x1b");
+
+    const reopened = behavior.submenu?.("6 settings", () => {});
+    expect(reopened?.render(100).join("\n")).toContain("auto");
+    reopened?.handleInput?.("\r");
+    expect(calls).toEqual([]);
+
+    await Promise.resolve();
+    expect(calls).toEqual(["auto"]);
+    releaseFirst();
+    await secondStart;
+    expect(calls).toEqual(["auto", "fast"]);
+    releaseSecond();
+    await coordinator.settled();
+
+    const finalList = behavior.submenu?.("6 settings", () => {});
+    expect(finalList?.render(100).join("\n")).toContain("fast");
+  });
+
+  it("rolls a failed async submenu update back and requests a rerender", async () => {
+    const notifications: string[] = [];
+    let renders = 0;
+    const coordinator = new GlobalSettingsCoordinator(async () => {
+      throw new Error("settings are read-only");
+    });
+    const failingCtx = {
+      ui: { notify: (message: string) => notifications.push(message) },
+    } as unknown as ExtensionCommandContext;
+    const behavior = settingsCategoryItems(
+      policyHarness().policy,
+      failingCtx,
+      () => renders++,
+      coordinator,
+    ).find((item) => item.id === "behavior")!;
+    const list = behavior.submenu?.("6 settings", () => {});
+
+    list?.handleInput?.("\r");
+    await coordinator.settled();
+    expect(list?.render(100).join("\n")).toContain("default");
+    expect(notifications).toEqual(["settings are read-only"]);
+    expect(renders).toBe(1);
+  });
+
+  it("refreshes the rollback baseline after an intervening external change", async () => {
+    await writeGlobalConfigValue("mode", "fast");
+    let fail = false;
+    const coordinator = new GlobalSettingsCoordinator(
+      async (group, id, display) => {
+        if (fail) throw new Error("write failed");
+        return updateGlobalChoiceSetting(group, id, display);
+      },
+    );
+    const behavior = settingsCategoryItems(
+      policyHarness().policy,
+      ctx,
+      () => {},
+      coordinator,
+    ).find((item) => item.id === "behavior")!;
+    const first = behavior.submenu?.("6 settings", () => {});
+    first?.handleInput?.("\r");
+    await coordinator.settled();
+    first?.handleInput?.("\x1b");
+
+    await writeGlobalConfigValue("mode", "thorough");
+    const reopened = behavior.submenu?.("6 settings", () => {});
+    expect(reopened?.render(100).join("\n")).toContain("thorough");
+    fail = true;
+    reopened?.handleInput?.("\r");
+    await coordinator.settled();
+    expect(reopened?.render(100).join("\n")).toContain("thorough");
+  });
+});

--- a/test/smart-compact-policy.test.ts
+++ b/test/smart-compact-policy.test.ts
@@ -32,7 +32,11 @@ afterEach(() => {
 
 function harness(
   branch: any[] = [],
-  options: { allowSmartCompact?: boolean; appendError?: boolean } = {},
+  options: {
+    allowSmartCompact?: boolean;
+    appendError?: boolean;
+    addSiblingBeforeAppendError?: boolean;
+  } = {},
 ) {
   let active = ["read", "smart_compact", "smart_recall"];
   const writes: Array<{ customType: string; data: unknown }> = [];
@@ -46,7 +50,10 @@ function harness(
           : [...names];
     },
     appendEntry: (customType: string, data: unknown) => {
-      if (options.appendError) throw new Error("session is read-only");
+      if (options.appendError) {
+        if (options.addSiblingBeforeAppendError) active.push("sibling_tool");
+        throw new Error("session is read-only");
+      }
       writes.push({ customType, data });
     },
   };
@@ -71,7 +78,7 @@ function harness(
 }
 
 describe("smart compact runtime policy", () => {
-  it("hides only smart_compact and persists a full branch-scoped policy", () => {
+  it("hides only smart_compact and persists a sparse branch override", () => {
     const test = harness();
     test.policy.restore(test.ctx);
     const result = test.policy.update(
@@ -85,10 +92,8 @@ describe("smart compact runtime policy", () => {
       {
         customType: "smart-compact-policy",
         data: {
-          version: 2,
-          agentToolAccess: "disabled",
-          autoTrigger: true,
-          showStatus: true,
+          version: 3,
+          overrides: { agentToolAccess: "disabled" },
         },
       },
     ]);
@@ -122,6 +127,59 @@ describe("smart compact runtime policy", () => {
       test.active().filter((name) => name === "smart_compact"),
     ).toHaveLength(1);
     expect(test.statuses.at(-1)).toBe("smart-compact: auto off");
+  });
+
+  it("applies sparse overrides over changing global defaults", () => {
+    const branch = [
+      {
+        type: "custom",
+        customType: "smart-compact-policy",
+        data: { version: 3, overrides: { autoTrigger: false } },
+      },
+    ];
+    const test = harness(branch);
+    test.policy.restore(test.ctx);
+    expect(test.policy.snapshot().agentToolAccess).toBe("inherit");
+
+    fs.writeFileSync(
+      path.join(home, ".pi", "agent", "settings.json"),
+      JSON.stringify({
+        smartCompact: { agentToolAccess: "disabled", autoTrigger: true },
+      }),
+    );
+    resetConfigCache();
+    test.policy.restore(test.ctx);
+
+    expect(test.policy.snapshot()).toEqual({
+      agentToolAccess: "disabled",
+      agentToolEnabled: false,
+      autoTrigger: false,
+      showStatus: true,
+    });
+    expect(test.policy.branchOverrides()).toEqual({ autoTrigger: false });
+  });
+
+  it("resets one override to the current global default", () => {
+    const test = harness();
+    test.policy.restore(test.ctx);
+    test.policy.update(
+      { agentToolAccess: "disabled", autoTrigger: false },
+      test.ctx,
+    );
+    const result = test.policy.reset("autoTrigger", test.ctx);
+
+    expect(result.ok).toBe(true);
+    expect(result.policy.autoTrigger).toBe(true);
+    expect(test.policy.branchOverrides()).toEqual({
+      agentToolAccess: "disabled",
+    });
+    expect(test.writes.at(-1)).toEqual({
+      customType: "smart-compact-policy",
+      data: {
+        version: 3,
+        overrides: { agentToolAccess: "disabled" },
+      },
+    });
   });
 
   it("disables both automatic lifecycle paths while manual registration remains", async () => {
@@ -163,7 +221,9 @@ describe("smart compact runtime policy", () => {
       },
     };
 
-    await handlers.get("session_start")![0]({}, ctx);
+    for (const handler of handlers.get("session_start") ?? []) {
+      await handler({}, ctx);
+    }
     await handlers.get("agent_settled")![0]({}, ctx);
     const nativeResult = await handlers.get("session_before_compact")![0](
       {
@@ -224,8 +284,13 @@ describe("smart compact runtime policy", () => {
     expect(test.statuses.at(-1)).toBeUndefined();
   });
 
-  it("falls back to global defaults when branch state is absent or invalid", () => {
+  it("keeps the last valid branch state when a trailing entry is invalid", () => {
     const test = harness([
+      {
+        type: "custom",
+        customType: "smart-compact-policy",
+        data: { version: 3, overrides: { autoTrigger: false } },
+      },
       {
         type: "custom",
         customType: "smart-compact-policy",
@@ -237,10 +302,10 @@ describe("smart compact runtime policy", () => {
     expect(test.policy.snapshot()).toEqual({
       agentToolAccess: "inherit",
       agentToolEnabled: true,
-      autoTrigger: true,
+      autoTrigger: false,
       showStatus: true,
     });
-    expect(test.statuses.at(-1)).toBeUndefined();
+    expect(test.statuses.at(-1)).toBe("smart-compact: auto off");
   });
 
   it("does not override a host tool deactivation while access is inherited", () => {
@@ -272,7 +337,10 @@ describe("smart compact runtime policy", () => {
   });
 
   it("rolls runtime state back when session persistence fails", () => {
-    const test = harness([], { appendError: true });
+    const test = harness([], {
+      appendError: true,
+      addSiblingBeforeAppendError: true,
+    });
     test.policy.restore(test.ctx);
     const result = test.policy.update(
       { agentToolAccess: "disabled", autoTrigger: false },
@@ -280,7 +348,12 @@ describe("smart compact runtime policy", () => {
     );
 
     expect(result.ok).toBe(false);
-    expect(test.active()).toEqual(["read", "smart_compact", "smart_recall"]);
+    expect(test.active()).toEqual([
+      "read",
+      "smart_recall",
+      "sibling_tool",
+      "smart_compact",
+    ]);
     expect(test.policy.snapshot()).toEqual({
       agentToolAccess: "inherit",
       agentToolEnabled: true,


### PR DESCRIPTION
## Summary

- unify every Smart Compact option under categorized `/smart-compact settings` TUI
- persist global defaults with owner-safe locked atomic writes and sparse branch overrides
- hot-apply tool/status/context-memory visibility while preserving manual host choices
- add model, numeric, path, pin, and profile-budget editors with shared validation bounds
- release stable `pi-smart-compact@9.6.0`

## Validation

- `bun install --frozen-lockfile`
- `bun run release:check`
- `bun run compat:pi 0.84.0`
- `bun audit`
- `npm pack --dry-run --json`
- 957 tests passed
