### PR TITLE
release: 9.6.2

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -150,7 +150,10 @@ preserve the actual route.
 
 `app/steps/window.ts` starts from Pi's compaction-aware
 `buildContextEntries()` view, never the append-only session history, and builds
-a content-free `CompactionWindowPlan` from the selected mode budget:
+a content-free `CompactionWindowPlan` from the selected mode budget. The shared
+`contextMessageEntries()` adapter uses Pi's `sessionEntryToContextMessages()` and
+`convertToLlm()`, retaining host-visible custom/branch/compaction summaries and
+original entry IDs while excluding private or context-disabled entries:
 
 - **hard `toolCall` / `toolResult` guard** — never orphan a result from its call
 - **soft recent-user/checkpoint/topical preferences** — retain raw only when the resulting suffix still fits the planned budget
@@ -171,11 +174,13 @@ keeps chunked recovery instead of sending an oversized one-shot prompt to
 native summarization. Manual runs use the profile's absolute adaptive tail, so
 model-window size cannot turn an explicit command into a full-context no-op.
 
-Before summarization the pipeline serializes and scrubs the full selected
-conversation into an in-memory prepared backup, then prunes redundant messages,
-loads the previous verified summary plus bounded continuity state, checks the
-incremental extraction cache, and loads the project fingerprint. The backup is
-written atomically only after the matching native compaction is confirmed.
+Before summarization the pipeline keeps a deferred reference to the recovered
+pre-prune messages, prunes redundant messages, loads prior continuity, checks the
+extraction cache, and loads the project fingerprint. Both synthesis and backup
+text use `serializeConversationText()` without the host summarizer's implicit
+2,000-character tool-result cap. Structural and text redaction remain enforced;
+binary attachment archival is outside this text format. The backup materializes
+and writes atomically only after the matching native compaction is confirmed.
 
 ### Extract
 
@@ -237,7 +242,12 @@ evidence is never copied into failure metrics. Both gates remain mandatory:
 summary-derived continuity fields cannot become evidence for their own initial
 verification.
 Polarity checks are symmetric: adding negation to a positive fact is rejected
-just as removing negation from a prohibition is. Unresolved-error source
+just as removing negation from a prohibition is. Short negation tokens such as
+`no` survive token filtering. Verbatim source clauses are not compared against
+the whole instruction's polarity, while additional contradictory clauses remain
+checked. Exact grounded path representations are not outcome claims; prose in
+file sections is still verified. Synthesis and post-state verification use the
+same summary budget for path encoding. Unresolved-error source
 snippets and fallback-rendered evidence share `summaryEvidenceLine()`, so
 Markdown prefixes and multiline wrapping cannot create false missing-error gaps.
 
@@ -264,8 +274,10 @@ and success telemetry. Aborted/unconfirmed candidates write none of them. The
 UI reports `Applied` only after that correlated commit and emits a separate
 warning if any durable side effect was partial.
 `ui/error-format.ts` converts verification/yield failures to one bounded,
-content-free diagnostic and collapses unknown multiline errors; full stacks are
-suppressed by default and emitted only under explicit `DEBUG=smart-compact`.
+content-free diagnostic and next action, including unknown/provider errors.
+Per-call categories survive in aggregated route metrics even when fallback
+succeeds; raw errors never enter that telemetry. Full stacks are suppressed by
+default and require restarting Pi with explicit `DEBUG=smart-compact`.
 Manual execution uses a two-line widget: a colored EESV phase chain plus a
 phase-specific action brief. Before Apply it explicitly says the conversation
 is unchanged. Routine info toasts are hidden unless `verbose`; handled provider,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## [Unreleased]
 
+## [9.6.2] - 2026-09-05
+
+### Fixed
+
+- Verification preserves short negation, accepts faithfully copied multi-clause instructions without hiding additional contradictions, and stops treating grounded filenames such as `published.md` as release claims.
+- Post-state verification uses the same path-evidence budget as synthesis, preventing Fast summaries from growing through false repair loops.
+- Zero-valued call/input overrides resolve to preset budgets; native automatic runs keep the four-call ceiling through mode refinement.
+- Planning and recovery preserve Pi-visible custom, branch-summary, and compaction-summary entries with their original IDs. Anchor boundaries use IDs rather than message-only offsets.
+- Text serialization no longer silently truncates tool results at 2,000 characters, including deferred pre-prune backups. Redaction and context-exclusion boundaries remain intact.
+
+### Changed
+
+- Threshold skips explain the actual model window, configured threshold, and manual early-compaction path. Agent-tool responses explicitly distinguish five-minute staging from application.
+- Provider failures have content-free categories, actionable warnings, and per-route failure counts even when deterministic fallback succeeds. Deterministic final assembly is labeled heuristic, not EESV generation.
+- Error UI avoids raw response bodies and explains when a Pi restart with `DEBUG=smart-compact` is useful. Output-cap watchdogs no longer count as timeouts, and cyclic error causes cannot break classification.
+- Preflight displays the actual calibrated post-summary reserve instead of a separate 25% estimate.
+
+### Tests
+
+- Added regression coverage for these verifier, budget, host-context, backup, diagnostic, and UI contracts, plus 20MB tool-history pruning, extraction, and lossless-text benchmark fixtures.
+
+### Release notes
+
+- Stable release approved by the maintainer with an explicit canary-evidence exception: the required 20 applied canary runs have not been collected. Deterministic checks are not evidence of a completed live canary.
+- No configuration migration or automatic provider-route change. Live provider failure diagnosis remains open; the new categories make subsequent failures diagnosable. Fast still rejects summaries that cannot safely meet the target budget.
+
 ## [9.6.1] - 2026-09-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ The interactive command uses the configured summary route and exact execution
 planner before spending LLM tokens. Its compact decision card compares the
 three modes by estimated after-size and saving, highlights the recommendation,
 and keeps only the selected plan plus hard tool-pair/zero-gap guarantees in the
-primary view. The plan reserves 25% of the LLM summary allowance for verified
-state/delta/continuity sections added after synthesis. Technical estimator,
+primary view. The plan reserves a calibrated allowance for verified
+state/delta/continuity sections added after synthesis (at least 25% of the LLM
+summary budget). The preview displays that actual allowance. Technical estimator,
 target, route, and boundary data stays under `D` instead of crowding the decision.
 
 - `↑` / `↓` changes `Fast`, `Balanced`, or `Thorough` and recalculates the plan.
@@ -185,8 +186,17 @@ During execution a two-line live brief shows the EESV phase chain and the
 meaningful current action; it states that the conversation remains unchanged
 until verified Apply. Routine phase toasts and raw per-batch watchdog/provider
 errors are suppressed by default: handled fallbacks appear as one content-free
-brief. `verbose` restores routine phase notices; full stack diagnostics require
-`DEBUG=smart-compact`.
+brief with a failure category and next action. `verbose` (also spelled `debug`)
+restores routine phase notices, not stack traces. For raw local diagnostics,
+restart Pi with `DEBUG=smart-compact`; logs may contain private conversation evidence.
+
+A skip at **38% / 102,957 tokens** means usage is below the configured
+`minContextPercent` (60% by default), relative to the active model's window.
+It does not mean 100K tokens is universally small. `tool=XX%` measures a different
+quantity. Use `/smart-compact` for deliberate early compaction with preview and
+unchanged verification/yield gates. The agent tool only **stages** a summary;
+run `/compact` within five minutes to apply it. With automatic compaction disabled,
+no background action consumes that candidate.
 
 ### Focus and budgets
 
@@ -250,7 +260,11 @@ independent of modes:
 | Verification repair | `verificationModel` | summary/selected model |
 
 Every run persists per-stage provider, model, reliability, latency, and token
-telemetry with schema-versioned verifier quality. `bun run provider-eval`
+telemetry with schema-versioned verifier quality. Failed dispatched calls also
+retain content-free categories (authentication, rate-limit, timeout, and so on),
+including runs completed by deterministic fallback. `/smart-compact metrics`
+separates those call failures from the compaction outcome; older records without
+categories remain explicitly unclassified. `bun run provider-eval`
 builds an advisory matrix by context pressure and tool density; it never edits
 configuration or selects a model. Legacy rows contribute operational evidence
 but not quality because old verifier score semantics are incompatible.
@@ -315,8 +329,13 @@ guidance for reaching the target.
   disappearing when they leave the unresolved set.
 - Cross-session guard and five-minute TTL for pending summaries
 - Session-log recovery for older, truncated tool results
-- The full selected pre-prune conversation is scrubbed and prepared in memory;
-  its 0600 backup is written only after the matching native compaction succeeds.
+- Host-visible custom messages, branch summaries, and earlier compaction summaries
+  participate in planning and extraction, with original entry IDs. Context-excluded
+  messages and extension-private state stay excluded.
+- Recovered pre-prune conversation text is backed up without an additional tool-result
+  length cap. Text backups are not binary attachment archives and remain subject to
+  configured redaction and available session-log recovery. The 0600 backup is
+  materialized and written only after the matching native compaction succeeds.
   Marker-owned retention leaves foreign files in custom directories untouched.
 - Private artifact directories are enforced as 0700 and files as 0600; stale state snapshots and orphaned atomic-write temp files are removed during bounded retention sweeps.
 
@@ -600,7 +619,7 @@ TUI, using a shared lock and atomic replacement while preserving other keys.
 | Path | Purpose |
 | --- | --- |
 | `settings.json` | Host configuration; the settings TUI can update `smartCompact` defaults |
