### PR TITLE
release: 9.6.1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,7 @@ section is about lifecycle.
 | --- | --- |
 | `/smart-compact` | Manual command. Explainable target-first preflight or direct args. Bypasses the adaptive pressure gate, not yield/verification gates. |
 | `session_before_compact` | Auto hook. Returns/stages a pending summary or runs under pressure; durable commit waits for matching `session_compact`. |
+| `session_compact_failed` | Pi 0.85 failure hook. Clears extension-owned staged state and records one error/cancellation outcome; older hosts simply never emit it. |
 | `agent_settled` | Opt-in pressure monitor. Requests `ctx.compact()` only; it never runs EESV or consumes/stages pending state. |
 | `smart_compact` tool | Agent-callable. Prepares a pending summary; never compacts mid-turn. |
 | `smart_recall` tool | Searches only the current project's bounded context graph; same session/branch ranks first. |
@@ -36,7 +37,8 @@ token/percentage, queue, in-flight, and per-session cooldown guards, then asks
 Pi for a normal host compaction. Pi re-enters `session_before_compact`, which
 reuses an already tool-staged summary or runs EESV exactly once under the
 host's signal and timeout. The matching `session_compact` event remains the
-only durable commit authority. This keeps proactive triggering out of the
+only durable commit authority; `session_compact_failed` discards the staged
+candidate without committing it. This keeps proactive triggering out of the
 pending/commit state machine and preserves branch-provenance checks.
 
 ### Host dependency boundary
@@ -72,7 +74,7 @@ threads a typed context through ten stages:
 | 1 | prepare | `app/steps/prepare.ts` | config + provider caps + budgets; auth remains lazy |
 | 2 | window | `app/steps/window.ts` | pick the prefix using a calibrated final-summary allowance |
 | 3 | recover | `app/steps/recover.ts` | restore log-truncated messages |
-| 4 | tier | `app/steps/tier.ts` | choose none / light / full |
+| 4 | tier | `app/steps/tier.ts` | admission gate + none / light / full pressure label; mode owns strategy |
 | 5 | extract | `app/steps/extract.ts` | prune + deterministic extraction + cache |
 | 6 | synthesize | `app/steps/synthesize.ts` | single-pass or EESV |
 | 7 | verify | `app/steps/verify.ts` | structural verify + repair; high-risk outcomes require successful tool evidence |