-| `compact-backups/` | Full selected pre-prune conversation backups, scrubbed before write and retention-pruned |
+| `compact-backups/` | Recovered selected pre-prune text backups without tool-output truncation; scrubbed and retention-pruned |
 | `.cache/compact-extraction-<session>.json` | Incremental extraction cache |
 | `.cache/compact-metrics.jsonl` | Tail-retained metrics log; 5 MiB cap |
 | `.cache/smart-compact-report.html` | Local HTML dashboard |

--- a/bench/hot-paths.bench.ts
+++ b/bench/hot-paths.bench.ts
@@ -17,6 +17,7 @@ import { verifySummary } from "../src/phases/verify.ts";
 import { resolveProviderWatchdogMs } from "../src/infra/llm-client.ts";
 import { makeTokenEstimator } from "../src/utils/tokens.ts";
 import type { LlmMessage, StructuredExtraction } from "../src/types.ts";
+import { serializeConversationText } from "../src/infra/ai-messages.ts";
 
 const fullConversation: LlmMessage[] = Array.from(
   { length: 2_500 },
@@ -39,6 +40,13 @@ const fullConversation: LlmMessage[] = Array.from(
     },
   ],
 ).flat();
+// Message count alone hid multi-megabyte tool-result regressions. Include
+// distinct file reads, mixed Unicode/log output, failures, and tail evidence.
+const largeConversation: LlmMessage[] = Array.from({ length: 500 }, (_, i): LlmMessage[] => [
+  { role: "assistant", content: [{ type: "toolCall", id: "large-" + i, name: "read", arguments: { path: "src/file-" + i + ".ts" } }] },
+  { role: "toolResult", toolCallId: "large-" + i, toolName: "read", isError: i % 10 === 0,
+    content: [{ type: "text", text: ("line " + i + ": ölçüm output value;\n").repeat(1600).slice(0, 40_000) + "END-EVIDENCE-" + i }] },
+]).flat();
 const incrementalDelta = fullConversation.slice(-100);
 const oneMegabyteSummary = "## Goal\n" + "x".repeat(1_000_000);
 const longDotlessToken = "x".repeat(24_000);