@@ -99,8 +101,8 @@ RcBase
   → StatedRc        (after state)
 ```
 
-Each stage adds a `_prepared` / `_windowed` / … discriminator field that is
-**never read at runtime** — it exists only to carry the type-level proof.
+Each stage adds a `_prepared` / `_windowed` / … discriminator field that
+carries the type-level proof and is checked by `advance()` at runtime.
 Mutation is preserved: a step mutates its input object and casts it to the
 next stage (no per-step copy of ~30 fields). The final alias
 `RunContext = StatedRc` keeps post-`buildState` consumers readable.
@@ -486,7 +488,7 @@ The code is organized into six layers, each with a single responsibility.
 | `app/steps/prepare.ts` | resolve config, provider caps, budgets, and cancellation; stage auth resolves lazily |
 | `app/steps/window.ts` | pick the prefix using provider-calibrated synthesis and deterministic post-processing bounds |
 | `app/steps/recover.ts` | recover full content for log-truncated messages |
-| `app/steps/tier.ts` | choose compaction tier (none / light / full) |
+| `app/steps/tier.ts` | admission gate + context-pressure label (none / light / full); modes own execution depth |
 | `app/steps/extract.ts` | pruning + deterministic extraction with incremental cache |
 | `app/steps/synthesize.ts` | single-pass / EESV synthesis |
 | `app/steps/verify.ts` | structural verification + repair with tool-result trust boundaries |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,25 @@
 
 ## [Unreleased]
 
+## [9.6.1] - 2026-09-04
+
 ### Changed
 
 - The package now declares its emitted artifact as ESM, and release audit pins that metadata in both source and packed manifests.
 - Internal `light` / `full` tiers are documented as admission/pressure labels; Fast, Balanced, and Thorough remain the controls that change synthesis strategy.
+- The Pi compatibility workspace now declares `@earendil-works/pi-server`, and Bun declarations are updated to 1.4.0.
 
 ### Fixed
 
 - Empty, truncated, partial, duplicate, or otherwise malformed batch-summary responses are rejected before cache insertion, so deterministic fallback is visible in telemetry and a retry can reach the provider.
 - Pi 0.85 `session_compact_failed` events now clear correlated extension candidates, progress UI, and deferred backup state while recording exactly one error/cancellation outcome.
+- Result overlays support Pi 0.85's split scrollbar track/thumb styling while retaining the Pi 0.84 API fallback.
 - Runtime pipeline transitions now reject a skipped stage even when a fresh object carries no earlier stage marker.
 
 ### Performance
 
 - File-reference extraction uses a semantics-preserving linear scanner instead of a regex with quadratic backtracking on long dotless tokens.
-- Summary verification pre-indexes path suffixes and ownership once, removing repeated reference × path normalization and allocation.
+- Summary verification uses bounded path-suffix and ownership indexes, removing repeated reference × path normalization without unbounded suffix allocation.
 
 ## [9.6.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Changed
+
+- The package now declares its emitted artifact as ESM, and release audit pins that metadata in both source and packed manifests.
+- Internal `light` / `full` tiers are documented as admission/pressure labels; Fast, Balanced, and Thorough remain the controls that change synthesis strategy.
+
+### Fixed
+
+- Empty, truncated, partial, duplicate, or otherwise malformed batch-summary responses are rejected before cache insertion, so deterministic fallback is visible in telemetry and a retry can reach the provider.
+- Pi 0.85 `session_compact_failed` events now clear correlated extension candidates, progress UI, and deferred backup state while recording exactly one error/cancellation outcome.
+- Runtime pipeline transitions now reject a skipped stage even when a fresh object carries no earlier stage marker.
+
+### Performance
+
+- File-reference extraction uses a semantics-preserving linear scanner instead of a regex with quadratic backtracking on long dotless tokens.
+- Summary verification pre-indexes path suffixes and ownership once, removing repeated reference × path normalization and allocation.
+
 ## [9.6.0] - 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ prompt.
 | --- | --- |
 | `/smart-compact` | Explicit manual run. Opens a target-first preflight or accepts direct args, dry-run, focus, and budgets. |
 | `session_before_compact` | Auto path. Returns/stages a verification-scored summary under pressure; durable state waits for matching `session_compact`. |
+| `session_compact_failed` | Pi 0.85 cleanup path. Discards extension-owned staged state and records a failed/cancelled outcome; it is inert on older hosts. |
 | `smart_compact` tool | Agent path. Produces a pending summary for Pi's next natural compact; does not compact mid-turn. Can be hidden from the agent. |
 | `/smart-compact loops` | Project-level open-loop manager: resolve/reopen, priority, pin/unpin. |
 | `/smart-compact settings` | Unified TUI for branch overrides and every `smartCompact` global setting. Manual `/smart-compact` always remains available. |

--- a/bench/hot-paths.bench.ts
+++ b/bench/hot-paths.bench.ts
@@ -6,7 +6,12 @@ import {
 } from "../src/utils/extraction.ts";
 import { pruneRedundant } from "../src/utils/pruning.ts";
 import { parseSummary } from "../src/domain/summary-parse.ts";
-import { buildUniquePathNeedles } from "../src/utils/file-needles.ts";
+import {
+  buildKnownPathReferenceIndex,
+  buildPathNeedleOwnershipIndex,
+  buildUniquePathNeedles,
+} from "../src/utils/file-needles.ts";
+import { extractFileRefs } from "../src/utils/file-ref-detect.ts";
 import { chunkLlmMessages } from "../src/phases/synthesize.ts";
 import { verifySummary } from "../src/phases/verify.ts";
 import { resolveProviderWatchdogMs } from "../src/infra/llm-client.ts";
@@ -36,6 +41,10 @@ const fullConversation: LlmMessage[] = Array.from(
 ).flat();
 const incrementalDelta = fullConversation.slice(-100);
 const oneMegabyteSummary = "## Goal\n" + "x".repeat(1_000_000);
+const longDotlessToken = "x".repeat(24_000);
+const longLeadingDotToken = ".a" + "x".repeat(24_000);
+const longUnicodePath = "é".repeat(16_000) + "/Auth.ts";
+const deepSlashPath = "a/".repeat(8_000) + "Auth.ts";
 const collidingPaths = Array.from(
   { length: 500 },
   (_, i) => "packages/p" + i + "/src/index.ts",
@@ -90,8 +99,12 @@ const P95_LIMIT_MS: Record<string, number> = {
   "prune 5k messages": 30,
   "chunk + bound 5k messages": 40,
   "parse 1MB canonical summary": 5,
+  "scan 24k dotless file-ref token": 5,
+  "scan 24k leading-dot file-ref token": 5,
+  "index 16k unicode path": 20,
+  "index 8k-segment path ownership": 20,
   "unique needles across 500 paths": 2,
-  "verify 500 grounded paths": 250,
+  "verify 500 grounded paths": 50,
   "resolve provider watchdog profile": 0.1,
 };
 
@@ -145,6 +158,34 @@ const benchmarks: Benchmark[] = [
     iterations: 5,
     run: () => {
       sink += parseSummary(oneMegabyteSummary).sections[0]?.body.length ?? 0;
+    },
+  },
+  {
+    name: "scan 24k dotless file-ref token",
+    iterations: 20,
+    run: () => {
+      sink += extractFileRefs(longDotlessToken).length;
+    },
+  },
+  {
+    name: "scan 24k leading-dot file-ref token",
+    iterations: 20,
+    run: () => {
+      sink += extractFileRefs(longLeadingDotToken).length;
+    },
+  },
+  {
+    name: "index 16k unicode path",
+    iterations: 5,
+    run: () => {
+      sink += buildKnownPathReferenceIndex([longUnicodePath]).boundarySuffixes.size;
+    },
+  },
+  {
+    name: "index 8k-segment path ownership",
+    iterations: 5,
+    run: () => {
+      sink += buildPathNeedleOwnershipIndex([deepSlashPath]).counts.size;
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "pi-smart-compact",
 	"version": "9.6.0",
 	"description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
+	"type": "module",
 	"packageManager": "bun@1.4.0",
 	"engines": {
 		"node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-smart-compact",
-	"version": "9.6.0",
+	"version": "9.6.1",
 	"description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
 	"type": "module",
 	"packageManager": "bun@1.4.0",

--- a/scripts/release-audit.ts
+++ b/scripts/release-audit.ts
@@ -26,8 +26,11 @@ function run(command: string[], cwd = workspace): string {
 
 try {
   const sourceManifest = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
-    name: string; version: string; peerDependencies: Record<string, string>;
+    name: string; version: string; type?: string; peerDependencies: Record<string, string>;
   };
+  if (sourceManifest.type !== "module") {
+    throw new Error("package.json must declare type=module for the ESM artifact");
+  }
   const constants = readFileSync(join(root, "src/constants.ts"), "utf8");
   if (!constants.includes(`export const VERSION = "${sourceManifest.version}";`)) {
     throw new Error("package.json and src/constants.ts versions differ");
@@ -69,6 +72,9 @@ try {
   const packedManifest = JSON.parse(run(["tar", "-xOf", tarball, "package/package.json"])) as typeof sourceManifest;
   if (packedManifest.name !== sourceManifest.name || packedManifest.version !== sourceManifest.version) {
     throw new Error("packed manifest identity differs from source");
+  }
+  if (packedManifest.type !== "module") {
+    throw new Error("packed manifest lost type=module");
   }
 
   const peerPaths: Record<string, string> = {};

--- a/src/app/run-context.ts
+++ b/src/app/run-context.ts
@@ -25,9 +25,9 @@
  *
  * Implementation note: mutation is preserved. Each step mutates the input
  * object and returns it cast to the next stage. The `_brand` field on each
- * extension is the only thing that distinguishes stages structurally — it is
- * never read at runtime. This lets us avoid copying ~30 fields per step
- * while still getting compile-time stage tracking.
+ * extension distinguishes stages structurally and is checked by `advance()`
+ * at runtime. This lets us avoid copying ~30 fields per step while retaining
+ * both compile-time and runtime stage tracking.
  *
  * The final `RunContext = StatedRc` alias keeps backwards-compatible imports
  * working for the `applyCompaction` / metrics paths that ran post-`buildState`.
@@ -213,8 +213,9 @@ export type RecoveredRc = RcBase & RecoveredExt;
 
 // ── Stage 4: Tiered ──────────────────────────────────────────────────────────
 //
-// After `selectTier`. If the tier is "none" the orchestrator bails before
-// any further work; only "light" or "full" reach later stages.
+// After `selectTier`. This is an admission gate plus a pressure label for
+// telemetry/UI: execution depth is controlled separately by CompactionMode.
+// If the tier is "none" the orchestrator bails before any further work.
 
 export type ActiveTier = Exclude<CompactionTier, "none">;
 
@@ -338,20 +339,21 @@ const STAGE_REQUIRED_FIELDS: Record<StageMarker, readonly string[]> = {
 /** Runtime-checked, in-place transition between adjacent pipeline stages. */
 export function advance<TIn extends RcBase, TOut extends TIn>(rc: TIn, stage: keyof TOut): TOut {
   if (!STAGE_ORDER.includes(stage as StageMarker)) throw new Error("Unknown pipeline stage: " + String(stage));
-  const marker = stage as StageMarker;
-  const index = STAGE_ORDER.indexOf(marker);
-  const record = rc as unknown as Record<string, unknown>;
-  const hasStageHistory = STAGE_ORDER.some(candidate => record[candidate] === true);
-  if (hasStageHistory) {
-    for (let prior = 0; prior < index; prior++) {
-      if (record[STAGE_ORDER[prior]] !== true) {
-        throw new Error("Pipeline stage out of order: " + marker + " requires " + STAGE_ORDER[prior]);
-      }
-    }
-  }
+	const marker = stage as StageMarker;
+	const index = STAGE_ORDER.indexOf(marker);
+	// SAFETY: `record` is used only for runtime marker/field presence checks;
+	// no value is trusted as a typed stage until every invariant below passes.
+	const record = rc as unknown as Record<string, unknown>;
+	for (let prior = 0; prior < index; prior++) {
+		if (record[STAGE_ORDER[prior]] !== true) {
+			throw new Error("Pipeline stage out of order: " + marker + " requires " + STAGE_ORDER[prior]);
+		}
+	}
   for (const field of STAGE_REQUIRED_FIELDS[marker]) {
     if (!(field in rc)) throw new Error("Pipeline stage " + marker + " missing field: " + field);
-  }
-  Object.defineProperty(rc, marker, { value: true, enumerable: true, configurable: false, writable: false });
-  return rc as unknown as TOut;
+	}
+	Object.defineProperty(rc, marker, { value: true, enumerable: true, configurable: false, writable: false });
+	// SAFETY: all preceding markers and every field required by this stage were
+	// checked above before installing the immutable discriminator.
+	return rc as unknown as TOut;
 }

--- a/src/app/steps/tier.ts
+++ b/src/app/steps/tier.ts
@@ -1,11 +1,12 @@
 /**
- * Step 4: select compaction tier.
+ * Step 4: apply the admission gate and record context-pressure tier.
  *
  * Stage: `RecoveredRc` → `TieredRc | null`.
  *
- * Returns `null` for tier="none" so the orchestrator can short-circuit. Only
- * "light" and "full" tiers reach later stages, which is enforced statically
- * by the `ActiveTier` type on `TieredRc.tier`.
+ * Returns `null` for tier="none" so the orchestrator can short-circuit. The
+ * "light" / "full" value is a telemetry and UI pressure label; Fast,
+ * Balanced, and Thorough modes independently control downstream strategy.
+ * `ActiveTier` statically proves that an admitted run cannot carry "none".
  */
 
 import type { RecoveredRc, TieredRc, ActiveTier } from "../run-context.ts";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "9.6.0";
+export const VERSION = "9.6.1";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.1;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;

--- a/src/domain/scrub.ts
+++ b/src/domain/scrub.ts
@@ -198,20 +198,20 @@ export class SecretScrubber {
       findings.set("credential", (findings.get("credential") ?? 0) + 1);
       this.total++;
     };
-    const visit = (value: unknown): unknown => {
+    const visit = <Value>(value: Value): Value => {
       if (typeof value === "string") {
         const result = this.scrubText(value);
         mergeFindings(findings, result.findings);
-        return result.value;
+        return result.value as Value;
       }
       if (value == null || typeof value !== "object") return value;
       const cached = seen.get(value);
-      if (cached !== undefined) return cached;
+      if (cached !== undefined) return cached as Value;
       if (Array.isArray(value)) {
         const output: unknown[] = [];
         seen.set(value, output);
         for (const item of value) output.push(visit(item));
-        return output;
+        return output as Value;
       }
       const output: Record<string, unknown> = {};
       seen.set(value, output);
@@ -229,9 +229,9 @@ export class SecretScrubber {
           output[key] = visit(item);
         }
       }
-      return output;
+      return output as Value;
     };
-    const value = visit(input) as T;
+    const value = visit(input);
     return {
       value,
       findings: [...findings].map(([kind, count]) => ({ kind, count })),

--- a/src/domain/tool-semantics.ts
+++ b/src/domain/tool-semantics.ts
@@ -240,9 +240,25 @@ export function classifyToolOperation(args: unknown, toolName?: string): ToolOpe
   if (hasPath || nameHas(name, ["read"])) return "read";
   return "unknown";
 }
-function stableValue(value: unknown): unknown {
+type StableJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | StableJsonValue[]
+  | { [key: string]: StableJsonValue };
+
+function stableValue(value: unknown): StableJsonValue {
   if (Array.isArray(value)) return value.map(stableValue);
-  if (!value || typeof value !== "object") return value;
+  if (
+    value == null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value !== "object") return undefined;
   return Object.fromEntries(
     Object.entries(value as Args)
       .sort(([left], [right]) => left.localeCompare(right))

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,26 @@ import { createSmartCompactPolicy } from "./app/smart-compact-policy.ts";
 
 export { findModelById, resolveModels } from "./app/model-routing.ts";
 
+/** Pi 0.85 lifecycle event; kept local so the extension still typechecks with older peers. */
+interface SessionCompactFailedEventCompat {
+  type: "session_compact_failed";
+  reason: "manual" | "threshold" | "overflow";
+  errorMessage?: string;
+  aborted: boolean;
+  willRetry: boolean;
+  fromExtension: boolean;
+}
+
+interface CompactFailedEventApi {
+  on(
+    event: "session_compact_failed",
+    handler: (
+      event: SessionCompactFailedEventCompat,
+      ctx: ExtensionContext,
+    ) => void | Promise<void>,
+  ): void;
+}
+
 /**
  * Translate a `ConsumeResult` into the side-effects the host expects:
  *   - log the reason (warn for expired/mismatch, debug for empty)
@@ -140,13 +160,14 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
   // Filesystem-backed, one-shot handoff survives extension reloads/process
   // restarts while project/session/branch scope prevents sibling leakage.
   const nativeContinuity = createNativeContinuityBridge();
+  const applyFailureWrites = new Map<string, Promise<boolean>>();
   const recordApplyFailure = (
     pending: PendingCompaction,
     reason: CommitDiscardReason,
-  ): void => {
-    if (!pending.metricsSnapshot) return;
+  ): Promise<boolean> | null => {
+    if (!pending.metricsSnapshot) return null;
     const cancelled = reason === "aborted" || reason === "shutdown";
-    void appendMetricsSnapshot(pending.sessionId, {
+    const write = appendMetricsSnapshot(pending.sessionId, {
       ...pending.metricsSnapshot,
       status: cancelled ? "cancelled" : "error",
       failureKind: cancelled
@@ -156,9 +177,18 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
           : "persistence",
       fallbackReason: "native-apply:" + reason,
     });
+    applyFailureWrites.set(pending.runId, write);
+    void write.finally(() => {
+      if (applyFailureWrites.get(pending.runId) === write) {
+        applyFailureWrites.delete(pending.runId);
+      }
+    });
+    return write;
   };
   const commitCandidates = createCompactionCommitStore({
-    onDiscard: recordApplyFailure,
+    onDiscard: (pending, reason) => {
+      void recordApplyFailure(pending, reason);
+    },
   });
   const onNativeApplyError = (runId: string): boolean =>
     Boolean(commitCandidates.discard(runId, "apply-error"));
@@ -184,7 +214,7 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
       return !signal.aborted;
     } catch (error) {
       log.warn("Failed to stage smart compaction commit candidate", error);
-      recordApplyFailure(pending, "apply-error");
+      void recordApplyFailure(pending, "apply-error");
       return false;
     }
   };
@@ -404,6 +434,32 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
         { projectId, sessionId, branchHeadId },
         renderContinuityCapsule(state),
       );
+  });
+
+  // SAFETY: Pi 0.85 added this event without changing the runtime `on`
+  // contract. Older supported hosts accept the registration and simply never
+  // emit it, so the narrow compatibility cast is safe in both directions.
+  const compactFailedEvents = pi as unknown as CompactFailedEventApi;
+  compactFailedEvents.on("session_compact_failed", async (event, ctx) => {
+    if (!event.fromExtension) return;
+    const sessionId = resolveSessionId(ctx);
+    clearCompactProgress(ctx);
+    const reason: CommitDiscardReason = event.aborted ? "aborted" : "apply-error";
+    const discarded = commitCandidates.clearSession(sessionId, reason);
+    const metricWrites = discarded.flatMap((pending) => {
+      const write = applyFailureWrites.get(pending.runId);
+      return write ? [write] : [];
+    });
+    if (metricWrites.length > 0) await Promise.all(metricWrites);
+    if (discarded.length > 0) {
+      log.warn(
+        "Discarded " +
+          discarded.length +
+          " staged smart compaction after native apply " +
+          (event.aborted ? "abort" : "failure") +
+          (event.errorMessage ? ": " + event.errorMessage : ""),
+      );
+    }
   });
 
   pi.on("before_agent_start", async (_event, ctx) => {

--- a/src/infra/ai-messages.ts
+++ b/src/infra/ai-messages.ts
@@ -43,6 +43,8 @@ export function asBranchMessage(message: unknown): Message {
  * `role` + `content` to render text, so the upcast is sound.
  */
 export function asSerializableMessages(msgs: LlmMessage[]): Message[] {
+  // SAFETY: `convertToLlm` produced these messages and pruning preserves every
+  // discriminant/identity field required by the corresponding Pi message type.
   return msgs as unknown as Message[];
 }
 

--- a/src/infra/context-graph.ts
+++ b/src/infra/context-graph.ts
@@ -81,9 +81,9 @@ export interface ContextGraphStats {
 }
 
 interface SqliteStatement {
-  run(...params: unknown[]): unknown;
-  all(...params: unknown[]): unknown[];
-  get(...params: unknown[]): unknown;
+  run(...params: unknown[]): void;
+  all<Row extends object = Record<string, unknown>>(...params: unknown[]): Row[];
+  get<Row extends object = Record<string, unknown>>(...params: unknown[]): Row | null;
 }
 
 interface SqliteDatabase {

--- a/src/phases/explore.ts
+++ b/src/phases/explore.ts
@@ -133,13 +133,31 @@ const EXPLORATION_TOOLS: Tool[] = [
   },
 ];
 
-function boundedExplorationValue(value: unknown, depth = 0): unknown {
+type JsonCompatibleValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | JsonCompatibleValue[]
+  | { [key: string]: JsonCompatibleValue };
+
+function boundedExplorationValue(
+  value: unknown,
+  depth = 0,
+): JsonCompatibleValue {
   if (typeof value === "string") {
     return value.length > TRUNC.PREVIEW_XL
       ? value.slice(0, TRUNC.PREVIEW_XL) + "…"
       : value;
   }
-  if (value == null || typeof value !== "object") return value;
+  if (
+    value == null ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value !== "object") return undefined;
   if (depth >= 3) return "[bounded]";
   if (Array.isArray(value))
     return value
@@ -157,7 +175,7 @@ function serializeExplorationResult(
   scrubber: SecretScrubber,
 ): string {
   const safe = boundedExplorationValue(scrubber.scrubValue(value).value);
-  const serialized = JSON.stringify(safe);
+  const serialized = JSON.stringify(safe) ?? "null";
   if (serialized.length <= MAX_EXPLORER_OUTPUT_CHARS) return serialized;
 
   let excerptChars = Math.max(

--- a/src/phases/synthesize.ts
+++ b/src/phases/synthesize.ts
@@ -54,18 +54,113 @@ function batchFieldPattern(name: string): RegExp {
 	let pattern = batchFieldPatterns.get(name);
 	if (!pattern) {
 		const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-		pattern = new RegExp("\\*\\*" + escaped + "\\*\\*:\\s*(.+?)(?:\\n|$)", "i");
+		pattern = new RegExp(
+			"(?:^|\\n)\\*\\*" + escaped + "\\*\\*:\\s*(.+?)(?:\\n|$)",
+			"i",
+		);
 		batchFieldPatterns.set(name, pattern);
 	}
 	return pattern;
 }
 
-function boundedToolArgs(value: unknown, depth = 0): unknown {
+/** A provider response completed, but did not satisfy the batch-output contract. */
+export class BatchSummaryFormatError extends Error {
+	readonly name = "BatchSummaryFormatError";
+
+	constructor(reason: string) {
+		super("Malformed batch summary response: " + reason);
+	}
+}
+
+const BATCH_REQUIRED_FIELDS = [
+	"Priority",
+	"Summary",
+	"Decisions",
+	"Modified",
+	"Deleted",
+	"Read",
+] as const;
+
+function assertCompleteBatchResponse(
+	stopReason: unknown,
+	sectionMap: ReadonlyMap<number, string>,
+	duplicateIds: ReadonlySet<number>,
+	batchSize: number,
+): void {
+	const reason = String(stopReason ?? "");
+	// `endTurn` is retained for older pi-ai/provider fixtures. Current pi-ai
+	// normalizes an ordinary completion to `stop`.
+	if (reason !== "stop" && reason !== "endTurn") {
+		throw new BatchSummaryFormatError("non-terminal stop reason " + (reason || "unknown"));
+	}
+	if (duplicateIds.size > 0) {
+		throw new BatchSummaryFormatError(
+			"duplicate chunk id(s): " + [...duplicateIds].sort((a, b) => a - b).join(", "),
+		);
+	}
+	const unexpected = [...sectionMap.keys()].filter(
+		(id) => id < 1 || id > batchSize,
+	);
+	if (unexpected.length > 0) {
+		throw new BatchSummaryFormatError(
+			"unexpected chunk id(s): " + unexpected.sort((a, b) => a - b).join(", "),
+		);
+	}
+	const missingSections: number[] = [];
+	for (let id = 1; id <= batchSize; id++) {
+		if (!sectionMap.has(id)) missingSections.push(id);
+	}
+	if (missingSections.length > 0) {
+		throw new BatchSummaryFormatError(
+			"missing chunk section(s): " + missingSections.join(", "),
+		);
+	}
+	for (let id = 1; id <= batchSize; id++) {
+		const section = sectionMap.get(id) ?? "";
+		const missingFields = BATCH_REQUIRED_FIELDS.filter(
+			(field) => !batchFieldPattern(field).test(section),
+		);
+		if (missingFields.length > 0) {
+			throw new BatchSummaryFormatError(
+				"chunk " + id + " missing field(s): " + missingFields.join(", "),
+			);
+		}
+	}
+	const missing: number[] = [];
+	for (let id = 1; id <= batchSize; id++) {
+		const section = sectionMap.get(id);
+		const summary = section?.match(batchFieldPattern("Summary"))?.[1].trim();
+		if (!summary || summary.toLowerCase() === "none") missing.push(id);
+	}
+	if (missing.length > 0) {
+		throw new BatchSummaryFormatError(
+			"missing usable Summary for chunk(s): " + missing.join(", "),
+		);
+	}
+}
+
+type JsonCompatibleValue =
+	| string
+	| number
+	| boolean
+	| null
+	| undefined
+	| JsonCompatibleValue[]
+	| { [key: string]: JsonCompatibleValue };
+
+function boundedToolArgs(value: unknown, depth = 0): JsonCompatibleValue {
 	if (typeof value === "string")
 		return value.length > TRUNC.DETAIL
 			? value.slice(0, TRUNC.DETAIL) + "…"
 			: value;
-	if (value == null || typeof value !== "object" || depth >= 2) return value;
+	if (
+		value == null ||
+		typeof value === "number" ||
+		typeof value === "boolean"
+	) return value;
+	if (typeof value === "bigint") return value.toString();
+	if (typeof value !== "object") return undefined;
+	if (depth >= 2) return "[bounded]";
 	if (Array.isArray(value))
 		return value.slice(0, 8).map((item) => boundedToolArgs(item, depth + 1));
 	return Object.fromEntries(
@@ -543,13 +638,22 @@ export async function summarizeBatch(
 
 	// ID-based parsing: map chunk number -> section content
 	const sectionMap = new Map<number, string>();
+	const duplicateIds = new Set<number>();
 	const sections = output.split(/^### /m).filter((s) => s.trim());
 	for (const sec of sections) {
 		const m = sec.match(/^CHUNK\s+(\d+):\s*(.*?)\n/i);
 		if (m) {
-			sectionMap.set(parseInt(m[1], 10), sec);
+			const id = parseInt(m[1], 10);
+			if (sectionMap.has(id)) duplicateIds.add(id);
+			else sectionMap.set(id, sec);
 		}
 	}
+	assertCompleteBatchResponse(
+		resp.stopReason,
+		sectionMap,
+		duplicateIds,
+		batch.length,
+	);
 
 	const result = batch.map((ch, i) => {
 		const id = i + 1;

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -29,8 +29,10 @@ import {
 	isDiagnosticConstraintText,
 } from "../utils/extraction.ts";
 import {
-	buildUniquePathNeedles,
-	isKnownPathReference,
+	buildKnownPathReferenceIndex,
+	buildPathNeedleOwnershipIndex,
+	buildUniquePathNeedlesFromIndex,
+	isKnownPathReferenceInIndex,
 	normalizePath,
 } from "../utils/file-needles.ts";
 import * as log from "../utils/logger.ts";
@@ -1117,8 +1119,9 @@ function verifyFileReferences(
 		...(continuity?.unresolvedErrors ?? []).flatMap((error) => error.files),
 		...(continuity?.openLoops ?? []).flatMap((loop) => loop.files),
 	]));
+	const knownFileIndex = buildKnownPathReferenceIndex(knownFiles);
 	for (const ref of new Set(extractFileRefs(summary))) {
-		const grounded = isKnownPathReference(ref, knownFiles)
+		const grounded = isKnownPathReferenceInIndex(ref, knownFileIndex)
 			|| Boolean(evidence.sourceMessages
 				&& sourceSupportsFileReference(ref, evidence.sourceMessages));
 		if (!grounded) addGap(accumulator, { kind: "fabricated-file", ref }, 4);
@@ -1144,9 +1147,11 @@ function verifyProgressConsistency(
 		}, 12);
 	}
 	const doneRefs = new Set(extractFileRefs(done).map(normalizePath));
+	const modifiedPathOwners = buildPathNeedleOwnershipIndex(paths.modified);
 	for (const file of extraction.modifiedFiles) {
-		const needles = buildUniquePathNeedles(file.path, paths.modified);
-		if (!needles.some((needle) => doneRefs.has(normalizePath(needle)))) continue;
+		const needles = buildUniquePathNeedlesFromIndex(file.path, modifiedPathOwners);
+		// Indexed needles are already normalized, as are the extracted Done refs.
+		if (!needles.some((needle) => doneRefs.has(needle))) continue;
 		const unresolved = collected.unresolved.find((error) => {
 			const firstLine = error.message.split(/\r?\n/, 1)[0] ?? "";
 			const refs = extractFileRefs(firstLine).map(normalizePath);

--- a/src/utils/file-needles.ts
+++ b/src/utils/file-needles.ts
@@ -90,15 +90,175 @@ export function buildUniquePathNeedles(
 	filePath: string,
 	allPaths: readonly string[],
 ): string[] {
-	const normalized = allPaths.map(normalizePath);
-	return buildPathNeedles(filePath).filter((needle) => {
-		let owners = 0;
-		for (const candidate of normalized) {
-			if (candidate === needle || candidate.endsWith("/" + needle)) owners++;
-			if (owners > 1) return false;
+	return buildUniquePathNeedlesFromIndex(
+		filePath,
+		buildPathNeedleOwnershipIndex(allPaths),
+	);
+}
+
+// ponytail: bound eager suffix copies; oversized paths retain exact linear fallback.
+const MAX_INDEXED_SUFFIX_CHARS = 1_024;
+
+export interface PathNeedleOwnershipIndex {
+	readonly counts: ReadonlyMap<string, number>;
+	readonly normalizedPaths: readonly string[];
+	readonly hasUnindexedSuffixes: boolean;
+}
+
+/** Count owners for every slash-boundary suffix once per supplied path. */
+export function buildPathNeedleOwnershipIndex(
+	allPaths: readonly string[],
+): PathNeedleOwnershipIndex {
+	const owners = new Map<string, number>();
+	const normalizedPaths = allPaths.map(normalizePath);
+	let hasUnindexedSuffixes = false;
+	for (const normalized of normalizedPaths) {
+		const suffixes = new Set([normalized]);
+		for (let index = 0; index < normalized.length; index++) {
+			if (normalized[index] !== "/") continue;
+			if (normalized.length - index - 1 <= MAX_INDEXED_SUFFIX_CHARS) {
+				suffixes.add(normalized.slice(index + 1));
+			} else {
+				hasUnindexedSuffixes = true;
+			}
 		}
-		return owners === 1;
+		for (const suffix of suffixes) {
+			owners.set(suffix, (owners.get(suffix) ?? 0) + 1);
+		}
+	}
+	return { counts: owners, normalizedPaths, hasUnindexedSuffixes };
+}
+
+/** Hot-loop variant that reuses suffix ownership counts across many files. */
+export function buildUniquePathNeedlesFromIndex(
+	filePath: string,
+	owners: PathNeedleOwnershipIndex,
+): string[] {
+	return buildPathNeedles(filePath).filter((needle) => {
+		if (!owners.hasUnindexedSuffixes) return owners.counts.get(needle) === 1;
+		let count = 0;
+		for (const candidate of owners.normalizedPaths) {
+			if (candidate === needle || candidate.endsWith("/" + needle)) count++;
+			if (count > 1) return false;
+		}
+		return count === 1;
 	});
+}
+
+export interface KnownPathReferenceIndex {
+	/** Full paths and every slash-boundary suffix. */
+	readonly segmentSuffixes: ReadonlySet<string>;
+	/** Sorted view used for prefix lookups of complete parent paths. */
+	readonly sortedSegmentSuffixes: readonly string[];
+	/** Suffixes beginning after a character the coarse file regex cannot consume. */
+	readonly boundarySuffixes: ReadonlySet<string>;
+	/** Normalized source paths retained for exact fallback on oversized suffixes. */
+	readonly normalizedPaths: readonly string[];
+	readonly hasUnindexedSuffixes: boolean;
+}
+
+const PATH_CANDIDATE_CHAR_RE = /[\w./-]/;
+
+/** Precompute every lookup shape accepted by `isKnownPathReference`. */
+export function buildKnownPathReferenceIndex(
+	knownPaths: readonly string[],
+): KnownPathReferenceIndex {
+	const segmentSuffixes = new Set<string>();
+	const boundarySuffixes = new Set<string>();
+	const normalizedPaths: string[] = [];
+	let hasUnindexedSuffixes = false;
+
+	for (const path of knownPaths) {
+		const normalizedPath = normalizePath(path).replace(/^\/+/, "");
+		if (!normalizedPath) continue;
+		normalizedPaths.push(normalizedPath);
+		segmentSuffixes.add(normalizedPath);
+
+		for (let index = 0; index < normalizedPath.length; index++) {
+			if (normalizedPath[index] === "/") {
+				if (normalizedPath.length - index - 1 <= MAX_INDEXED_SUFFIX_CHARS) {
+					segmentSuffixes.add(normalizedPath.slice(index + 1));
+				} else {
+					hasUnindexedSuffixes = true;
+				}
+			}
+			if (
+				index > 0 &&
+				!PATH_CANDIDATE_CHAR_RE.test(normalizedPath[index - 1])
+			) {
+				if (normalizedPath.length - index <= MAX_INDEXED_SUFFIX_CHARS) {
+					boundarySuffixes.add(normalizedPath.slice(index));
+				} else {
+					hasUnindexedSuffixes = true;
+				}
+			}
+		}
+	}
+
+	return {
+		segmentSuffixes,
+		sortedSegmentSuffixes: [...segmentSuffixes].sort(),
+		boundarySuffixes,
+		normalizedPaths,
+		hasUnindexedSuffixes,
+	};
+}
+
+function matchesKnownPathReference(
+	normalizedRef: string,
+	normalizedPaths: readonly string[],
+): boolean {
+	const pathShaped = normalizedRef.includes("/");
+	return normalizedPaths.some((normalizedPath) => {
+		if (
+			normalizedPath === normalizedRef ||
+			normalizedPath.endsWith("/" + normalizedRef)
+		) return true;
+		if (normalizedPath.endsWith(normalizedRef)) {
+			const boundary = normalizedPath[
+				normalizedPath.length - normalizedRef.length - 1
+			];
+			if (boundary && !PATH_CANDIDATE_CHAR_RE.test(boundary)) return true;
+		}
+		if (!pathShaped) return false;
+		return (
+			normalizedPath.startsWith(normalizedRef + "/") ||
+			normalizedPath.includes("/" + normalizedRef + "/")
+		);
+	});
+}
+
+function sortedHasPrefix(values: readonly string[], prefix: string): boolean {
+	let low = 0;
+	let high = values.length;
+	while (low < high) {
+		const middle = (low + high) >>> 1;
+		if (values[middle] < prefix) low = middle + 1;
+		else high = middle;
+	}
+	return values[low]?.startsWith(prefix) ?? false;
+}
+
+/** Indexed variant for hot loops that check many references against one path set. */
+export function isKnownPathReferenceInIndex(
+	ref: string,
+	index: KnownPathReferenceIndex,
+): boolean {
+	const normalizedRef = normalizePath(ref).replace(/^\/+/, "");
+	if (!normalizedRef) return false;
+	if (
+		index.segmentSuffixes.has(normalizedRef) ||
+		index.boundarySuffixes.has(normalizedRef)
+	) {
+		return true;
+	}
+	if (
+		normalizedRef.includes("/") &&
+		sortedHasPrefix(index.sortedSegmentSuffixes, normalizedRef + "/")
+	) return true;
+	return index.hasUnindexedSuffixes
+		? matchesKnownPathReference(normalizedRef, index.normalizedPaths)
+		: false;
 }
 
 /** Whether an extracted file reference can refer to at least one known path. */
@@ -108,32 +268,8 @@ export function isKnownPathReference(
 ): boolean {
 	const normalizedRef = normalizePath(ref).replace(/^\/+/, "");
 	if (!normalizedRef) return false;
-	const pathShaped = normalizedRef.includes("/");
-	return knownPaths.some((path) => {
-		const normalizedPath = normalizePath(path).replace(/^\/+/, "");
-		if (
-			normalizedPath === normalizedRef ||
-			normalizedPath.endsWith("/" + normalizedRef)
-		)
-			return true;
-
-		// The coarse file regex begins again after characters it cannot consume
-		// (spaces, `@`, non-ASCII letters). Ground that exact trailing fragment,
-		// but never an arbitrary mid-segment suffix such as `uth.ts` for `auth.ts`.
-		if (normalizedPath.endsWith(normalizedRef)) {
-			const boundary =
-				normalizedPath[normalizedPath.length - normalizedRef.length - 1];
-			if (boundary && !/[\w./-]/.test(boundary)) return true;
-		}
-		if (!pathShaped) return false;
-
-		// A dotted directory may legitimately name a complete parent segment.
-		// Never accept a partial segment such as `Foo.App` for `Foo.Application`.
-		return normalizedPath.split("/").some((_, index, parts) =>
-			parts
-				.slice(index)
-				.join("/")
-				.startsWith(normalizedRef + "/"),
-		);
-	});
+	return matchesKnownPathReference(
+		normalizedRef,
+		knownPaths.map((path) => normalizePath(path).replace(/^\/+/, "")),
+	);
 }

--- a/src/utils/file-ref-detect.ts
+++ b/src/utils/file-ref-detect.ts
@@ -34,8 +34,26 @@ export const CODE_EXT_RE =
  */
 export const VERSION_RE = /^v?\d+(?:\.\d+)+(?:[-+][\w.-]+)?$/i;
 
-/** Coarse-grained `word.ext` matcher used as the candidate generator. */
+/**
+ * Coarse-grained `word.ext` matcher retained as the public candidate grammar.
+ * `extractFileRefs` implements the same match semantics with a linear scanner:
+ * running this greedy expression directly has quadratic backtracking on long
+ * dotless tokens.
+ */
 export const FILE_REF_CANDIDATE_RE = /[\w.\/-]+\.[\w]+/g;
+
+function isAsciiWordCode(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    code === 95 ||
+    (code >= 97 && code <= 122)
+  );
+}
+
+function isCandidateCode(code: number): boolean {
+  return isAsciiWordCode(code) || code === 45 || code === 46 || code === 47;
+}
 
 /**
  * Decide whether a candidate token (already produced by
@@ -66,14 +84,42 @@ export function isLikelyFileRef(candidate: string): boolean {
  * classification.
  */
 export function extractFileRefs(summary: string): string[] {
-  const matcher = new RegExp(FILE_REF_CANDIDATE_RE.source, FILE_REF_CANDIDATE_RE.flags);
   const refs: string[] = [];
-  for (const match of summary.matchAll(matcher)) {
+  let cursor = 0;
+  while (cursor < summary.length) {
+    while (cursor < summary.length && !isCandidateCode(summary.charCodeAt(cursor))) cursor++;
+    const runStart = cursor;
+    while (cursor < summary.length && isCandidateCode(summary.charCodeAt(cursor))) cursor++;
+    const runEnd = cursor;
+
+    // This is the linear equivalent of the regex's greedy first class: use
+    // the last dot that has a word character after it, then consume that word
+    // suffix. A literal dot at runStart cannot match because `[...]+` must
+    // consume at least one character before the regex's `\.`.
+    let extensionDot = -1;
+    for (let index = runStart + 1; index + 1 < runEnd; index++) {
+      if (
+        summary.charCodeAt(index) === 46 &&
+        isAsciiWordCode(summary.charCodeAt(index + 1))
+      ) {
+        extensionDot = index;
+      }
+    }
+    if (extensionDot < 0) continue;
+
+    let matchEnd = extensionDot + 2;
+    while (
+      matchEnd < runEnd &&
+      isAsciiWordCode(summary.charCodeAt(matchEnd))
+    ) {
+      matchEnd++;
+    }
+    const candidate = summary.slice(runStart, matchEnd);
     // `Foo.Application/Services` is a directory path, not a file named
     // `Foo.Application`. A separator immediately after the regex match proves
     // the candidate was only a dotted directory prefix.
-    if (/[\\/]/.test(summary[(match.index ?? 0) + match[0].length] ?? "")) continue;
-    if (isLikelyFileRef(match[0])) refs.push(match[0]);
+    if (/[\\/]/.test(summary[matchEnd] ?? "")) continue;
+    if (isLikelyFileRef(candidate)) refs.push(candidate);
   }
   return refs;
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -567,6 +567,7 @@ export function computeToolCharPercentage(
   return totalChars > 0 ? Math.round((toolChars / totalChars) * 100) : 0;
 }
 
+/** Admission result plus context-pressure label; modes own execution depth. */
 export type CompactionTier = "none" | "light" | "full";
 
 export function selectCompactionTier(

--- a/test/batch-synthesis.test.ts
+++ b/test/batch-synthesis.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai";
+import { createServices } from "../src/infra/services.ts";
+import { clearSynthesisCache } from "../src/infra/synthesis-cache.ts";
+import {
+	BatchSummaryFormatError,
+	summarizeBatch,
+} from "../src/phases/synthesize.ts";
+import type {
+	LlmChunk,
+	LlmMessage,
+	StructuredExtraction,
+} from "../src/types.ts";
+
+const model = {
+	provider: "test-provider",
+	id: "test-model",
+	api: "openai-responses",
+	contextWindow: 100_000,
+} as Model<Api>;
+
+const extraction: StructuredExtraction = {
+	modifiedFiles: [],
+	readFiles: [],
+	deletedFiles: [],
+	errors: [],
+	decisions: [],
+	constraints: [],
+	topics: [],
+	timeline: [],
+	mainGoal: "Preserve the decision",
+	lastUserMessages: ["Keep atomic writes"],
+	lastErrors: [],
+	messageCount: 1,
+};
+
+const chunk: LlmChunk = {
+	topic: "Persistence",
+	startIndex: 0,
+	endIndex: 0,
+	tokenEstimate: 20,
+	priority: "high",
+	messages: [
+		{
+			role: "user",
+			content: [{ type: "text", text: "Keep atomic writes" }],
+			timestamp: 1,
+		} as LlmMessage,
+	],
+};
+
+function response(text: string, stopReason = "stop"): AssistantMessage {
+	return {
+		role: "assistant",
+		content: text ? [{ type: "text", text }] : [],
+		usage: { input: 1, output: 1 },
+		stopReason,
+		timestamp: Date.now(),
+	} as AssistantMessage;
+}
+
+const valid = [
+	"### CHUNK 1: Persistence",
+	"**Summary**: Atomic writes remain required.",
+	"**Decisions**: Keep atomic writes",
+	"**Modified**: None",
+	"**Read**: None",
+	"**Deleted**: None",
+	"**Priority**: high",
+].join("\n");
+
+function withoutField(field: string): string {
+	return valid
+		.split("\n")
+		.filter((line) => !line.startsWith("**" + field + "**:"))
+		.join("\n");
+}
+
+async function expectBatchFormatError(
+	promise: Promise<unknown>,
+): Promise<void> {
+	try {
+		await promise;
+		throw new Error("Expected batch response validation to fail");
+	} catch (error) {
+		expect(error).toBeInstanceOf(BatchSummaryFormatError);
+	}
+}
+
+beforeEach(() => clearSynthesisCache());
+
+describe("summarizeBatch response validation", () => {
+	it("does not cache an empty successful response", async () => {
+		let calls = 0;
+		const services = createServices({
+			llm: {
+				complete: async () => response(calls++ === 0 ? "" : valid),
+			},
+		});
+
+		await expectBatchFormatError(summarizeBatch(
+				[chunk],
+				extraction,
+				model,
+				{ apiKey: "test" },
+				undefined,
+				services,
+				1_000,
+				"session",
+			));
+
+		const retried = await summarizeBatch(
+			[chunk],
+			extraction,
+			model,
+			{ apiKey: "test" },
+			undefined,
+			services,
+			1_000,
+			"session",
+		);
+		expect(retried[0].summary).toBe("Atomic writes remain required.");
+		expect(calls).toBe(2);
+
+		await summarizeBatch(
+			[chunk],
+			extraction,
+			model,
+			{ apiKey: "test" },
+			undefined,
+			services,
+			1_000,
+			"session",
+		);
+		expect(calls).toBe(2);
+	});
+
+	it("rejects and does not cache sections missing required fields", async () => {
+		for (const field of [
+			"Priority",
+			"Summary",
+			"Decisions",
+			"Modified",
+			"Deleted",
+			"Read",
+		]) {
+			clearSynthesisCache();
+			let calls = 0;
+			const services = createServices({
+				llm: {
+					complete: async () => response(calls++ === 0 ? withoutField(field) : valid),
+				},
+			});
+
+			await expectBatchFormatError(summarizeBatch(
+				[chunk],
+				extraction,
+				model,
+				{ apiKey: "test" },
+				undefined,
+				services,
+				1_000,
+				"session",
+			));
+			await summarizeBatch(
+				[chunk],
+				extraction,
+				model,
+				{ apiKey: "test" },
+				undefined,
+				services,
+				1_000,
+				"session",
+			);
+			expect(calls).toBe(2);
+		}
+	});
+
+	it("accepts explicit None values for optional list fields", async () => {
+		const services = createServices({
+			llm: {
+				complete: async () => response(
+					valid.replace("**Decisions**: Keep atomic writes", "**Decisions**: None"),
+				),
+			},
+		});
+		const result = await summarizeBatch(
+			[chunk],
+			extraction,
+			model,
+			{ apiKey: "test" },
+			undefined,
+			services,
+		);
+		expect(result[0].keyDecisions).toEqual([]);
+		expect(result[0].filesModified).toEqual([]);
+		expect(result[0].filesDeleted).toEqual([]);
+		expect(result[0].filesRead).toEqual([]);
+	});
+
+	it("rejects truncated, partial, and duplicate chunk responses", async () => {
+		const second = { ...chunk, topic: "Follow-up", startIndex: 1, endIndex: 1 };
+		for (const malformed of [
+			response(valid, "length"),
+			response(valid),
+			response(valid + "\n\n" + valid),
+		]) {
+			const services = createServices({
+				llm: { complete: async () => malformed },
+			});
+			await expectBatchFormatError(summarizeBatch(
+					malformed.stopReason === "length" ? [chunk] : [chunk, second],
+					extraction,
+					model,
+					{ apiKey: "test" },
+					undefined,
+					services,
+				));
+		}
+	});
+});

--- a/test/eval-adversarial.test.ts
+++ b/test/eval-adversarial.test.ts
@@ -308,6 +308,7 @@ describe("adversarial planning and safety", () => {
       flags: { force: true },
       config: { minContextPercent: 60 },
       notify: () => {},
+      _prepared: true,
     } as any);
     expect(window!.accTokens).toBeGreaterThanOrEqual(20_000);
   });

--- a/test/file-needles.test.ts
+++ b/test/file-needles.test.ts
@@ -15,9 +15,14 @@
  */
 import { describe, it, expect } from "bun:test";
 import {
+	buildKnownPathReferenceIndex,
+	buildPathNeedleOwnershipIndex,
 	buildPathNeedles,
 	buildUniquePathNeedles,
+	buildUniquePathNeedlesFromIndex,
 	isKnownPathReference,
+	isKnownPathReferenceInIndex,
+	normalizePath,
 	GENERIC_BASENAMES,
 	MIN_BARE_BASENAME_LEN,
 } from "../src/utils/file-needles.ts";
@@ -111,6 +116,43 @@ describe("buildUniquePathNeedles", () => {
 		);
 	});
 
+	it("reuses a suffix ownership index without changing uniqueness", () => {
+		const paths = [
+			"packages/api/src/auth.ts",
+			"packages/web/src/auth.ts",
+			"packages/web/src/routes.ts",
+		];
+		const owners = buildPathNeedleOwnershipIndex(paths);
+		for (const path of paths) {
+			expect(buildUniquePathNeedlesFromIndex(path, owners)).toEqual(
+				buildUniquePathNeedles(path, paths),
+			);
+		}
+	});
+
+	it("bounds pathological suffix indexes without changing long-path matches", () => {
+		const unicodePath = "é".repeat(4_096) + "/Auth.ts";
+		const deepPath = "a/".repeat(2_048) + "Auth.ts";
+		const paths = [unicodePath, deepPath, "short/Auth.ts"];
+		const known = buildKnownPathReferenceIndex(paths);
+
+		expect(known.hasUnindexedSuffixes).toBe(true);
+		expect(isKnownPathReferenceInIndex("Auth.ts", known)).toBe(true);
+		expect(
+			isKnownPathReferenceInIndex(
+				"é".repeat(2_048) + "/Auth.ts",
+				known,
+			),
+		).toBe(true);
+		expect(isKnownPathReferenceInIndex("missing.ts", known)).toBe(false);
+
+		const owners = buildPathNeedleOwnershipIndex(paths);
+		expect(owners.hasUnindexedSuffixes).toBe(true);
+		expect(buildUniquePathNeedlesFromIndex("short/Auth.ts", owners)).toEqual([
+			"short/auth.ts",
+		]);
+	});
+
 	it("recognizes a suffix reference to a known path", () => {
 		expect(
 			isKnownPathReference("api/src/auth.ts", ["packages/api/src/auth.ts"]),
@@ -148,6 +190,58 @@ describe("buildUniquePathNeedles", () => {
 		expect(
 			isKnownPathReference("ma/src/Auth.cs", ["/repo/çalışma/src/Auth.cs"]),
 		).toBe(true);
+	});
+
+	it("keeps indexed lookups identical to the previous matching rules", () => {
+		const legacyMatch = (ref: string, knownPaths: readonly string[]): boolean => {
+			const normalizedRef = normalizePath(ref).replace(/^\/+/, "");
+			if (!normalizedRef) return false;
+			const pathShaped = normalizedRef.includes("/");
+			return knownPaths.some((path) => {
+				const normalizedPath = normalizePath(path).replace(/^\/+/, "");
+				if (
+					normalizedPath === normalizedRef ||
+					normalizedPath.endsWith("/" + normalizedRef)
+				) return true;
+				if (normalizedPath.endsWith(normalizedRef)) {
+					const boundary = normalizedPath[
+						normalizedPath.length - normalizedRef.length - 1
+					];
+					if (boundary && !/[\w./-]/.test(boundary)) return true;
+				}
+				if (!pathShaped) return false;
+				return normalizedPath.split("/").some((_, index, parts) =>
+					parts.slice(index).join("/").startsWith(normalizedRef + "/"),
+				);
+			});
+		};
+
+		let seed = 0xc0ffee;
+		const alphabet = "abXZ19_./- @é\\";
+		const randomText = (maxLength: number): string => {
+			seed = (seed * 1_664_525 + 1_013_904_223) >>> 0;
+			const length = seed % (maxLength + 1);
+			let text = "";
+			for (let index = 0; index < length; index++) {
+				seed = (seed * 1_664_525 + 1_013_904_223) >>> 0;
+				text += alphabet[seed % alphabet.length];
+			}
+			return text;
+		};
+
+		for (let sample = 0; sample < 1_000; sample++) {
+			const paths = Array.from(
+				{ length: 1 + (sample % 8) },
+				() => randomText(80),
+			);
+			const index = buildKnownPathReferenceIndex(paths);
+			for (let refIndex = 0; refIndex < 8; refIndex++) {
+				const ref = randomText(40);
+				expect(isKnownPathReferenceInIndex(ref, index)).toBe(
+					legacyMatch(ref, paths),
+				);
+			}
+		}
 	});
 });
 

--- a/test/file-ref-detect.test.ts
+++ b/test/file-ref-detect.test.ts
@@ -151,6 +151,29 @@ describe("extractFileRefs — integration", () => {
     const s = "a/b.ts and c/d.ts";
     expect(extractFileRefs(s)).toEqual(extractFileRefs(s));
   });
+
+  it("preserves the legacy candidate grammar without regex backtracking", () => {
+    const legacyExtract = (summary: string): string[] => {
+      const matcher = new RegExp(FILE_REF_CANDIDATE_RE.source, FILE_REF_CANDIDATE_RE.flags);
+      const refs: string[] = [];
+      for (const match of summary.matchAll(matcher)) {
+        if (/[\\/]/.test(summary[(match.index ?? 0) + match[0].length] ?? "")) continue;
+        if (isLikelyFileRef(match[0])) refs.push(match[0]);
+      }
+      return refs;
+    };
+    let seed = 0x5eed;
+    const alphabet = "abcXYZ019_./- :,@\\";
+    for (let sample = 0; sample < 1_000; sample++) {
+      let text = "";
+      const length = 8 + (sample % 96);
+      for (let index = 0; index < length; index++) {
+        seed = (seed * 1_664_525 + 1_013_904_223) >>> 0;
+        text += alphabet[seed % alphabet.length];
+      }
+      expect(extractFileRefs(text)).toEqual(legacyExtract(text));
+    }
+  });
 });
 
 describe("FILE_REF_CANDIDATE_RE", () => {

--- a/test/lifecycle-e2e.test.ts
+++ b/test/lifecycle-e2e.test.ts
@@ -245,6 +245,81 @@ describe("extension lifecycle end to end", () => {
       ),
     ).toHaveLength(1);
 
+    const failedResponse = (await before(
+      { reason: "threshold", signal: new AbortController().signal },
+      ctx,
+    )) as any;
+    const failedRunId = failedResponse.compaction.details.runId as string;
+    const failed = handlers.get("session_compact_failed")![0];
+    const failedEvent = {
+      type: "session_compact_failed",
+      reason: "threshold",
+      errorMessage: "Compaction failed: synthetic host failure",
+      aborted: false,
+      willRetry: false,
+      fromExtension: true,
+    };
+    await failed(failedEvent, ctx);
+    expect(
+      readMetricsLog().filter(
+        (entry) => entry.runId === failedRunId && entry.status === "error",
+      ),
+    ).toHaveLength(1);
+
+    // Failure delivery is idempotent, and a late success cannot commit the
+    // candidate that the failed lifecycle already discarded.
+    await failed(failedEvent, ctx);
+    await applied(
+      {
+        fromExtension: true,
+        compactionEntry: {
+          id: "failed-compaction-entry",
+          details: failedResponse.compaction.details,
+        },
+      },
+      ctx,
+    );
+    expect(loadProjectFingerprint(projectId)?.sessionCount).toBe(1);
+    expect(
+      readMetricsLog().filter((entry) => entry.runId === failedRunId),
+    ).toHaveLength(1);
+
+    const abortedResponse = (await before(
+      { reason: "threshold", signal: new AbortController().signal },
+      ctx,
+    )) as any;
+    const abortedRunId = abortedResponse.compaction.details.runId as string;
+    await failed({ ...failedEvent, errorMessage: undefined, aborted: true }, ctx);
+    expect(
+      readMetricsLog().filter(
+        (entry) => entry.runId === abortedRunId && entry.status === "cancelled",
+      ),
+    ).toHaveLength(1);
+
+    // A native failure not supplied by an extension must not touch a staged
+    // smart-compaction candidate.
+    const unaffectedResponse = (await before(
+      { reason: "threshold", signal: new AbortController().signal },
+      ctx,
+    )) as any;
+    const unaffectedRunId = unaffectedResponse.compaction.details.runId as string;
+    await failed({ ...failedEvent, fromExtension: false }, ctx);
+    await applied(
+      {
+        fromExtension: true,
+        compactionEntry: {
+          id: "unaffected-compaction-entry",
+          details: unaffectedResponse.compaction.details,
+        },
+      },
+      ctx,
+    );
+    expect(
+      readMetricsLog().filter(
+        (entry) => entry.runId === unaffectedRunId && entry.status === "success",
+      ),
+    ).toHaveLength(1);
+
     const shutdown = handlers.get("session_shutdown")![0];
     await shutdown({}, ctx);
   }, 20_000);

--- a/test/pipeline-integration.test.ts
+++ b/test/pipeline-integration.test.ts
@@ -410,13 +410,13 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
     expect(notices.join("\n")).not.toContain("simulated provider outage");
   });
 
-  it("records a one-batch fallback and never caches its degraded synthesis", async () => {
+  it("records a malformed one-batch fallback and never caches its degraded synthesis", async () => {
     const messages = [userMsg("Preserve the release plan"), assistantMsg("Working through the release plan")];
     let calls = 0;
     setLlmClient({
       complete: async () => {
         calls++;
-        if (calls === 1) throw new Error("single batch unavailable");
+        if (calls === 1) return makeSummaryResponse("");
         return makeSummaryResponse(
           "## Goal\nPreserve the release plan\n## Progress\n### Done\n- none\n### In Progress\n- release\n### Blocked\n- none\n## Critical Context\n- keep release evidence",
         );

--- a/test/stage-machine.test.ts
+++ b/test/stage-machine.test.ts
@@ -64,6 +64,8 @@ describe("stage machine type chain", () => {
   it("rejects skipped runtime stage markers and missing stage fields", () => {
     expect(() => advance({ _prepared: true } as any, "_recovered" as any))
       .toThrow("requires _windowed");
+    expect(() => advance({ tier: "light" } as any, "_tiered" as any))
+      .toThrow("requires _prepared");
     expect(() => advance({} as any, "_prepared" as any))
       .toThrow("missing field: config");
   });

--- a/test/state-step-continuity.test.ts
+++ b/test/state-step-continuity.test.ts
@@ -134,6 +134,13 @@ describe("buildState continuity integration", () => {
       explorationRounds: 0,
       modelLabel: "openai/test",
       notify: () => {},
+      _prepared: true,
+      _windowed: true,
+      _recovered: true,
+      _tiered: true,
+      _extracted: true,
+      _synthesized: true,
+      _verified: true,
     };
 
     const result = buildState(rc);

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -7,7 +7,7 @@ import {
 	formatVerificationGap,
 	patchSummary,
 } from "../src/phases/verify.ts";
-import { verifyAndPatch } from "../src/app/steps/verify.ts";
+import { verifyAndPatch as runVerificationStep } from "../src/app/steps/verify.ts";
 import type { CompactionState, StructuredExtraction } from "../src/types.ts";
 import { createServices } from "../src/infra/services.ts";
 import { assembleFallback } from "../src/phases/synthesize.ts";
@@ -51,6 +51,20 @@ function makeState(partial: Partial<CompactionState> = {}): CompactionState {
 		compactionVersion: "test",
 		...partial,
 	};
+}
+
+/** Direct step fixtures bypass upstream work but must carry its stage proof. */
+function verifyAndPatch(
+	input: any,
+): ReturnType<typeof runVerificationStep> {
+	return runVerificationStep(Object.assign(input, {
+		_prepared: true,
+		_windowed: true,
+		_recovered: true,
+		_tiered: true,
+		_extracted: true,
+		_synthesized: true,
+	}));
 }
 
 describe("verifySummary", () => {


### PR DESCRIPTION
## Summary

- harden batch synthesis validation and native compaction failure cleanup
- replace pathological file-reference/path verification work with bounded linear/indexed paths
- declare and audit the package as ESM, tighten runtime stage proofs, and document tier semantics
- ship Pi 0.85 lifecycle/scrollbar compatibility and Bun 1.4 declaration updates
- bump package/runtime metadata to 9.6.1

## Validation

- Bun 1.4.0 `bun run release:check`: 965 tests, adversarial gate, benchmarks, build, and packed artifact audit passed
- Pi compatibility: 0.84.0 and latest (0.85.0) passed
- `bun audit`: 0 vulnerabilities across 186 packages
- `npm pack --dry-run`: 172 expected files

## Release decision

The release owner explicitly approved a stable 9.6.1 publication despite the telemetry report remaining `HOLD` because no 9.6.1 canary runs exist.