@@ -97,6 +105,9 @@ const P95_LIMIT_MS: Record<string, number> = {
   "incremental hit (legacy full index)": 5,
   "incremental hit (optimized)": 3,
   "prune 5k messages": 30,
+  "prune 20MB tool history": 1_000,
+  "extract 20MB tool history": 1_000,
+  "serialize 20MB backup text": 250,
   "chunk + bound 5k messages": 40,
   "parse 1MB canonical summary": 5,
   "scan 24k dotless file-ref token": 5,
@@ -109,6 +120,13 @@ const P95_LIMIT_MS: Record<string, number> = {
 };
 
 const benchmarks: Benchmark[] = [
+  { name: "prune 20MB tool history", iterations: 1, run: () => { sink += pruneRedundant(largeConversation).messages.length; } },
+  { name: "extract 20MB tool history", iterations: 1, run: () => { sink += extractStructured(largeConversation, PROFILES.balanced).messageCount; } },
+  { name: "serialize 20MB backup text", iterations: 1, run: () => {
+    const transcript = serializeConversationText(largeConversation);
+    if (!transcript.endsWith("END-EVIDENCE-499")) throw new Error("Backup tail lost");
+    sink += transcript.length;
+  } },
   {
     name: "incremental hit (legacy full index)",
     iterations: 20,
@@ -238,7 +256,7 @@ function measure(benchmark: Benchmark): Measurement {
 }
 
 console.log(
-  "pi-smart-compact hot-path benchmark (5,000 messages, 100-message delta)",
+  "pi-smart-compact hot-path benchmark (5,000 messages, 100-message delta, 20MB tool history)",
 );
 const measurements = benchmarks.map((benchmark) => ({
   name: benchmark.name,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-smart-compact",
-	"version": "9.6.1",
+	"version": "9.6.2",
 	"description": "Verification-oriented smart compaction extension for Pi Coding Agent — deterministic extraction, exploration, synthesis, verification, metrics, and safety checks.",
 	"type": "module",
 	"packageManager": "bun@1.4.0",

--- a/src/app/mode-policy.ts
+++ b/src/app/mode-policy.ts
@@ -1,6 +1,7 @@
 import type {
   CompactionMode, CompactionState, CompressionProfile, EffectiveCompactionMode, StructuredExtraction,
 } from "../types.ts";
+import { AUTO_TRIGGER_MAX_LLM_CALLS } from "../constants.ts";
 
 export interface ModePolicy {
   profile: CompressionProfile;
@@ -93,7 +94,14 @@ export function batchOutputLimit(mode: EffectiveCompactionMode, chunks: number, 
   return Math.min(Math.max(budget.min, chunks * budget.perChunk), budget.max, providerMax);
 }
 
-export function effectiveBudget(configured: number, modeDefault: number): number {
+export function effectiveBudget(configured: number, modeDefault: number, override?: number): number {
+  if (override !== undefined && override > 0) return override;
   if (configured <= 0) return modeDefault;
   return Math.min(configured, modeDefault);
+}
+
+/** Shared by initial preparation and auto-mode refinement. Zero means preset, never unlimited. */
+export function resolveCallBudget(configured: number, mode: EffectiveCompactionMode, override?: number, automatic = false): number {
+  const budget = effectiveBudget(configured, MODE_POLICIES[mode].maxLlmCalls, override);
+  return automatic ? Math.min(budget, AUTO_TRIGGER_MAX_LLM_CALLS) : budget;
 }

--- a/src/app/preflight.ts
+++ b/src/app/preflight.ts
@@ -20,6 +20,7 @@ import {
   type TokenEstimator,
 } from "../utils/tokens.ts";
 import { MODE_POLICIES } from "./mode-policy.ts";
+import { contextMessageEntries } from "../infra/ai-messages.ts";
 import type { CompactionWindowPlan } from "./run-context.ts";
 import {
   estimateFinalSummaryAllowance,
@@ -128,11 +129,7 @@ export function prepareManualPreflightContext(
       ? ctx.sessionManager.buildContextEntries()
       : ctx.sessionManager.getBranch()
   ) as unknown[];
-  const msgs = branch.filter(
-    (entry): entry is SessionMessageEntry =>
-      (entry as { type?: string; message?: unknown }).type === "message" &&
-      (entry as { message?: unknown }).message != null,
-  );
+  const msgs = contextMessageEntries(branch);
   const totalTokens = ctx.getContextUsage()?.tokens ?? 0;
   const modelContextWindow = ctx.model?.contextWindow;
   const contextWindowTokens =
@@ -140,7 +137,7 @@ export function prepareManualPreflightContext(
       ? (modelContextWindow as number)
       : 0;
   const contextPercent = safeContextPercent(totalTokens, modelContextWindow);
-  const toolPercent = computeToolCharPercentage(branch);
+  const toolPercent = computeToolCharPercentage(msgs);
   const overflowedContext =
     contextWindowTokens > 0 && totalTokens > contextWindowTokens;
   const estimator = makeTokenEstimator(

--- a/src/app/register-smart-compact-tool.ts
+++ b/src/app/register-smart-compact-tool.ts
@@ -40,7 +40,7 @@ export function registerSmartCompactTool(
     description:
       "EESV smart compaction v" +
       VERSION +
-      " with deterministic extraction, exploration, and verification. Compacts the conversation into a structured summary preserving goals, decisions, open loops, modified files, and critical context. Call only when actual context usage is high; ignore pi-auto-context tool=XX% because that is tool-output ratio, not context fullness. The tool internally checks context usage and skips if not needed.",
+      " with deterministic extraction, exploration, and verification. Prepares and stages a verified summary for the next /compact; this tool does not apply compaction mid-turn. The staged summary expires after 5 minutes. Call only when actual context usage is high; tool=XX% is tool-output ratio, not context fullness. Checks the configured context threshold before starting.",
     promptSnippet: "Smart compaction",
     promptGuidelines: [
       "Use only when actual context usage is high (for example pi-auto-context context>=60%).",
@@ -144,7 +144,7 @@ export function registerSmartCompactTool(
       const sessionId = resolveSessionId(ctx);
       if (!dryRun && pendingRef.peek(sessionId)?.sessionId === sessionId) {
         return textResult(
-          "A smart summary is already staged for this session. The next /compact will use it; no LLM calls were made.",
+          "A smart summary is already staged; context is unchanged. Run /compact before the 5-minute staging TTL expires to apply it. No LLM calls were made.",
         );
       }
 
@@ -166,11 +166,10 @@ export function registerSmartCompactTool(
       }
       if (contextPercent < config.minContextPercent) {
         return textResult(
-          "Context is only " +
-            percent +
-            "% full (" +
-            totalTokens.toLocaleString() +
-            " tokens). Compaction is not needed yet. The tool=97% in status means tool output ratio, NOT context usage.",
+          "Compaction skipped: context " + percent + "% (" + totalTokens.toLocaleString() +
+            " / " + (ctx.model?.contextWindow ?? 0).toLocaleString() + " tokens), below the " +
+            config.minContextPercent + "% agent-tool threshold. tool=XX% measures tool-output ratio, not context usage. " +
+            "For deliberate early compaction, the user can run /smart-compact; preview and safety checks still apply.",
         );
       }
 
@@ -216,9 +215,9 @@ export function registerSmartCompactTool(
                   (staged.details.mode ?? staged.details.profile) +
                   "). Tokens: " +
                   (staged.tokensBefore ?? 0).toLocaleString() +
-                  " — cached for " +
+                  " — staged, not applied, for " +
                   Math.round(FIVE_MINUTES_MS / 60_000) +
-                  " min. The next /compact will use it automatically.",
+                  " min. Context is unchanged. Run /compact within that time to apply it; expiry discards the candidate.",
               },
             ],
             details: staged.details,

--- a/src/app/run-smart-compact.ts
+++ b/src/app/run-smart-compact.ts
@@ -391,7 +391,9 @@ export async function runSmartCompact(opts: SmartCompactOptions): Promise<Compac
         hasPending
           ? "Smart compact prepared in " + dur + " — awaiting native /compact"
           : runFailed
-            ? "Smart compact stopped safely in " + dur + " · no summary applied · Pi fallback continues"
+            ? "Smart compact stopped safely in " + dur + (base.flags.skipCompact
+              ? " · no summary staged · context unchanged"
+              : " · no summary applied · Pi fallback continues")
             : "Smart compact run finished in " + dur,
         runFailed ? "warning" : "info",
       );

--- a/src/app/steps/extract.ts
+++ b/src/app/steps/extract.ts
@@ -44,9 +44,8 @@ import {
 } from "../../utils/fingerprint.ts";
 import { getPreviousCompactionContext } from "../../utils/helpers.ts";
 import { isPrefixOf, legacyPrefixMatch } from "../../utils/id-fingerprint.ts";
-import { serializeConversation } from "@earendil-works/pi-coding-agent";
 import {
-  asSerializableMessages,
+  serializeConversationText,
   scrubLlmMessages,
 } from "../../infra/ai-messages.ts";
 import { prepareConversationBackup } from "../../utils/backups.ts";
@@ -101,7 +100,7 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
 
   const extractionStart = pruneEnd;
   const convText = rc.services.scrubber.scrubText(
-    serializeConversation(asSerializableMessages(rc.llmMessages)),
+    serializeConversationText(rc.llmMessages),
   ).value;
   const convTokens = rc.estimator.text(convText);
   let preparedBackup: PreparedConversationBackup | undefined;
@@ -115,9 +114,7 @@ export function extractWithCache(rc: TieredRc): ExtractedRc {
         selectedMessages,
         rc.services.scrubber,
       );
-      const backupText = serializeConversation(
-        asSerializableMessages(safeMessages),
-      );
+      const backupText = serializeConversationText(safeMessages);
       const scrubbed = rc.services.scrubber.scrubText(backupText);
       // Scrub false-positives permanently damage the backup (a restore brings
       // back redacted text) — surface redactions so the user can review.

--- a/src/app/steps/prepare.ts
+++ b/src/app/steps/prepare.ts
@@ -8,7 +8,7 @@
 
 import type { RcBase, PreparedRc, ResolvedAuth } from "../run-context.ts";
 import { advance } from "../run-context.ts";
-import { effectiveBudget, MODE_POLICIES } from "../mode-policy.ts";
+import { effectiveBudget, resolveCallBudget, MODE_POLICIES } from "../mode-policy.ts";
 import { DEFAULT_CONFIG } from "../../constants.ts";
 import { getProviderCaps } from "../../utils/tokens.ts";
 import { loadConfig } from "../../utils/config.ts";
@@ -53,11 +53,8 @@ export async function prepareRun(rc: RcBase): Promise<PreparedRc> {
         : config.maxLatencyMs;
   }
   const policy = MODE_POLICIES[rc.mode];
-  const callBudget =
-    rc.maxLlmCalls ?? effectiveBudget(config.maxLlmCalls, policy.maxLlmCalls);
-  const inputBudget =
-    rc.maxLlmInputTokens ??
-    effectiveBudget(config.maxLlmInputTokens, policy.maxInputTokens);
+  const callBudget = resolveCallBudget(config.maxLlmCalls, rc.mode, rc.maxLlmCalls, rc.flags.autoTriggered && !rc.flags.skipCompact);
+  const inputBudget = effectiveBudget(config.maxLlmInputTokens, policy.maxInputTokens, rc.maxLlmInputTokens);
   rc.services.budget = new BudgetGuard(
     callBudget,
     rc.timeoutMs,

--- a/src/app/steps/state.ts
+++ b/src/app/steps/state.ts
@@ -124,6 +124,7 @@ export function buildState(rc: VerifiedRc): StatedRc {
   const verificationEvidence = {
     sourceMessages: rc.llmMessages,
     steering: { focus: rc.focus, note: rc.userNote },
+    summaryBudgetTokens: rc.profileCfg?.summaryBudgetTokens ?? 6_000,
   };
   let postVerification = verifySummary(summary, extraction, compactionState, verificationEvidence);
   const postInitialScore = postVerification.score;

--- a/src/app/steps/synthesize.ts
+++ b/src/app/steps/synthesize.ts
@@ -35,6 +35,7 @@ import {
 	continuityRisk,
 	deterministicExtractionConfidence,
 	effectiveBudget,
+	resolveCallBudget,
 	MODE_POLICIES,
 	modeFromLegacyProfile,
 	resolveMode,
@@ -49,6 +50,7 @@ import {
 	synthesisCacheKey,
 } from "../../infra/synthesis-cache.ts";
 import { resolveStageAuth } from "../stage-auth.ts";
+import { formatGenerationFailureForUi } from "../../ui/error-format.ts";
 
 export async function summarizeConversation(
 	rc: ExtractedRc,
@@ -69,10 +71,8 @@ export async function summarizeConversation(
 			rc.mode = refined;
 			const policy = MODE_POLICIES[refined];
 			rc.services.budget.setLimits(
-				rc.maxLlmCalls ??
-					effectiveBudget(rc.config.maxLlmCalls, policy.maxLlmCalls),
-				rc.maxLlmInputTokens ??
-					effectiveBudget(rc.config.maxLlmInputTokens, policy.maxInputTokens),
+				resolveCallBudget(rc.config.maxLlmCalls, refined, rc.maxLlmCalls, rc.flags.autoTriggered && !rc.flags.skipCompact),
+				effectiveBudget(rc.config.maxLlmInputTokens, policy.maxInputTokens, rc.maxLlmInputTokens),
 				policy.maxOutputTokens,
 			);
 			// The retention window and output allowance were already planned before
@@ -202,8 +202,8 @@ export async function summarizeConversation(
 		generationFallbacks.push("summary route unavailable");
 		log.debugError("Summary route unavailable", error);
 		rc.notify(
-			"Summary route unavailable · using deterministic fallback",
-			"info",
+			"Summary route unavailable · using deterministic fallback [" + formatGenerationFailureForUi(error) + "]",
+			"warning",
 		);
 	}
 
@@ -253,8 +253,8 @@ export async function summarizeConversation(
 			generationFallbacks.push("single-pass generation failed");
 			log.debugError("Single-pass synthesis used deterministic fallback", err);
 			rc.notify(
-				"Single-pass generation stopped · using deterministic fallback",
-				"info",
+				"Single-pass generation stopped · using deterministic fallback [" + formatGenerationFailureForUi(err) + "]",
+				"warning",
 			);
 			finalSummary = assembleFallback(
 				[],
@@ -444,8 +444,8 @@ export async function summarizeConversation(
 						generationFallbacks.push("1 synthesis batch fallback");
 						log.debugError("Synthesis batch used deterministic fallback", err);
 						rc.notify(
-							"Synthesis batch stopped · deterministic evidence fallback preserved coverage",
-							"info",
+							"Synthesis batch stopped · deterministic evidence fallback preserved coverage [" + formatGenerationFailureForUi(err) + "]",
+							"warning",
 						);
 						showProgressOverlay(rc.ctx, {
 							phase: 3,
@@ -566,8 +566,8 @@ export async function summarizeConversation(
 				);
 				rc.notify(
 					failedBatches.length +
-						" synthesis batch(es) stopped · deterministic evidence fallback preserved coverage",
-					"info",
+						" synthesis batch(es) stopped · deterministic evidence fallback preserved coverage [" + formatGenerationFailureForUi(failedBatches[0]) + "]",
+					"warning",
 				);
 				showProgressOverlay(rc.ctx, {
 					phase: 3,
@@ -590,6 +590,7 @@ export async function summarizeConversation(
 			explorationRounds,
 			totalBatches: batches.length,
 		});
+		method = "eesv";
 		try {
 			const r = await assembleLLM(
 				summaries,
@@ -605,11 +606,13 @@ export async function summarizeConversation(
 				rc.previousState,
 			);
 			if (r?.startsWith("##")) finalSummary = r;
-			else throw new Error("bad");
+			else throw new Error("Invalid summary response");
 		} catch (err) {
 			cacheable = false;
 			generationFallbacks.push("assembly generation failed");
 			log.debugError("Assembly used deterministic fallback", err);
+			rc.notify("Assembly stopped · using deterministic fallback [" + formatGenerationFailureForUi(err) + "]", "warning");
+			method = "heuristic";
 			finalSummary = assembleFallback(
 				summaries,
 				extraction,
@@ -618,7 +621,6 @@ export async function summarizeConversation(
 				rc.previousState,
 			);
 		}
-		method = "eesv";
 	}
 
 	Object.assign(rc, {

--- a/src/app/steps/tier.ts
+++ b/src/app/steps/tier.ts
@@ -18,7 +18,7 @@ import {
 } from "../../utils/helpers.ts";
 
 export function selectTier(rc: RecoveredRc): TieredRc | null {
- const toolPercent = computeToolCharPercentage(rc.branch);
+ const toolPercent = computeToolCharPercentage(rc.msgs);
  const tier: ActiveTier | "none" = rc.flags.overflowRecovery
   ? "full"
   : rc.flags.force

--- a/src/app/steps/window.ts
+++ b/src/app/steps/window.ts
@@ -31,6 +31,7 @@ import {
 } from "../../constants.ts";
 import { safeContextPercent, type TokenEstimator } from "../../utils/tokens.ts";
 import { isRecord } from "../../utils/type-guards.ts";
+import { contextMessageEntries } from "../../infra/ai-messages.ts";
 
 export type { CompactionWindowPlan } from "../run-context.ts";
 
@@ -342,10 +343,7 @@ export function resolveCompactionWindow(rc: PreparedRc): WindowedRc | null {
     typeof manager.buildContextEntries === "function"
       ? manager.buildContextEntries()
       : manager.getBranch();
-  const msgs = branch.filter(
-    (entry: { type: string; message?: unknown }) =>
-      entry.type === "message" && entry.message != null,
-  ) as SessionMessageEntry[];
+  const msgs = contextMessageEntries(branch);
   if (msgs.length < 3) {
     if (rc.flags.force)
       rc.notify(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ import type { CompressionProfile, ProfileConfig } from "./types.ts";
  * `package.json#version`. Do not hand-edit this line for releases; bump
  * package.json and run `bun run sync-version`.
  */
-export const VERSION = "9.6.1";
+export const VERSION = "9.6.2";
 export const CHARS_PER_TOKEN = 3.8;
 export const MIN_COMPACTION_SAVING_RATIO = 0.1;
 export const ESTIMATOR_ROUNDING_TOLERANCE_TOKENS = 1;

--- a/src/domain/provider-evaluation.ts
+++ b/src/domain/provider-evaluation.ts
@@ -52,7 +52,7 @@ export function providerStage(phase: LLMCallMetric["phase"]): ProviderRouteStage
 export function aggregateProviderRoutes(metrics: readonly LLMCallMetric[]): ProviderRouteMetric[] {
   const groups = new Map<string, {
     stage: ProviderRouteStage; provider: string; model: string; calls: number;
-    successes: number; latency: number; input: number; output: number;
+    successes: number; latency: number; input: number; output: number; failures: NonNullable<ProviderRouteMetric["failures"]>;
   }>();
   for (const metric of metrics) {
     const stage = providerStage(metric.phase);
@@ -60,10 +60,11 @@ export function aggregateProviderRoutes(metrics: readonly LLMCallMetric[]): Prov
     const key = stage + "\u0000" + provider + "\u0000" + metric.model;
     const group = groups.get(key) ?? {
       stage, provider, model: metric.model, calls: 0, successes: 0,
-      latency: 0, input: 0, output: 0,
+      latency: 0, input: 0, output: 0, failures: {},
     };
     group.calls++;
     if (metric.success) group.successes++;
+    else if (metric.failureKind) group.failures[metric.failureKind] = (group.failures[metric.failureKind] ?? 0) + 1;
     group.latency += Math.max(0, metric.latencyMs);
     group.input += Math.max(0, metric.inputTokens)
       + Math.max(0, metric.cacheHitTokens)
@@ -77,6 +78,7 @@ export function aggregateProviderRoutes(metrics: readonly LLMCallMetric[]): Prov
     model: group.model,
     calls: group.calls,
     successes: group.successes,
+    ...(Object.keys(group.failures).length ? { failures: group.failures } : {}),
     avgLatencyMs: group.calls ? Math.round(group.latency / group.calls) : 0,
     inputTokens: group.input,
     outputTokens: group.output,

--- a/src/domain/telemetry.ts
+++ b/src/domain/telemetry.ts
@@ -62,12 +62,14 @@ export interface PrivacySafeTelemetry {
   privacy: "aggregate-only; no session ids, project ids, prompts, summaries, paths, or error text";
 }
 
-function errorFields(error: unknown): { name: string; message: string; status: number | null; code: string } {
+function errorFields(error: unknown, seen = new Set<object>()): { name: string; message: string; status: number | null; code: string } {
   if (!error || typeof error !== "object") {
     return { name: "", message: String(error ?? ""), status: null, code: "" };
   }
+  if (seen.has(error) || seen.size >= 8) return { name: "", message: "", status: null, code: "" };
+  seen.add(error);
   const value = error as { name?: unknown; message?: unknown; status?: unknown; statusCode?: unknown; code?: unknown; cause?: unknown };
-  const cause = value.cause && value.cause !== error ? errorFields(value.cause) : null;
+  const cause = value.cause ? errorFields(value.cause, seen) : null;
   const numericStatus = Number(value.status ?? value.statusCode);
   return {
     name: typeof value.name === "string" ? value.name : cause?.name ?? "",
@@ -81,13 +83,14 @@ function errorFields(error: unknown): { name: string; message: string; status: n
 export function classifyTelemetryFailure(error: unknown, timedOut = false): TelemetryFailureKind {
   const fields = errorFields(error);
   const text = (fields.name + " " + fields.code + " " + fields.message).toLowerCase();
-  if (timedOut || /timeout|timed out|watchdog|deadline/.test(text)) return "timeout";
+  if (timedOut) return "timeout";
+  if (/max(?:imum)? output|output.?limit|visible[ -]output|length limit/.test(text)) return "output-limit";
+  if (/timeout|timed out|watchdog|deadline/.test(text)) return "timeout";
   if (fields.name.toLowerCase() === "verificationgateerror") return "verification";
   if (fields.name.toLowerCase() === "yieldgateerror") return "yield";
   if (/budgetexceeded|token budget|call budget|latency budget/.test(text)) return "budget";
   if (fields.status === 429 || /rate.?limit|too many requests|quota/.test(text)) return "rate-limit";
   if (fields.status === 401 || fields.status === 403 || /unauthori[sz]ed|authentication|api.?key|credential/.test(text)) return "authentication";
-  if (/max(?:imum)? output|output.?limit|visible output|length limit/.test(text)) return "output-limit";
   if (/abort|cancel/.test(text)) return "cancelled";
   if (/native compaction|persist|write|rename|filesystem|sqlite|database/.test(text)) return "persistence";
   if (/verificationgateerror|verification gate|verification.*(?:gap|summary)/.test(text)) return "verification";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ import type { PendingCompaction } from "./types.ts";
 import {
   MIN_TOKEN_THRESHOLD,
   FIVE_MINUTES_MS,
-  AUTO_TRIGGER_MAX_LLM_CALLS,
   AUTO_TRIGGER_TIMEOUT_CAP_MS,
 } from "./constants.ts";
 import { loadConfig } from "./utils/config.ts";
@@ -341,10 +340,6 @@ export default function smartCompactExtension(pi: ExtensionAPI) {
             onNativeApplyError,
             autoTriggered: true,
             overflowRecovery: event.reason === "overflow",
-            maxLlmCalls: Math.min(
-              config.maxLlmCalls,
-              AUTO_TRIGGER_MAX_LLM_CALLS,
-            ),
             timeoutMs: effectiveTimeoutMs,
             abortSignal: event.signal,
             cancellationOut,

--- a/src/infra/ai-messages.ts
+++ b/src/infra/ai-messages.ts
@@ -16,9 +16,26 @@
  * which is the preferred pattern for any new code that talks to a provider.
  */
 
-import type { Message } from "@earendil-works/pi-ai";
-import type { LlmMessage } from "../types.ts";
+import { contentText, type Message } from "@earendil-works/pi-ai";
+import type { LlmMessage, SessionMessageEntry } from "../types.ts";
+import { convertToLlm, sessionEntryToContextMessages, serializeConversation, type SessionEntry } from "@earendil-works/pi-coding-agent";
 import type { SecretScrubber } from "../domain/scrub.ts";
+
+/** Preserve the host's context projection and original entry IDs, including custom and branch summaries. */
+export function contextMessageEntries(entries: readonly unknown[]): SessionMessageEntry[] {
+  // SAFETY: these are host SessionManager entries, not provider-supplied data.
+  return (entries as readonly SessionEntry[]).flatMap(entry =>
+    convertToLlm(sessionEntryToContextMessages(entry)).map(message => ({ type: "message" as const, id: entry.id, message })),
+  );
+}
+
+/** Text transcript without the host summarizer's implicit 2,000-character tool-result cap. */
+export function serializeConversationText(messages: LlmMessage[]): string {
+  return asSerializableMessages(messages).map(message => message.role === "toolResult"
+    ? "[Tool result]: " + contentText(message.content, "")
+    : serializeConversation([message]),
+  ).filter(Boolean).join("\n\n");
+}
 
 /**
  * Upcast a raw branch entry's `message` to a `Message` for `convertToLlm`.

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -156,7 +156,10 @@ function hasListedPath(
 	return false;
 }
 
-function outcomeClaims(summary: string): string[] {
+function outcomeClaims(summary: string, pathEvidence: ReadonlyMap<string, string>): string[] {
+	// Only exact, grounded path representations are exempt. Prose in a file
+	// section still needs outcome evidence; a heading is not a trust boundary.
+	const pathLines = new Set(Array.from(pathEvidence, ([path, display]) => [path, display, "`" + path + "`"]).flat());
 	return Array.from(
 		new Set(
 			summary
@@ -167,7 +170,7 @@ function outcomeClaims(summary: string): string[] {
 						.replace(/^\[[ x]\]\s+/i, "")
 						.trim(),
 				)
-				.filter((line) => line.length > 0 && !line.startsWith("#"))
+				.filter((line) => line.length > 0 && !line.startsWith("#") && !pathLines.has(line))
 				.filter((line) => HIGH_RISK_OUTCOME_RE.test(line))
 				.filter(
 					(line) =>
@@ -587,7 +590,7 @@ function stemToken(token: string): string {
 function semanticTokens(text: string): string[] {
 	return (text.normalize("NFKC").match(/[\p{L}\p{N}_-]+/gu) ?? [])
 		.map(stemToken)
-		.filter((token) => token.length > 2);
+		.filter((token) => token.length > 2 || NEGATION_MARKERS.has(token));
 }
 
 interface SemanticShape {
@@ -638,7 +641,8 @@ function hasEffectiveTargetNegation(tokens: string[], anchor: string): boolean {
 		const nearbyNegations = tokens
 			.slice(nearbyStart, anchorIndex + 3)
 			.map((near, offset) =>
-				NEGATION_MARKERS.has(near) ? nearbyStart + offset : -1,
+				NEGATION_MARKERS.has(near) && !(near === "without" && nearbyStart + offset > anchorIndex)
+					? nearbyStart + offset : -1,
 			)
 			.filter((index) => index >= 0);
 		const governingStart = Math.max(0, anchorIndex - 3);
@@ -736,6 +740,9 @@ function hasSemanticEvidence(source: string, target: string): boolean {
 }
 
 function hasSemanticContradiction(source: string, target: string): boolean {
+	// Do not apply a whole instruction's polarity to one of its own clauses.
+	// Other target fragments remain checked, even beside a verbatim copy.
+	const sourceFragments = new Set(semanticFragments(source).map(tokens => tokens.join(" ")));
 	const { sourceTokens, concepts, anchor, negative, conditional } =
 		semanticShape(source);
 	if (!anchor) return false;
@@ -744,7 +751,7 @@ function hasSemanticContradiction(source: string, target: string): boolean {
 		Math.max(1, Math.ceil(concepts.length * 0.6)),
 	);
 	return semanticFragments(target).some((tokens) => {
-		if (!tokens.includes(anchor)) return false;
+		if (!tokens.includes(anchor) || sourceFragments.has(tokens.join(" "))) return false;
 		const overlap = concepts.filter((concept) => tokens.includes(concept)).length;
 		// Sharing a generic anchor such as "release" or "file" is not enough:
 		// another constraint in the same section must overlap the actual concepts.
@@ -1169,6 +1176,7 @@ function verifyProgressConsistency(
 function verifyOpenLoopsAndClaims(
 	summary: string,
 	parsed: CanonicalSummary,
+	paths: PathVerificationData,
 	extraction: StructuredExtraction,
 	continuity: CompactionState | null,
 	evidence: VerificationEvidence,
@@ -1184,7 +1192,7 @@ function verifyOpenLoopsAndClaims(
 	}
 	if (!evidence.sourceMessages) return;
 	const tools = successfulToolEvidence(evidence.sourceMessages);
-	for (const claim of outcomeClaims(summary)) {
+	for (const claim of outcomeClaims(summary, paths.rendered)) {
 		if (!successfulToolSupportsClaim(claim, tools, extraction)) {
 			addGap(accumulator, { kind: "unsupported-claim", claim }, 20);
 		}
@@ -1227,6 +1235,7 @@ export function verifySummary(
 	verifyOpenLoopsAndClaims(
 		summary,
 		parsed,
+		paths,
 		extraction,
 		continuity,
 		evidence,

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,8 @@ export interface LLMCallMetric {
  cacheWriteTokens: number;
  latencyMs: number;
  success: boolean;
+ /** Content-free provider failure category; never stores response/error text. */
+ failureKind?: TelemetryFailureKind;
  /** True when provider usage was absent or partial and local estimates were used. */
  usageEstimated?: boolean;
 }
@@ -121,6 +123,7 @@ export interface ProviderRouteMetric {
  model: string;
  calls: number;
  successes: number;
+ failures?: Partial<Record<TelemetryFailureKind, number>>;
  avgLatencyMs: number;
  inputTokens: number;
  outputTokens: number;

--- a/src/ui/error-format.ts
+++ b/src/ui/error-format.ts
@@ -1,26 +1,42 @@
 import { VerificationGateError } from "../phases/verify.ts";
 import { YieldGateError } from "../domain/yield-gate.ts";
+import { classifyTelemetryFailure } from "../domain/telemetry.ts";
+import type { TelemetryFailureKind } from "../types.ts";
 
-const MAX_ERROR_TEXT = 240;
-const DEBUG_HINT = "Conversation unchanged. Set DEBUG=smart-compact for stack diagnostics.";
-
-function compactText(error: unknown): string {
-  const text = error instanceof Error ? error.message : String(error);
-  return text.replace(/\s+/g, " ").trim().slice(0, MAX_ERROR_TEXT) || "Unknown error";
+function failureAction(kind: TelemetryFailureKind): string {
+  switch (kind) {
+    case "authentication": return "Check the selected model's credentials or use /login.";
+    case "rate-limit": return "Wait for the provider quota to recover before retrying.";
+    case "timeout": return "Try Fast or review the latency budget in /smart-compact settings.";
+    case "budget": return "Review call/token limits in /smart-compact settings.";
+    case "output-limit": return "Review the model output limit and reasoning level.";
+    case "provider":
+    case "validation": return "Check model availability and /smart-compact metrics; select another route manually if needed.";
+    case "cancelled": return "Retry when ready.";
+    default: return "For local stack diagnostics, restart Pi with DEBUG=smart-compact and reproduce.";
+  }
 }
 
-/** One bounded, content-free UI line; full diagnostics belong in local logs. */
+/** Never echo provider errors: their bodies may contain prompts, credentials, or paths. */
+export function formatGenerationFailureForUi(error: unknown): string {
+  const kind = classifyTelemetryFailure(error);
+  return kind + ". " + failureAction(kind);
+}
+
+/** One content-free UI line; raw diagnostics require explicit local opt-in. */
 export function formatCompactErrorForUi(error: unknown): string {
   if (error instanceof VerificationGateError) {
     const kinds = error.gapKinds.slice(0, 4).join(", ") || "unknown";
     return "Verification stopped apply at the " + error.stage + " gate: " + error.score + "/100, " + error.gapCount +
-      (error.gapCount === 1 ? " unresolved gap [" : " unresolved gaps [") + kinds + "]. " + DEBUG_HINT;
+      (error.gapCount === 1 ? " unresolved gap [" : " unresolved gaps [") + kinds + "]. Conversation unchanged. " +
+      "Review /smart-compact metrics; do not bypass verification. For local evidence, restart Pi with DEBUG=smart-compact.";
   }
   if (error instanceof YieldGateError) {
     const reason = error.reason === "target-miss" ? "target missed" : "saving below 10%";
     return "Yield check stopped apply: estimated " + error.estimatedAfterTokens.toLocaleString() +
       "t after vs " + error.targetAfterTokens.toLocaleString() + "t target (" + reason +
-      "). " + DEBUG_HINT;
+      "). Conversation unchanged. Try /smart-compact balanced for a larger target; safety checks still apply.";
   }
-  return "Smart compact failed: " + compactText(error) + ". " + DEBUG_HINT;
+  return "Smart compact failed [" + classifyTelemetryFailure(error) + "]. Conversation unchanged. " +
+    failureAction(classifyTelemetryFailure(error));
 }

--- a/src/ui/metrics-report.ts
+++ b/src/ui/metrics-report.ts
@@ -306,6 +306,13 @@ export function buildMetricsReport(
     "## Stage provider/model comparison",
     ...(providerRoutes.length ? providerRoutes : ["- No stage-route evidence yet"]),
     "",
+    "## Recent provider call failures (not compaction outcomes)",
+    ...entries.slice(-20).flatMap(entry => (entry.providerRoutes ?? [])
+      .filter(route => route.successes < route.calls)
+      .map(route => "- " + route.stage + " / " + route.provider + "/" + route.model + ": " +
+        (route.calls - route.successes) + "/" + route.calls + " calls failed; " +
+        (route.failures ? JSON.stringify(route.failures) : "legacy cause unclassified"))),
+    "",
     "## Failure taxonomy",
     ...(Object.keys(insights.failures).length
       ? Object.entries(insights.failures).map(([kind, count]) => "- " + kind + ": " + count)

--- a/src/ui/overlays.ts
+++ b/src/ui/overlays.ts
@@ -357,8 +357,8 @@ export function formatPreflightSummary(
       );
     return lines;
   }
-  const stateReserve = Math.ceil(
-    plan.summaryBudgetTokens * POST_SUMMARY_RESERVE_RATIO,
+  const stateReserve = Math.max(0,
+    (plan.finalSummaryAllowanceTokens ?? plan.summaryBudgetTokens + Math.ceil(plan.summaryBudgetTokens * POST_SUMMARY_RESERVE_RATIO)) - plan.summaryBudgetTokens,
   );
   const lines = [
     "Plan  " +

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -57,6 +57,7 @@ import {
   type SmartCompactServices,
 } from "../infra/services.ts";
 import { toolOperationSignature } from "../domain/tool-semantics.ts";
+import { classifyTelemetryFailure } from "../domain/telemetry.ts";
 
 // ── Cache Options ──
 
@@ -289,6 +290,7 @@ export async function trackedComplete(
         cacheWriteTokens: 0,
         latencyMs: Date.now() - start,
         success: false,
+        failureKind: classifyTelemetryFailure(err),
       },
       svc,
     );

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -86,15 +86,8 @@ function branchIndexToMsgIndex(
   branchIdx: number,
   msgs: SessionMessageEntry[],
 ): number {
-  let msgCount = 0;
-  for (let i = 0; i <= branchIdx && i < branchEntries.length; i++) {
-    const e = branchEntries[i] as Record<string, unknown> | undefined;
-    if (e?.type === "message") {
-      if (msgCount >= msgs.length) return msgs.length - 1;
-      msgCount++;
-    }
-  }
-  return Math.max(0, Math.min(msgCount - 1, msgs.length - 1));
+  const id = (branchEntries[branchIdx] as { id?: string } | undefined)?.id;
+  return Math.max(0, msgs.findIndex(entry => entry.id === id));
 }
 
 export type SmartBoundaryKind = "anchor" | "topical";

--- a/src/utils/session-log.ts
+++ b/src/utils/session-log.ts
@@ -22,7 +22,7 @@ import { StringDecoder } from "node:string_decoder";
 import { extractText, TRUNCATE_RE } from "./extraction.ts";
 import type { LlmMessage, SessionMessageEntry } from "../types.ts";
 import { convertToLlm } from "@earendil-works/pi-coding-agent";
-import { asBranchMessage } from "../infra/ai-messages.ts";
+import { asBranchMessage, contextMessageEntries } from "../infra/ai-messages.ts";
 import {
   sessionsDir as sessionsDirPath,
   home as piHome,
@@ -308,15 +308,11 @@ async function readOriginalMessageMap(
       } catch {
         continue;
       }
-      if (
-        entry.type !== "message" ||
-        !entry.id ||
-        !remaining.has(entry.id) ||
-        !entry.message
-      )
-        continue;
+      if (!entry.id || !remaining.has(entry.id)) continue;
       remaining.delete(entry.id);
-      const normalized = normalizeLogMessage(entry.message, entry.timestamp);
+      const normalized = entry.type === "message" && entry.message
+        ? normalizeLogMessage(entry.message, entry.timestamp)
+        : contextMessageEntries([entry])[0]?.message as LlmMessage | undefined;
       if (normalized) map.set(entry.id, normalized);
       if (remaining.size === 0) break;
     }

--- a/test/ai-messages.test.ts
+++ b/test/ai-messages.test.ts
@@ -2,9 +2,30 @@ import { describe, it, expect } from "bun:test";
 import {
   asBranchMessage,
   asSerializableMessages,
+  contextMessageEntries,
 } from "../src/infra/ai-messages.ts";
 import type { Message } from "@earendil-works/pi-ai";
 import type { LlmMessage } from "../src/types.ts";
+import { computeToolCharPercentage, smartKeepBoundary } from "../src/utils/helpers.ts";
+
+describe("host-visible context projection", () => {
+  it("preserves prior compaction and anchor IDs while excluding private and context-disabled entries", () => {
+    const branch = [
+      { type: "compaction", id: "compaction", timestamp: "2026-01-01T00:00:00Z", summary: "Previous facts", tokensBefore: 100 },
+      { type: "message", id: "hidden", message: { role: "bashExecution", command: "hidden", output: "PRIVATE_SENTINEL", exitCode: 0, excludeFromContext: true } },
+      { type: "message", id: "anchor", message: { role: "toolResult", toolName: "context", toolCallId: "anchor-1", content: [{ type: "text", text: "Decision checkpoint" }], details: { anchor: "checkpoint" }, timestamp: 0 } },
+      { type: "message", id: "tool", message: { role: "toolResult", toolName: "read", toolCallId: "call-1", content: [{ type: "text", text: "x".repeat(200) }], timestamp: 0 } },
+      { type: "custom", id: "private", customType: "state", data: "PRIVATE_SENTINEL" },
+    ];
+    const msgs = contextMessageEntries(branch);
+    expect(msgs.map(entry => entry.id)).toEqual(["compaction", "anchor", "tool"]);
+    expect(JSON.stringify(msgs)).not.toContain("PRIVATE_SENTINEL");
+    expect(JSON.stringify(msgs)).toContain("Previous facts");
+    expect(smartKeepBoundary(msgs, 2, branch)).toBe(1);
+    expect(computeToolCharPercentage(msgs)).toBeGreaterThan(0);
+    expect(computeToolCharPercentage(msgs)).toBeLessThan(computeToolCharPercentage(branch));
+  });
+});
 
 describe("asBranchMessage", () => {
   it("returns the same object reference (no defensive copy)", () => {

--- a/test/error-format.test.ts
+++ b/test/error-format.test.ts
@@ -4,6 +4,14 @@ import { YieldGateError } from "../src/domain/yield-gate.ts";
 import { formatCompactErrorForUi } from "../src/ui/error-format.ts";
 
 describe("bounded Smart Compact error UX", () => {
+  it("offers a credential action without echoing provider response bodies", () => {
+    const error = Object.assign(new Error("SECRET_PROVIDER_PAYLOAD"), { status: 401 });
+    const text = formatCompactErrorForUi(error);
+    expect(text).toContain("authentication");
+    expect(text).toContain("/login");
+    expect(text).not.toContain("SECRET_PROVIDER_PAYLOAD");
+    expect(text).not.toContain("DEBUG");
+  });
   it("renders verification diagnostics without evidence text or stack lines", () => {
     const error = new VerificationGateError({
       ok: false,
@@ -42,15 +50,17 @@ describe("bounded Smart Compact error UX", () => {
 
     expect(formatCompactErrorForUi(error)).toBe(
       "Yield check stopped apply: estimated 42,000t after vs 40,000t target (target missed). " +
-      "Conversation unchanged. Set DEBUG=smart-compact for stack diagnostics.",
+      "Conversation unchanged. Try /smart-compact balanced for a larger target; safety checks still apply.",
     );
   });
 
-  it("collapses and caps unknown multiline errors while retaining opt-in debug guidance", () => {
+  it("does not expose unknown error text and explains how to collect opt-in diagnostics", () => {
     const text = formatCompactErrorForUi(new Error("first line\n" + "trace ".repeat(200)));
 
     expect(text).not.toContain("\n");
     expect(text.length).toBeLessThan(340);
-    expect(text).toEndWith("Conversation unchanged. Set DEBUG=smart-compact for stack diagnostics.");
+    expect(text).not.toContain("first line");
+    expect(text).toContain("internal");
+    expect(text).toContain("restart Pi with DEBUG=smart-compact");
   });
 });

--- a/test/index-tool.test.ts
+++ b/test/index-tool.test.ts
@@ -4,6 +4,23 @@ import { BUDGET_LIMITS } from "../src/constants.ts";
 import { registerSmartCompactTool } from "../src/app/register-smart-compact-tool.ts";
 
 describe("smart_compact tool cancellation", () => {
+  it("explains the actual threshold, model window, and manual early-compaction option", async () => {
+    let tool: any;
+    registerSmartCompactTool({ registerTool: (definition: any) => { tool = definition; } } as any, {
+      pendingRef: { peek: () => undefined } as any, runLock: {} as any,
+      onNativeApplyError: () => false, policy: { isAgentToolEnabled: () => true } as any,
+    });
+    const result = await tool.execute("low-usage", {}, undefined, () => {}, {
+      model: { contextWindow: 272_000 }, getContextUsage: () => ({ tokens: 102_957 }),
+      sessionManager: { getSessionId: () => "early-compact" },
+    });
+    expect(result.content[0].text).toContain("38%");
+    expect(result.content[0].text).toContain("272,000");
+    expect(result.content[0].text).toContain("threshold");
+    expect(result.content[0].text).toContain("/smart-compact");
+    expect(result.content[0].text).not.toContain("tool=97%");
+    expect(tool.description).toContain("stages");
+  });
   it("keeps manual settings explicit when TUI is unavailable", async () => {
     let command: any;
     const notifications: Array<{ message: string; level: string }> = [];
@@ -133,7 +150,8 @@ describe("smart_compact tool cancellation", () => {
       failure = error;
     }
     expect(failure).toBeInstanceOf(Error);
-    expect((failure as Error).message).toContain("synthetic pipeline failure");
+    expect((failure as Error).message).toContain("internal");
+    expect((failure as Error).message).not.toContain("synthetic pipeline failure");
   });
 
   it("does not start the pipeline when the host signal is already aborted", async () => {

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -74,6 +74,17 @@ describe("metrics reporting", () => {
     expect(report).toContain("Stage provider/model comparison");
   });
 
+  it("separates failed provider calls from successful deterministic compaction", () => {
+    const report = metricsReport.buildMetricsReport([{
+      ts: new Date().toISOString(), sessionId: "synthetic", status: "success", method: "heuristic",
+      totalCalls: 2, totalInput: 0, totalOutput: 0, totalCacheHit: 0, avgLatency: 5, cacheHitRate: 0,
+      providerRoutes: [{ stage: "synthesize", provider: "openai", model: "test", calls: 2, successes: 0, avgLatencyMs: 5, inputTokens: 0, outputTokens: 0, failures: { authentication: 2 } }],
+    }]);
+    expect(report).toContain("success 1");
+    expect(report).toContain("2/2 calls failed");
+    expect(report).toContain('"authentication":2');
+  });
+
   it("attributes pre-repair quality only to one successful synthesis route", () => {
     const svc = services.createServices();
     for (const phase of ["explore", "batch", "patch"] as const) {

--- a/test/mode-policy.test.ts
+++ b/test/mode-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { batchOutputLimit, deterministicExtractionConfidence, modeFromLegacyProfile, MODE_POLICIES, resolveMode } from "../src/app/mode-policy.ts";
+import { batchOutputLimit, deterministicExtractionConfidence, modeFromLegacyProfile, MODE_POLICIES, resolveMode, resolveCallBudget, effectiveBudget } from "../src/app/mode-policy.ts";
 import type { StructuredExtraction } from "../src/types.ts";
 
 const extraction = (partial: Partial<StructuredExtraction> = {}): StructuredExtraction => ({
@@ -8,6 +8,15 @@ const extraction = (partial: Partial<StructuredExtraction> = {}): StructuredExtr
 });
 
 describe("compaction mode policy", () => {
+  it("keeps preset defaults finite, automatic runs capped, and explicit manual overrides usable", () => {
+    expect(resolveCallBudget(0, "fast", 0, true)).toBe(3);
+    expect(resolveCallBudget(0, "balanced", 0, true)).toBe(4);
+    expect(resolveCallBudget(0, "thorough", undefined, true)).toBe(4);
+    expect(resolveCallBudget(2, "thorough", undefined, true)).toBe(2);
+    expect(resolveCallBudget(0, "fast", 10)).toBe(10);
+    expect(resolveCallBudget(0, "fast", 10, true)).toBe(4);
+    expect(effectiveBudget(0, 100_000, 0)).toBe(100_000);
+  });
   it("uses pressure first and deterministic risk second in auto mode", () => {
     expect(resolveMode("auto", 90, extraction())).toBe("fast");
     expect(resolveMode("auto", 65, extraction())).toBe("fast");

--- a/test/pipeline-integration.test.ts
+++ b/test/pipeline-integration.test.ts
@@ -33,6 +33,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { extractWithCache } from "../src/app/steps/extract.ts";
+import { prepareRun } from "../src/app/steps/prepare.ts";
+import { buildState } from "../src/app/steps/state.ts";
+import { verifyAndPatch } from "../src/app/steps/verify.ts";
+import { assembleFallback } from "../src/phases/synthesize.ts";
+import { AUTO_TRIGGER_MAX_LLM_CALLS, DEFAULT_CONFIG, PROFILES } from "../src/constants.ts";
+import { aggregateProviderRoutes } from "../src/domain/provider-evaluation.ts";
 import { summarizeConversation } from "../src/app/steps/synthesize.ts";
 import { setLlmClient, resetLlmClient } from "../src/infra/llm-client.ts";
 import type { LlmClient } from "../src/infra/llm-client.ts";
@@ -147,6 +153,34 @@ afterEach(() => {
 });
 
 describe("pipeline integration: extract -> synthesize (single-pass)", () => {
+  it("resolves zero budget overrides before enforcing the automatic call ceiling", async () => {
+    const rc = makeTieredRc([]);
+    rc.config = { ...DEFAULT_CONFIG, maxLatencyMs: 0, maxLlmCalls: 0 };
+    rc.mode = "balanced";
+    rc.maxLlmCalls = 0;
+    rc.flags.autoTriggered = true;
+    await prepareRun(rc);
+    for (let i = 0; i < AUTO_TRIGGER_MAX_LLM_CALLS; i++) rc.services.budget.reserveCall(1, 1);
+    expect(() => rc.services.budget.reserveCall(1, 1)).toThrow("budget");
+  });
+
+  it("keeps Fast path encoding stable through post-state verification", async () => {
+    const rc = makeTieredRc([]);
+    rc.profileCfg = { ...PROFILES.aggressive };
+    rc.profile = "aggressive";
+    rc.mode = "fast";
+    rc.totalTokens = 100_000;
+    (rc as any).compactionPlan = { summaryBudgetTokens: 3_000, retainedTokens: 1_000, fixedContextTokens: 0, targetAfterTokens: 80_000, projectedAfterTokens: 80_000 };
+    const extracted = extractWithCache(rc);
+    extracted.extraction.readFiles = Array.from({ length: 200 }, (_, i) => "src/" + "directory/".repeat(15) + `module-${i}.ts`);
+    const summary = assembleFallback([], extracted.extraction, undefined, 3_000);
+    const synthesized = Object.assign(extracted, { _synthesized: true, finalSummary: summary, summaries: [], method: "heuristic" }) as any;
+    const verified = await verifyAndPatch(synthesized);
+    const stated = buildState(verified);
+    expect(stated.verificationProvenance.deterministicPatched).toEqual([]);
+    expect(stated.finalSummary.length).toBeLessThan(summary.length + 2_000);
+  });
+
   it("bounds long lineage while retaining pre-compaction state heads", () => {
     const lineage = Array.from({ length: 1_001 }, (_, index) => ({
       id: "entry-" + (index + 1),
@@ -230,7 +264,7 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
     const truncatedEvidence = "TRUNCATED-MIDDLE-BACKUP-EVIDENCE";
     const longToolResult: LlmMessage = {
       role: "toolResult", toolCallId: "long-output", isError: false, timestamp: Date.now(),
-      content: [{ type: "text", text: "a".repeat(MAX_TOOL_OUTPUT_CHARS) + truncatedEvidence + "b".repeat(MAX_TOOL_OUTPUT_CHARS) }],
+      content: [{ type: "text", text: "a".repeat(4_000) + truncatedEvidence + "b".repeat(MAX_TOOL_OUTPUT_CHARS) }],
     };
     const messages = [
       userMsg("Preserve the selected span"), assistantMsg(removedEvidence), longToolResult,
@@ -274,6 +308,13 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
       resetConfigCache();
       fs.rmSync(home, { recursive: true, force: true });
     }
+  });
+
+  it("does not re-truncate preserved assistant and tool evidence at serialization", () => {
+    const tool: LlmMessage = { role: "toolResult", toolName: "bash", toolCallId: "long", isError: true, content: [{ type: "text", text: "output ".repeat(600) + "CRITICAL_END_SENTINEL" }] };
+    // Error output survives pruning and must survive the synthesis serializer too.
+    const extracted = extractWithCache(makeTieredRc([userMsg("Diagnose the failure"), tool]));
+    expect(extracted.convText).toContain("CRITICAL_END_SENTINEL");
   });
 
   it("produces a summary when the LLM returns a well-formed markdown response", async () => {
@@ -406,8 +447,11 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
     expect(synthesized.method).toBe("heuristic");
     expect(synthesized.finalSummary.length).toBeGreaterThan(0);
     expect(synthesized.llmCalls).toBe(1);
-    expect(notices).toContain("Single-pass generation stopped · using deterministic fallback");
+    expect(notices.join("\n")).toContain("Single-pass generation stopped");
+    expect(notices.join("\n")).toContain("provider");
     expect(notices.join("\n")).not.toContain("simulated provider outage");
+    expect(aggregateProviderRoutes(tiered.services.metrics.snapshot())[0]?.failures).toEqual({ provider: 1 });
+    expect(JSON.stringify(tiered.services.metrics.snapshot())).not.toContain("simulated provider outage");
   });
 
   it("records a malformed one-batch fallback and never caches its degraded synthesis", async () => {
@@ -437,7 +481,7 @@ describe("pipeline integration: extract -> synthesize (single-pass)", () => {
 
     const first = await summarizeConversation(makeExtracted());
     expect(first.generationFallbacks).toContain("1 synthesis batch fallback");
-    expect(notices).toContain("Synthesis batch stopped · deterministic evidence fallback preserved coverage");
+    expect(notices.join("\n")).toContain("Synthesis batch stopped · deterministic evidence fallback preserved coverage");
     expect(calls).toBe(2);
 
     await summarizeConversation(makeExtracted());

--- a/test/preflight-ui.test.ts
+++ b/test/preflight-ui.test.ts
@@ -130,6 +130,13 @@ describe("smart compact preflight UI", () => {
       .toContain("summary up to 6K + ~1.5K verified-state reserve");
   });
 
+  it("shows the actual calibrated allowance rather than a second hard-coded reserve", () => {
+    const item = preview("fast", true);
+    item.plan!.finalSummaryAllowanceTokens = 15_000;
+    expect(formatPreflightSummary(item, "openai/summary").join("\n"))
+      .toContain("summary up to 6K + ~9K verified-state reserve");
+  });
+
   it("renders the three-mode decision card, supports D, and never exceeds width", async () => {
     const result = await showCompactUI(context((component, done) => {
       const narrowLines = component.render(36);

--- a/test/session-log-stream.test.ts
+++ b/test/session-log-stream.test.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import os from "node:os";
 import { resolveCompactionMessages, hasTruncatedMessages } from "../src/utils/session-log.ts";
 import type { SessionMessageEntry } from "../src/types.ts";
+import { contextMessageEntries } from "../src/infra/ai-messages.ts";
 
 let prevHome: string | undefined;
 let tmp: string;
@@ -48,6 +49,17 @@ function entryWith(id: string, content: string): SessionMessageEntry {
 }
 
 describe("resolveCompactionMessages with streaming parser", () => {
+  it("recovers host-visible custom and branch summaries by original entry ID", async () => {
+    const entries = [
+      { type: "custom_message", id: "custom", timestamp: "2026-01-01T00:00:00Z", customType: "restore", content: "RESTORED_FULL_TEXT", display: true },
+      { type: "branch_summary", id: "branch", timestamp: "2026-01-01T00:00:00Z", summary: "BRANCH_FULL_TEXT", fromId: "old" },
+    ];
+    fs.writeFileSync(makeSessionsDir("host-visible"), entries.map(e => JSON.stringify(e)).join("\n"));
+    const truncated = contextMessageEntries(entries.map(e => ({ ...e, content: "head…✂900", summary: "head…✂900" })));
+    const recovered = await resolveCompactionMessages("host-visible", truncated);
+    expect(JSON.stringify(recovered)).toContain("RESTORED_FULL_TEXT");
+    expect(JSON.stringify(recovered)).toContain("BRANCH_FULL_TEXT");
+  });
   it("recovers messages from a small log", async () => { writeLog("sess-1", [
     { id: "e-0", role: "user", content: "hello" },
     { id: "e-1", role: "assistant", content: "world" },

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -39,6 +39,15 @@ describe("privacy-safe canary telemetry", () => {
     expect(classifyTelemetryFailure(new Error("unexpected invariant"))).toBe("internal");
   });
 
+  it("bounds cyclic causes and distinguishes output watchdogs from timeouts", () => {
+    const first = new Error("provider request failed");
+    const second = Object.assign(new Error("unauthorized"), { status: 401, cause: first });
+    first.cause = second;
+    expect(classifyTelemetryFailure(first)).toBe("authentication");
+    expect(classifyTelemetryFailure(new Error("Codex visible-output watchdog stopped generation"))).toBe("output-limit");
+    expect(classifyTelemetryFailure(new Error("Codex visible-output watchdog stopped generation"), true)).toBe("timeout");
+  });
+
   it("holds a canary until the sample floor is met", () => {
     const report = assessCanary([
       ...Array.from({ length: 20 }, () => metric("stable")),

--- a/test/tier.test.ts
+++ b/test/tier.test.ts
@@ -5,6 +5,7 @@ describe("selectTier overflow recovery", () => {
   it("bypasses the percentage gate after Pi reports a provider overflow", () => {
     const rc = {
       branch: [],
+      msgs: [],
       flags: { force: false, autoTriggered: true, overflowRecovery: true },
       contextPercent: 25,
       totalTokens: 50_000,

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -68,6 +68,29 @@ function verifyAndPatch(
 }
 
 describe("verifySummary", () => {
+	it("preserves short negation and checks additional contradictions beside verbatim clauses", () => {
+		const cases = [
+			["No new dependencies", "New dependencies", false],
+			["No new dependencies", "No new dependencies", true],
+			["Do not deploy now; deploy only after approval", "Do not deploy now; deploy only after approval", true],
+			["Do not deploy now; deploy only after approval", "Do not deploy now; deploy only after approval\n- Deploy now without approval", false],
+		] as const;
+		for (const [source, target, ok] of cases) {
+			const extraction = makeExtraction({ constraints: [{ index: 0, text: source, category: "prohibition", confidence: 1 }] });
+			const summary = assembleFallback([], extraction).replace(source, target);
+			expect(verifySummary(summary, extraction).ok).toBe(ok);
+		}
+	});
+
+	it("does not treat known path evidence as a release claim, but still checks prose in file sections", () => {
+		const extraction = makeExtraction({ readFiles: ["docs/published.md", "src/released.ts"] });
+		const evidence = { sourceMessages: [] };
+		const summary = assembleFallback([], extraction);
+		expect(verifySummary(summary, extraction, null, evidence).gaps).toEqual([]);
+		const fabricated = summary + "\n## Files Read\n- Published the release\n";
+		expect(verifySummary(fabricated, extraction, null, evidence).gaps.some(g => g.kind === "unsupported-claim")).toBe(true);
+	});
+
 	it("returns perfect score for complete coverage", () => {
 		const extraction = makeExtraction({
 			modifiedFiles: [

--- a/test/window-boundary.test.ts
+++ b/test/window-boundary.test.ts
@@ -5,6 +5,9 @@ import type { SessionMessageEntry } from "../src/types.ts";
 import { getProviderCaps, makeTokenEstimator, TokenCalibrationStore } from "../src/utils/tokens.ts";
 import { POST_SUMMARY_RESERVE_RATIO } from "../src/constants.ts";
 import { verifyCompactionYield } from "../src/domain/yield-gate.ts";
+import { buildSessionContext, convertToLlm, type SessionEntry } from "@earendil-works/pi-coding-agent";
+import { prepareManualPreflightContext } from "../src/app/preflight.ts";
+import { recoverSessionLog } from "../src/app/steps/recover.ts";
 
 function messageEntry(
   id: string,
@@ -49,6 +52,27 @@ function makePreparedRc(branch: SessionMessageEntry[], keepRecentTokens = 30_000
 }
 
 describe("resolveCompactionWindow tool-result boundary", () => {
+  it("preserves every host-visible entry through preview, planning, and recovery", async () => {
+    const branch: SessionEntry[] = [
+      { type: "custom_message", id: "custom", parentId: null, timestamp: "2026-01-01T00:00:00Z", customType: "smart-compact-restore", content: "RESTORED_SENTINEL: schema 7 is mandatory", display: false },
+      { type: "branch_summary", id: "branch", parentId: "custom", timestamp: "2026-01-01T00:00:00Z", fromId: "old", summary: "BRANCH_SENTINEL: port 9123" },
+      { type: "custom", id: "private", parentId: "branch", timestamp: "2026-01-01T00:00:00Z", customType: "private-state", data: "NOT_LLM_VISIBLE" },
+      ...Array.from({ length: 15 }, (_, i) => messageEntry("msg-" + i, i ? "msg-" + (i-1) : "private", { role: i % 2 ? "assistant" : "user", content: [{ type: "text", text: ("Work item " + i + " ").repeat(1300) }], timestamp: i })) as SessionEntry[],
+    ];
+    const rc = makePreparedRc(branch as unknown as SessionMessageEntry[], 6_000);
+    rc.ctx.getContextUsage = () => ({ tokens: 70_000 }) as any;
+    const preview = prepareManualPreflightContext(rc.ctx, { provider: "openai", id: "test" } as any, new TokenCalibrationStore());
+    const window = resolveCompactionWindow(rc)!;
+    expect(window).not.toBeNull();
+    expect(preview.msgs.map(e => e.id)).toEqual(window.msgs.map(e => e.id));
+    const recovered = await recoverSessionLog(window);
+    const host = convertToLlm(buildSessionContext(branch).messages);
+    expect(recovered.llmMessages).toEqual(host.slice(0, window.keepFrom));
+    expect(JSON.stringify(recovered.llmMessages)).toContain("RESTORED_SENTINEL");
+    expect(JSON.stringify(recovered.llmMessages)).toContain("BRANCH_SENTINEL");
+    expect(JSON.stringify(recovered.llmMessages)).not.toContain("NOT_LLM_VISIBLE");
+  });
+
   it("does not compact the only user turn just to retain a trailing tool result", () => {
     const toolCallId = "call_test|fc_test";
     const branch: SessionMessageEntry[] = [


### PR DESCRIPTION
## Smart Compact 9.6.2 — stable

### Fixes
- Preserve short negation and faithful multi-clause instructions during verification; stop treating grounded filenames such as `published.md` as release claims.
- Use consistent Fast path-evidence budgets through post-state verification. Resolve zero-valued budget overrides to finite preset limits and retain the automatic four-call ceiling.
- Preserve Pi-visible custom messages, branch summaries, and earlier compaction summaries with their original boundary IDs. Private/context-excluded entries remain excluded.
- Remove the hidden 2,000-character tool-result cap from synthesis and deferred text backups. Configured redaction stays enforced; text backups are not binary attachment archives.

### Diagnostics and UX
- Threshold skips now show the actual model window, configured threshold, and manual early-compaction path.
- Agent-tool responses distinguish five-minute staging from applying compaction.
- Provider failures carry content-free categories and per-route counts, including runs completed by deterministic fallback. Actionable error messages replace raw provider response bodies and unconditional DEBUG hints.
- Preflight shows the planner's actual calibrated post-summary allowance.
- Add realistic 20MB tool-history benchmark fixtures and permanent regression tests.

### Validation
- Bun 1.4.0: source/script/test typechecks; 979 passing tests; adversarial and benchmark gates; build; frozen isolated package audit.
- Isolated Pi compatibility checks passed for 0.84.0 and 0.85.1.
- Dependency audit: no known vulnerabilities in 186 packages.

### Release qualification
This stable release has an explicit maintainer-approved exception to the 20-applied-run canary requirement. Live canary evidence is incomplete; deterministic/compatibility tests do not substitute for it. Runtime verification, yield, approval, and persistence safety gates remain enabled.

Live provider failure diagnosis remains open. This release does not automatically change model routes or configuration. Fast still rejects summaries that cannot safely meet the target budget.

### Update
```sh
pi update npm:pi-smart-compact
```
Restart Pi to load the updated extension.
